### PR TITLE
POM maintenance (Fall edition)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
 
       # Building the jpipe.jar artefact
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       # run unit tests
       - name: Test with Maven
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       # run linter
       - name: CheckStyle (Google ruleset)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '$JAVA_ENV_VERSION'
+          java-version: "$JAVA_ENV_VERSION"
           distribution: 'adopt'
 
       # Building the jpipe.jar artefact
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '$JAVA_ENV_VERSION'
+          java-version: "$JAVA_ENV_VERSION"
           distribution: 'adopt'
       # run unit tests
       - name: Test with Maven
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '$JAVA_ENV_VERSION'
+          java-version: "$JAVA_ENV_VERSION"
           distribution: 'adopt'
       # run linter
       - name: CheckStyle (Google ruleset)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  JAVA_ENV_VERSION: 21
+
 jobs:
 
   build:
@@ -35,7 +38,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '21'
+          java-version: '$JAVA_ENV_VERSION'
           distribution: 'adopt'
 
       # Building the jpipe.jar artefact
@@ -58,7 +61,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '21'
+          java-version: '$JAVA_ENV_VERSION'
           distribution: 'adopt'
       # run unit tests
       - name: Test with Maven
@@ -73,7 +76,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '21'
+          java-version: '$JAVA_ENV_VERSION'
           distribution: 'adopt'
       # run linter
       - name: CheckStyle (Google ruleset)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     branches: [ "main" ]
 
 env:
-  JAVA_ENV_VERSION: 21
+  JAVA_ENV_VERSION: '21'
 
 jobs:
 
@@ -24,22 +24,23 @@ jobs:
         uses: actions/checkout@v3
         
      # added cache to used cached maven dependencies from previous build. 
-      - name: Cache Maven dependencies
-        uses: actions/cache@v3
-        with:
-          # A directory to store and save the cache
-          path: ~/.m2/repository
-          # An explicit key for restoring and saving the cache 
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+#    - name: Cache Maven dependencies
+#      uses: actions/cache@v3
+#      with:
+#          # A directory to store and save the cache
+#         path: ~/.m2/repository
+#          # An explicit key for restoring and saving the cache
+#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: |
+#            ${{ runner.os }}-maven-
 
       # Setting up Java for running mvn
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: "$JAVA_ENV_VERSION"
+          java-version: ${{env.JAVA_ENV_VERSION}}
           distribution: 'adopt'
+          cache: 'maven'
 
       # Building the jpipe.jar artefact
       - name: Create executable jar with Maven
@@ -61,8 +62,9 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: "$JAVA_ENV_VERSION"
+          java-version: ${{env.JAVA_ENV_VERSION}}
           distribution: 'adopt'
+          cache: 'maven'
       # run unit tests
       - name: Test with Maven
         run: mvn test
@@ -76,8 +78,9 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: "$JAVA_ENV_VERSION"
+          java-version: ${{env.JAVA_ENV_VERSION}}
           distribution: 'adopt'
+          cache: 'maven'
       # run linter
       - name: CheckStyle (Google ruleset)
         run: mvn checkstyle:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
         uses: actions/checkout@v3
-        
-     # added cache to used cached maven dependencies from previous build. 
-#    - name: Cache Maven dependencies
-#      uses: actions/cache@v3
-#      with:
-#          # A directory to store and save the cache
-#         path: ~/.m2/repository
-#          # An explicit key for restoring and saving the cache
-#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-maven-
 
       # Setting up Java for running mvn
       - name: Set up Java
@@ -47,11 +36,17 @@ jobs:
         run: mvn clean package -DskipTests -Dcheckstyle.skip
         
       # Uploading artifact 
-      - name: Store Artifact
+      - name: Store Artifact - Library
         uses: actions/upload-artifact@v3
         with:
-          name: jpipe-artifact
+          name: jpipe-lib.jar
           path: target/jpipe.jar
+      # Uploading artifact - Compiler
+      - name: Store Artifact - compiler
+        uses: actions/upload-artifact@v3
+        with:
+          name: jpipe-compiler.jar
+          path: target/jpipe-jar-with-dependencies.jar
 
   test:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,17 @@
 
     <groupId>eu.ace-design</groupId>
     <artifactId>jpipe</artifactId>
-    <version>0.2</version>
+
+    <!-- Versioning convention: YYYY.term, 1 = Winter, 2 = Summer, 3 = Fall -->
+    <version>2023.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <antlr4.visitor>true</antlr4.visitor>
         <antlr4.listener>true</antlr4.listener>
-        <maven.compiler.source>20</maven.compiler.source>
-        <maven.compiler.target>20</maven.compiler.target>
+        <!-- Should use latest LTS version -->
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -21,12 +24,12 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.13.0</version>
+            <version>4.13.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>guru.nidi</groupId>
@@ -37,30 +40,30 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <!-- Log plugins -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.20.0</version>
+            <version>2.21.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.20.0</version>
+            <version>2.21.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.20.0</version>
+            <version>2.21.1</version>
         </dependency>
     </dependencies>
 
@@ -72,7 +75,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>17</release>
+                    <compilerArgs>
+                        <arg>-proc:full</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Implementation of #49

- Make versioning convention explicit (`YYYY.term`)
- Bump java support to latest LTS (being 21)
- Bump dependencies to latest stable version available 
  - Will have to consider moving to  `log4j 3` at some point (when out of alpha release) (see #48), but stashed for now.

```
mosser@azrael jpipe % mvn versions:display-dependency-updates
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   commons-cli:commons-cli ............................... 1.5.0 -> 1.6.0
[INFO]   org.antlr:antlr4-runtime ............................ 4.13.0 -> 4.13.1
[INFO]   org.apache.logging.log4j:log4j-api ............ 2.20.0 -> 3.0.0-alpha1
[INFO]   org.apache.logging.log4j:log4j-core ........... 2.20.0 -> 3.0.0-alpha1
[INFO]   org.apache.logging.log4j:log4j-slf4j-impl ..... 2.20.0 -> 3.0.0-alpha1
[INFO]   org.junit.jupiter:junit-jupiter-api .................. 5.4.2 -> 5.10.1
[INFO]   org.junit.jupiter:junit-jupiter-engine ............... 5.4.2 -> 5.10.1
```