### PR TITLE
specify log level from cli #45

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -15,6 +15,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+
 
 
 /**
@@ -40,11 +46,23 @@ public class Main {
             String format = cmd.getOptionValue("format",
                                     "png");
             String[] diagramNames = cmd.getOptionValues("diagram");
+            configureLogLevel(cmd);
 
             process(inputFile, outputDirectory, diagramNames, format);
         } catch (Exception | Error e) {
             System.err.println(ANSI_RED + e.getMessage() + ANSI_RESET);
             System.exit(1);
+        }
+    }
+
+    private static void configureLogLevel(CommandLine cmd) {
+        if (cmd.hasOption("log-level")) {
+            LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+            Configuration config = ctx.getConfiguration();
+            LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+            String level = cmd.getOptionValue("log-level");
+            loggerConfig.setLevel(Level.getLevel(level));
+            ctx.updateLoggers();
         }
     }
 

--- a/src/main/java/ca/mcscert/jpipe/CommandLineConfiguration.java
+++ b/src/main/java/ca/mcscert/jpipe/CommandLineConfiguration.java
@@ -54,7 +54,7 @@ public class CommandLineConfiguration {
     public void help() {
         Logo.sout();
         HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp(APP_NAME, getOptions());
+        formatter.printHelp(APP_NAME, getOptions(), true);
     }
 
     /**
@@ -87,20 +87,26 @@ public class CommandLineConfiguration {
         options.addOption(input);
 
         Option output = new Option("o", "output", true,
-                "output file path");
+                "output file(s) directory\n(default: .)");
         output.setRequired(false);
         options.addOption(output);
 
 
         Option diagram = new Option("d", "diagram", true,
-                "diagram names (you can specify multiple with repeated -d)");
+                "diagram names\n(use multiple -d if needed. Default: all)");
         diagram.setArgs(Option.UNLIMITED_VALUES);
         options.addOption(diagram);
 
         Option format = new Option("f", "format", true,
-                "output format (png, svg)");
+                "output format in [png, svg]\n(Default: png)");
         format.setRequired(false);
         options.addOption(format);
+
+        Option logLvl = new Option(null, "log-level", true,
+                "log level for Java logging API\n(default: ERROR)");
+        format.setRequired(false);
+        options.addOption(logLvl);
+
 
         return options;
     }

--- a/src/main/java/ca/mcscert/jpipe/Logo.java
+++ b/src/main/java/ca/mcscert/jpipe/Logo.java
@@ -7,16 +7,17 @@ public class Logo {
 
     @Override
     public String toString() {
-        return
-                "McMaster University - McMaster Centre for Software Certification (c) 2023-...\n"
-                        + "   _ ______  _\n"
-                        + "  (_)| ___ \\(_)\n"
-                        + "   _ | |_/ / _  _ __    ___\n"
-                        + "  | ||  __/ | || '_ \\  / _ \\\n"
-                        + "  | || |    | || |_) ||  __/\n"
-                        + "  | |\\_|    |_|| .__/  \\___|\n"
-                        + " _/ |          | |\n"
-                        + "|__/           |_|";
+        return """
+                McMaster University - McSCert (c) 2023-...
+                   _ ______  _
+                  (_)| ___ \\(_)
+                   _ | |_/ / _  _ __    ___
+                  | ||  __/ | || '_ \\  / _ \\
+                  | || |    | || |_) ||  __/
+                  | |\\_|    |_|| .__/  \\___|
+                 _/ |          | |
+                |__/           |_|
+                """;
     }
 
     /**


### PR DESCRIPTION
By default, the released compiler operates at the `error` level (#45 ). This make sense for regular usage, but it isn't very pleasant for debugging.

We can now use the `--log-level` parameter to override the logging value, if necessary.

To use the `trace` level:
```
mosser@azrael jpipe % java -jar jpipe.jar -i src/test/resources/simple.jd --log-level trace
```

By default (using `error`):
```
mosser@azrael jpipe % java -jar jpipe.jar -i src/test/resources/simple.jd 
```
If the log level is not known (e.g., `traceXXXX`), the system defaults back to `error` (compatible with log4j semantics).