### PR TITLE
Syntax for composition unit

### DIFF
--- a/src/main/antlr4/ca/mcscert/jpipe/syntax/JPipe.g4
+++ b/src/main/antlr4/ca/mcscert/jpipe/syntax/JPipe.g4
@@ -5,18 +5,20 @@ grammar JPipe;
  ******************/
 
 // Root rule for parsing (called by the compiler)
-unit            : (justification | pattern | load | implementation)+ EOF;
+unit            : (justification | pattern | load | composition)+ EOF;
 
+// Load contents from another file
+load            : LOAD file=STRING;
+
+// Declare a justification
 justification   : JUSTIFICATION id=ID (impl=IMPLEMENTS parent=ID)? OPEN justif_body CLOSE;
 justif_body     : (evidence | sub_conclusion | strategy | relation | conclusion)+;
 
+// Definition of a pattern
 pattern         : PATTERN id=ID OPEN pattern_body CLOSE;
 pattern_body    : (abs_support | evidence | sub_conclusion | strategy | relation | conclusion)+;
 
-load            : LOAD file=STRING;
-
-implementation  : IMPLEMENTATION id=ID OF justifiation_id=ID OPEN impl_body CLOSE;
-impl_body       : (IMPLEMENTS id=ID OPEN (probe | operation) expectation? CLOSE)+;
+// Body of a justification/pattern content
 
 identified_element: id=ID IS name=STRING;
 evidence        : EVIDENCE      identified_element;
@@ -25,17 +27,14 @@ sub_conclusion  : SUBCONCLUSION identified_element;
 conclusion      : CONCLUSION    identified_element;
 abs_support     : ABS_SUPPORT   identified_element;
 
-probe           : PROBE IS command;
-operation       : OPERATION IS command;
-expectation     : EXPECTATION IS expression;
-
 relation        : from=ID SUPPORT_LNK to=ID;
 
-command         : id=ID command_args?;
-command_args    : OP_CALL STRING (SEP_CALL STRING)* CL_CALL;
+// Definition of a composition
+composition     : COMPOSITION name=ID OPEN directive+ CLOSE;
+directive       : merge_directive;  // Will eventually support weaving
+merge_directive : JUSTIFICATION id=ID IS merge_equation;
+merge_equation  : left=ID COMPO_OPERATOR (right=ID | merge_equation);
 
-expression      : (boolean_expr | command) (op=BOOL_OP expression)*;
-boolean_expr    : (NOT)? symbol=ID (op=ARITH_OP INTEGER)?;
 
 /*****************
  ** Lexer rules **
@@ -45,6 +44,7 @@ boolean_expr    : (NOT)? symbol=ID (op=ARITH_OP INTEGER)?;
 PATTERN         : 'pattern';
 ABS_SUPPORT     : '@support';
 JUSTIFICATION   : 'justification';
+IMPLEMENTS      : 'implements';
 IS              : 'is';
 EVIDENCE        : 'evidence';
 STRATEGY        : 'strategy';
@@ -52,15 +52,8 @@ SUBCONCLUSION   : 'sub-conclusion';
 CONCLUSION      : 'conclusion';
 SUPPORT_LNK     : 'supports';
 LOAD            : 'load';
-IMPLEMENTATION  : 'implementation';
-OF              : 'of';
-IMPLEMENTS      : 'implements';
-PROBE           : 'probe';
-EXPECTATION     : 'expectation';
-OPERATION       : 'operation';
-BOOL_OP         : 'or' | 'and';
-NOT             : 'not';
-ARITH_OP        : '==' | '>' | '<' | '<=' | '>=';
+COMPOSITION     : 'composition';
+COMPO_OPERATOR  : 'with';
 
 // Making whitespaces and newlines irrelevant to the syntax
 WHITESPACE  : [ \t]+                -> channel(HIDDEN);
@@ -81,3 +74,33 @@ CL_CALL     : ')';
 SEP_CALL    : ',';
 
 fragment STRING_CHAR : ~('\r' | '\n');
+
+
+/*************************************************************
+ ** Deads code related to justification implementation  TBD **
+ *************************************************************/
+
+// PARSING
+
+//implementation  : IMPLEMENTATION id=ID OF justifiation_id=ID OPEN impl_body CLOSE;
+//impl_body       : (IMPLEMENTS id=ID OPEN (probe | operation) expectation? CLOSE)+;
+//probe           : PROBE IS command;
+//operation       : OPERATION IS command;
+//expectation     : EXPECTATION IS expression;
+//command         : id=ID command_args?;
+//command_args    : OP_CALL STRING (SEP_CALL STRING)* CL_CALL;
+//expression      : (boolean_expr | command) (op=BOOL_OP expression)*;
+//boolean_expr    : (NOT)? symbol=ID (op=ARITH_OP INTEGER)?;
+
+
+// LEXING
+
+//IMPLEMENTATION  : 'implementation';
+//OF              : 'of';
+
+//PROBE           : 'probe';
+//EXPECTATION     : 'expectation';
+//OPERATION       : 'operation';
+//BOOL_OP         : 'or' | 'and';
+//NOT             : 'not';
+//ARITH_OP        : '==' | '>' | '<' | '<=' | '>=';

--- a/src/main/java/ca/mcscert/jpipe/compiler/CompositionError.java
+++ b/src/main/java/ca/mcscert/jpipe/compiler/CompositionError.java
@@ -1,0 +1,11 @@
+package ca.mcscert.jpipe.compiler;
+
+/**
+ * Runtime exception thrown when encountering a composition error.
+ */
+public class CompositionError extends RuntimeException {
+
+    public CompositionError(String message) {
+        super("[CompositionError] " + message);
+    }
+}

--- a/src/main/java/ca/mcscert/jpipe/compiler/ModelCreationListener.java
+++ b/src/main/java/ca/mcscert/jpipe/compiler/ModelCreationListener.java
@@ -19,6 +19,7 @@ import ca.mcscert.jpipe.syntax.JPipeParser;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -274,13 +275,14 @@ public class ModelCreationListener extends JPipeBaseListener {
         logger.trace("Exiting composition unit " + ctx.name.getText());
     }
 
-    @Override
-    public void enterMerge_directive(JPipeParser.Merge_directiveContext ctx) {
-        logger.trace("  Entering merge unit " + ctx.id.getText());
-        this.mergeBuilder = new MergeBuilder(
-            (List<JustificationDiagram>) this.justifications.values());
+  @Override
+  public void enterMerge_directive(JPipeParser.Merge_directiveContext ctx) {
+    logger.trace("  Entering merge unit " + ctx.id.getText());
+    List<JustificationDiagram> list =
+        new ArrayList<JustificationDiagram>(this.justifications.values());
+    this.mergeBuilder = new MergeBuilder(list);
 
-    }
+  }
 
     @Override
     public void exitMerge_directive(JPipeParser.Merge_directiveContext ctx) {

--- a/src/main/java/ca/mcscert/jpipe/compiler/builders/MergeBuilder.java
+++ b/src/main/java/ca/mcscert/jpipe/compiler/builders/MergeBuilder.java
@@ -1,0 +1,66 @@
+package ca.mcscert.jpipe.compiler.builders;
+
+import ca.mcscert.jpipe.compiler.CompositionError;
+import ca.mcscert.jpipe.model.JustificationDiagram;
+import ca.mcscert.jpipe.operators.MergeOperator;
+import ca.mcscert.jpipe.operators.NaryOperator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Builder element to accumulate elements to merge and then trigger the operator.
+ */
+public class MergeBuilder {
+
+    private final Set<String> contents;
+    private final Map<String, JustificationDiagram> known;
+
+    /**
+     * Instantiate a merge builder, considering the justification diagram we already know.
+     *
+     * @param encountered the known diagrams
+     */
+    public MergeBuilder(List<JustificationDiagram> encountered) {
+        this.contents = new HashSet<>();
+        this.known = encountered.stream()
+                        .collect(Collectors.toMap(JustificationDiagram::name, Function.identity()));
+    }
+
+    /**
+     * Register a new justification diagram id to be part of this composition.
+     *
+     * @param id the id to register (must be known)
+     */
+    public void register(String id) {
+        if (! known.containsKey(id)) {
+            error("Cannot compose unknown justification [" + id + "]");
+        }
+        this.contents.add(id);
+    }
+
+    /**
+     * Error mechanism if merge is not consistent at parsing level.
+     *
+     * @param message the error message to send to the user
+     */
+    protected final void error(String message) {
+        throw new CompositionError(message);
+    }
+
+    /**
+     * Finalize the build by merging the diagrams and storing the result.
+     *
+     * @return the merged diagram
+     */
+    public JustificationDiagram build() {
+        Set<JustificationDiagram> toMerge =
+                contents.stream().map(known::get).collect(Collectors.toSet());
+        NaryOperator merge = new MergeOperator();
+        return merge.apply(toMerge);
+    }
+
+}

--- a/src/main/java/ca/mcscert/jpipe/operators/MergeOperator.java
+++ b/src/main/java/ca/mcscert/jpipe/operators/MergeOperator.java
@@ -1,0 +1,24 @@
+package ca.mcscert.jpipe.operators;
+
+import ca.mcscert.jpipe.compiler.ModelCreationListener;
+import ca.mcscert.jpipe.model.JustificationDiagram;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Implement a "merge union" semantic on top of justification diagrams.
+ */
+public final class MergeOperator implements NaryOperator {
+
+    private static final Logger logger = LogManager.getLogger(ModelCreationListener.class);
+
+    @Override
+    public JustificationDiagram apply(Set<JustificationDiagram> input) {
+        logger.trace("OPERATOR -- MERGE");
+        logger.trace("  inputs: "
+                + input.stream().map(JustificationDiagram::name).collect(Collectors.toSet()));
+        throw new UnsupportedOperationException("Not implemented yet!");
+    }
+}

--- a/src/main/java/ca/mcscert/jpipe/operators/NaryOperator.java
+++ b/src/main/java/ca/mcscert/jpipe/operators/NaryOperator.java
@@ -1,0 +1,19 @@
+package ca.mcscert.jpipe.operators;
+
+import ca.mcscert.jpipe.model.JustificationDiagram;
+import java.util.Set;
+
+/**
+ * Model an n-ary composition operator.
+ */
+public interface NaryOperator {
+
+    /**
+     * Apply the operator on Justification Diagrams, taking a set of inputs.
+     *
+     * @param input the set of justification diagrams to compose
+     * @return the result of the composition operator
+     */
+    JustificationDiagram apply(Set<JustificationDiagram> input);
+
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="trace">
+        <Root level="error">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="error">
+        <Root level="trace">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/src/test/resources/composition.jd
+++ b/src/test/resources/composition.jd
@@ -1,0 +1,34 @@
+justification j1 {
+
+    conclusion c1 is "a shared conclusion"
+
+    strategy s1 is "a strategy"
+    s1 supports c1
+
+    evidence e1 is "an evidence specific to j1"
+    e1 supports s1
+
+    evidence e2 is "a shared evidence"
+    e2 supports s1
+
+}
+
+justification j2 {
+
+    conclusion c2 is "a shared conclusion"
+
+    strategy s1 is "another strategy"
+    s1 supports c2
+
+    evidence e3 is "an evidence specific to j2"
+    e3 supports s1
+
+    evidence e4 is "a shared evidence"
+    e4 supports s1
+
+}
+
+
+composition unit1 {
+    justification j is j1 with j2
+}


### PR DESCRIPTION
Assuming existing justification diagrams, one can now create composition units:

```
composition unit1 {
    justification j is j1 with j2
}
```

This is compiled thanks to a `MergeBuilder`, and triggers a `MergeOperator` when finalizing the justification.

The implementation of the merge operator is TBD by @Nirmal-code 