### PR TITLE
Support stdin / stdout by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: ${{env.JAVA_ENV_VERSION}}
           distribution: 'adopt'
       # run integration tests (any test ending with IT)
       - name: Integration tests with Maven (failsafe)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ The jPipe environment is a experimental framework used to create pipelines that 
 It's an extension of so-called Justification Diagrams to support the notion of pipelines.
 
 ## General Information
-- Version: 23.07.03
+- Version: 24.02
 - Contributors:
   - Sébastien Mosser, McMaster University (Hamilton, Canada)
+  - Nirmal Chaudhari, McMaster University (Hamilton, Canada)
   - Corinne Pulgar, École de Technologie Supérieure (Montréal, Canada)
   - Deesha Patel, McMaster University (Hamilton, Canada)
   - Aaron Loh, McMaster University (Hamilton, Canada)
@@ -37,20 +38,20 @@ version of the jPipe compiler.
 
 ### Using the command-line interface
 
-Soon, you'll find some help about using the compiler by invoking `java -jar jpipe.jar --help`. In the meanwhile... 
-be patient :)
+You'll find a complete description of the compiler's options by invoking `java -jar jpipe.jar --help`. 
 
-In the MVP version, running the compiler on a file will produce one PNG file per justification diagram, in the same 
-directory. Assume the file `my_input.jd` contains two diagrams, names "J1" and "J2".
+Here is a list of the main options for end-users:
 
-```
-$ java -jar jpipe.jar my_input.jd
-```
-
-Will produce two png files: `my_input_J1.png` and `my_input_J2.png`
-
+- `-i`, `--input`: Specify the filename to be used as input (default is `stdin`)
+- `-d`, `--diagram`: Specify the name of the diagram to compile.
+    - If there is only one diagram in the compilation unit, it will default to this one.
+- `-o`, `--output`: Specify the output filename to use as output (default is `stdout`)
+- `-f`, `--format`: Specify the output format (PNG or SVG). Default is PNG.
+- `--all`: Flush all diagrams in the directory provided as argument.
 
 ## How to contribute?
 
-Feel free to fork this repository and send a pull request.
+Found a bug, or want to add a cool feature? Feel free to fork this repository and send a pull request. 
+
+If you're interested in contributing to the research effort related to jPipe, feel free to contact the PI: [Dr. Sébastien Mosser](mossers@mcmaster.ca). We do have undergrad summer internships available to contribute to the compiler, as well as MASc and PhD positions in Software Engineering at Mac.
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.21.1</version>
         </dependency>
+        <!-- JSON (for error messages and LSP) -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20231013</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -12,6 +12,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.FileSystemException;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -44,7 +45,7 @@ public class Main {
             logger.info(config);
             Unit unit = new Compiler().compile(config.input);
             if (config.flushAll()) {
-                // flushAllDiagrams(unit, config.all().get(), config.format());
+                flushAllDiagrams(unit, config.all().get(), config.format());
             } else {
                 processOne(unit, config.diagramName(), config.output(), config.format());
             }
@@ -217,76 +218,15 @@ public class Main {
 
     }
 
-
-
-
-
-
-
-    /*
-
-
-    private static void process(String inputFile, String outputDirectory,
-                                String[] diagramNames, String format) {
-        Unit unit = buildUnitFromFile(inputFile);
-        File outputDir = getOutputDirectory(outputDirectory);
-        Set<String> relevantDiagrams = extractDiagrams(unit, diagramNames);
-        Exportation<JustificationDiagram> exporter = new DiagramExporter();
-
-        for (String diagramName : relevantDiagrams) {
-            JustificationDiagram diag = unit.findByName(diagramName).orElseThrow();
-            String outfile = getOutputFilePath(inputFile, outputDir, diagramName, format);
-            exporter.export(diag, outfile, format);
+    private static void flushAllDiagrams(Unit unit, File outputDirectory, String format)
+            throws IOException {
+        Set<String> identifiers = unit.getIdentifiers();
+        for (String id : identifiers) {
+            String filename = outputDirectory.getPath() + "/" + id + "." + format.toLowerCase();
+            File outputFile = new File(filename);
+            processOne(unit, Optional.of(id), Optional.of(outputFile), format);
         }
+
     }
-
-    private static String getOutputFilePath(String inputFile, File outputDir,
-                                            String name, String format) {
-        return outputDir.getAbsolutePath() + "/"
-                + removeFileExtension(inputFile) + "_" + name + "." + format;
-    }
-
-    private static Set<String> extractDiagrams(Unit unit, String[] diagramNames) {
-        Set<String> all = unit.getJustificationSet().stream()
-                              .map(JustificationDiagram::name).collect(Collectors.toSet());
-        if (diagramNames == null || diagramNames.length == 0) {
-            return all;
-        }
-        Set<String> asked = new HashSet<>();
-        for (String name : diagramNames) {
-            if (all.contains(name)) {
-             asked.add(name);
-            } else {
-             throw new ExportationError("Unknown diagram identifier: [" + name + "]");
-            }
-        }
-        return asked;
-    }
-
-    private static File getOutputDirectory(String outputDirectory) {
-        File outputDir = new File(outputDirectory);
-        if (!outputDir.exists()) {
-            throw new IllegalArgumentException("Output directory does not exist: "
-                    + outputDir.getPath());
-        }
-        return outputDir;
-    }
-
-    private static Unit buildUnitFromFile(String inputFile) {
-        try {
-            return (new Compiler()).compile(inputFile);
-        } catch (IOException e) {
-            throw new RuntimeException("IO error: " + e.getMessage(), e);
-        }
-    }
-
-    private static String removeFileExtension(String filename) {
-        File f = new File(filename);
-        return f.getName().replaceAll("(?<!^)[.][^.]*$", "");
-    }
-
-
-     */
-
 
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,5 +1,6 @@
 import ca.mcscert.jpipe.ColorPrinter;
 import ca.mcscert.jpipe.CommandLineConfiguration;
+import ca.mcscert.jpipe.compiler.CompilationErrorLog;
 import ca.mcscert.jpipe.compiler.Compiler;
 import ca.mcscert.jpipe.exporters.DiagramExporter;
 import ca.mcscert.jpipe.exporters.Exportation;
@@ -45,9 +46,11 @@ public class Main {
             } else {
                 processOne(unit, config.diagramName(), config.output(), config.format());
             }
+            CompilationErrorLog.singleton().printAsText(System.err);
         } catch (Exception | Error e) {
             ColorPrinter printer = new ColorPrinter(System.err);
             printer.println("Top-level error: " + e.getMessage());
+            CompilationErrorLog.singleton().printAsText(System.err);
             System.exit(1);
         }
     }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,13 +1,17 @@
 import ca.mcscert.jpipe.CommandLineConfiguration;
 import ca.mcscert.jpipe.compiler.Compiler;
-import ca.mcscert.jpipe.compiler.exceptions.CompilationError;
 import ca.mcscert.jpipe.exporters.DiagramExporter;
 import ca.mcscert.jpipe.exporters.Exportation;
 import ca.mcscert.jpipe.exporters.ExportationError;
 import ca.mcscert.jpipe.model.JustificationDiagram;
 import ca.mcscert.jpipe.model.Unit;
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.FileSystemException;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -16,19 +20,16 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 
 
-
 /**
- * Entry point of the compiler.
+ * Entry point of the compiler. Boring but necessary stuff.
  */
 public class Main {
-
-    public static final String ANSI_RESET = "\u001B[0m";
-    public static final String ANSI_RED = "\u001B[31m";
 
     /**
      * Entry point of the system, triggering the compilation process.
@@ -38,16 +39,15 @@ public class Main {
     public static void main(String[] args) {
         try {
             CommandLine cmd = getCommandLineArgs(args);
-
-            String inputFile = cmd.getOptionValue("input");
-            String outputDirectory = cmd.getOptionValue("output",
-                                                        System.getProperty("user.dir"));
-            String format = cmd.getOptionValue("format",
-                                    "png");
-            String[] diagramNames = cmd.getOptionValues("diagram");
             configureLogLevel(cmd);
-
-            process(inputFile, outputDirectory, diagramNames, format);
+            CompilerConfiguration config = configure(cmd);
+            logger.info(config);
+            Unit unit = new Compiler().compile(config.input);
+            if (config.flushAll()) {
+                // flushAllDiagrams(unit, config.all().get(), config.format());
+            } else {
+                processOne(unit, config.diagramName(), config.output(), config.format());
+            }
         } catch (Exception | Error e) {
             String msg = e.getMessage();
             System.err.println(ANSI_RED + msg + ANSI_RESET);
@@ -55,15 +55,103 @@ public class Main {
         }
     }
 
-    private static void configureLogLevel(CommandLine cmd) {
-        if (cmd.hasOption("log-level")) {
-            LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-            Configuration config = ctx.getConfiguration();
-            LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
-            String level = cmd.getOptionValue("log-level");
-            loggerConfig.setLevel(Level.getLevel(level));
-            ctx.updateLoggers();
+    /**
+     * Model a consistent configuration of the compiler.
+     *
+     * @param input input file to be used   (empty => stdin)
+     * @param output output file to be used (empty => stdout)
+     * @param diagramName diagram name to export
+     * @param format file format to be used
+     * @param all should we export EVERYTHING instead of just one diagram?
+     */
+    private record CompilerConfiguration(Optional<File> input,
+                                         Optional<File> output,
+                                         Optional<String> diagramName, String format,
+                                         Optional<File> all)  {
+        public boolean flushAll() {
+            return all.isPresent();
         }
+
+    }
+
+    private static final String ANSI_RESET = "\u001B[0m";
+    private static final String ANSI_RED = "\u001B[31m";
+    private static final Logger logger = LogManager.getLogger();
+
+
+    /**
+     * Extract information from command line arguments, checking for errors.
+     *
+     *  @param args an Apache CLI command line
+     * @return a consistent CompilerConfiguration (with default values when needed)
+     * @throws IOException if the file system is not OK with the configuration
+     */
+    private static CompilerConfiguration configure(CommandLine args) throws IOException {
+        // Process input stream
+        logger.debug("Configuring input stream to stdin (default)");
+        Optional<File> input = Optional.empty();
+        if (args.hasOption("-i")) {
+            logger.debug("Overriding with user-provided file as input");
+            File inputFile = new File(args.getOptionValue("-i"));
+            if (! inputFile.exists()) {
+                throw new FileNotFoundException("Input file not found: " + inputFile.getPath());
+            }
+            input = Optional.of(inputFile);
+        }
+
+        // Process format
+        logger.debug("Configuring output format to PNG");
+        String format = "PNG";
+        if (args.hasOption("-f")) {
+            logger.debug("Overriding with user-provided file format");
+            format = args.getOptionValue("-f");
+            if (! Set.of("PNG", "SVG").contains(format)) {
+                throw new IllegalArgumentException("Unknown format: " + format);
+            }
+        }
+
+        // Process the "flush all" option first:
+        if (args.hasOption("--all")) {
+            logger.info("Switching to 'flush all diagrams' mode");
+            File outputDirectory = new File(args.getOptionValue("--all"));
+            if (! outputDirectory.exists()) {
+                if (! outputDirectory.mkdir()) {
+                    throw new FileSystemException("Unable to create directory: "
+                            + outputDirectory.getPath());
+                }
+            }
+            if (! outputDirectory.isDirectory()) {
+                throw new FileSystemException("Output must be a directory: "
+                        + outputDirectory.getPath());
+            }
+            return new CompilerConfiguration(input, null, null,
+                    format, Optional.of(outputDirectory));
+        }
+
+        logger.debug("Switching to 'export one diagram' mode");
+        // We're not in flush mode, so process output stream
+        Optional<File> output = Optional.empty();
+        if (args.hasOption("-o")) {
+            File outputFile = new File(args.getOptionValue("-o"));
+            if (outputFile.exists()) {
+                if (! outputFile.canWrite()) {
+                    throw new FileSystemException("Output file not writable: "
+                            + outputFile.getPath());
+                }
+            } else {
+                if (!outputFile.createNewFile()) {
+                    throw new FileSystemException("Cannot create output file "
+                            + outputFile.getPath());
+                }
+            }
+            output = Optional.of(outputFile);
+        }
+
+        Optional<String> diagram = Optional.empty();
+        if (args.hasOption("-d")) {
+           diagram = Optional.of(args.getOptionValue("-d"));
+        }
+        return new CompilerConfiguration(input, output, diagram, format, Optional.empty());
     }
 
     /**
@@ -82,6 +170,61 @@ public class Main {
         }
         return tmp.get();
     }
+
+    /**
+     * Manually override the log level, mainly for debugging purpose (dev mode).
+     *
+     * @param cmd the commandline (Apache CLI) containing (maybe) the log level to override to
+     */
+    private static void configureLogLevel(CommandLine cmd) {
+        if (cmd.hasOption("log-level")) {
+            LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+            Configuration config = ctx.getConfiguration();
+            LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+            String level = cmd.getOptionValue("log-level");
+            loggerConfig.setLevel(Level.getLevel(level));
+            ctx.updateLoggers();
+        }
+    }
+
+
+    private static void processOne(Unit unit, Optional<String> diagramName,
+                                   Optional<File> output, String format)
+            throws IOException {
+        String identifier;
+        if (diagramName.isEmpty()) {
+            if (unit.getIdentifiers().size() == 1) {
+                identifier = unit.getIdentifiers().stream().toList().get(0);
+            } else {
+                throw new IllegalArgumentException("Must specify diagram name!");
+            }
+        } else {
+            identifier = diagramName.get();
+        }
+        OutputStream os = System.out;
+        if (output.isPresent()) {
+            os = new FileOutputStream(output.get());
+        }
+        Exportation<JustificationDiagram> exporter = new DiagramExporter();
+        JustificationDiagram diag =
+                unit.findByName(identifier).orElseThrow(()
+                        -> new IllegalArgumentException("unknown diagram " + identifier));
+        try {
+            exporter.export(diag, os, format);
+        } finally {
+            os.close();
+        }
+
+    }
+
+
+
+
+
+
+
+    /*
+
 
     private static void process(String inputFile, String outputDirectory,
                                 String[] diagramNames, String format) {
@@ -132,8 +275,8 @@ public class Main {
     private static Unit buildUnitFromFile(String inputFile) {
         try {
             return (new Compiler()).compile(inputFile);
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException("File not found: " + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new RuntimeException("IO error: " + e.getMessage(), e);
         }
     }
 
@@ -141,4 +284,9 @@ public class Main {
         File f = new File(filename);
         return f.getName().replaceAll("(?<!^)[.][^.]*$", "");
     }
+
+
+     */
+
+
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,22 +1,18 @@
+import ca.mcscert.jpipe.ColorPrinter;
 import ca.mcscert.jpipe.CommandLineConfiguration;
 import ca.mcscert.jpipe.compiler.Compiler;
 import ca.mcscert.jpipe.exporters.DiagramExporter;
 import ca.mcscert.jpipe.exporters.Exportation;
-import ca.mcscert.jpipe.exporters.ExportationError;
 import ca.mcscert.jpipe.model.JustificationDiagram;
 import ca.mcscert.jpipe.model.Unit;
 import java.io.File;
-import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.FileSystemException;
-import java.nio.file.Paths;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.Level;
@@ -50,8 +46,8 @@ public class Main {
                 processOne(unit, config.diagramName(), config.output(), config.format());
             }
         } catch (Exception | Error e) {
-            String msg = e.getMessage();
-            System.err.println(ANSI_RED + msg + ANSI_RESET);
+            ColorPrinter printer = new ColorPrinter(System.err);
+            printer.println("Top-level error: " + e.getMessage());
             System.exit(1);
         }
     }
@@ -75,8 +71,6 @@ public class Main {
 
     }
 
-    private static final String ANSI_RESET = "\u001B[0m";
-    private static final String ANSI_RED = "\u001B[31m";
     private static final Logger logger = LogManager.getLogger();
 
 
@@ -208,8 +202,9 @@ public class Main {
         }
         Exportation<JustificationDiagram> exporter = new DiagramExporter();
         JustificationDiagram diag =
-                unit.findByName(identifier).orElseThrow(()
-                        -> new IllegalArgumentException("unknown diagram " + identifier));
+                unit.findByName(identifier)
+                        .orElseThrow(() ->
+                                new IllegalArgumentException("Unknown diagram " + identifier));
         try {
             exporter.export(diag, os, format);
         } finally {

--- a/src/main/java/ca/mcscert/jpipe/ColorPrinter.java
+++ b/src/main/java/ca/mcscert/jpipe/ColorPrinter.java
@@ -1,0 +1,28 @@
+package ca.mcscert.jpipe;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+/**
+ * Print message in color to the terminal using ANSI Code.
+ */
+public class ColorPrinter {
+
+    private static final String ANSI_RESET = "\u001B[0m";
+    private static final String ANSI_RED   = "\u001B[31m";
+
+    private final PrintStream stream;
+
+    public ColorPrinter(OutputStream stream) {
+        this.stream = new PrintStream(stream);
+    }
+
+    public void println(String message) {
+        stream.println(ANSI_RED + message + ANSI_RESET);
+    }
+
+    public void print(String message) {
+        stream.print(ANSI_RED + message + ANSI_RESET);
+    }
+
+}

--- a/src/main/java/ca/mcscert/jpipe/CommandLineConfiguration.java
+++ b/src/main/java/ca/mcscert/jpipe/CommandLineConfiguration.java
@@ -62,9 +62,8 @@ public class CommandLineConfiguration {
      *
      * @param args the arguments provided by the user
      * @return true if the option is found
-     * @throws ParseException is Apache CLI cannot parse the arguments
      */
-    private boolean checkForHelp(String[] args) throws ParseException {
+    private boolean checkForHelp(String[] args) {
         Set<String> arguments = new HashSet<>(Arrays.asList(args));
         return (arguments.contains("-h") || arguments.contains("--help"));
     }
@@ -82,19 +81,19 @@ public class CommandLineConfiguration {
         options.addOption(help);
 
         Option input = new Option("i", "input", true,
-                "input file path");
-        input.setRequired(true);
+                "input file path (default: stdin)");
+        input.setRequired(false);
         options.addOption(input);
 
         Option output = new Option("o", "output", true,
-                "output file(s) directory\n(default: .)");
+                "output file path (default: stdout)");
         output.setRequired(false);
         options.addOption(output);
 
 
         Option diagram = new Option("d", "diagram", true,
-                "diagram names\n(use multiple -d if needed. Default: all)");
-        diagram.setArgs(Option.UNLIMITED_VALUES);
+                "diagram name (default if only one)");
+        diagram.setRequired(false);
         options.addOption(diagram);
 
         Option format = new Option("f", "format", true,
@@ -102,11 +101,15 @@ public class CommandLineConfiguration {
         format.setRequired(false);
         options.addOption(format);
 
+        Option all = new Option(null, "all", true,
+                "Flush all diagrams into the provided directory");
+        all.setRequired(false);
+        options.addOption(all);
+
         Option logLvl = new Option(null, "log-level", true,
                 "log level for Java logging API\n(default: ERROR)");
         format.setRequired(false);
         options.addOption(logLvl);
-
 
         return options;
     }

--- a/src/main/java/ca/mcscert/jpipe/compiler/CompilationErrorLog.java
+++ b/src/main/java/ca/mcscert/jpipe/compiler/CompilationErrorLog.java
@@ -1,0 +1,126 @@
+package ca.mcscert.jpipe.compiler;
+
+import ca.mcscert.jpipe.ColorPrinter;
+import java.io.PrintStream;
+import java.util.LinkedList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Log all errors encountered while compiling the unit.
+ */
+public class CompilationErrorLog {
+
+    private static CompilationErrorLog singleton;
+
+    /**
+     * Offer a global compilationError log using hte singleton pattern.
+     *
+     * @return a singleton-ed instance of the log.
+     */
+    public static CompilationErrorLog singleton() {
+        if (singleton == null) {
+            singleton = new CompilationErrorLog();
+        }
+        return singleton;
+    }
+
+    private CompilationErrorLog() { }
+
+    /**
+     * Represent a compilation error that happened during the process.
+     *
+     * @param line the line where the error was detected (null if NA).
+     * @param column the column where the error was detected (null if NA)
+     * @param source the source of the error (ce.g., compilation phase)
+     * @param message the error message
+     */
+    private record Log(Integer line, Integer column, String source, String message) {
+
+        public String asText() {
+            return (this.source() == null ? "" : this.source())
+                    + (this.line() == null ? "" : ":" + line)
+                    + (this.column() == null ? "" : ":" + this.column())
+                    + " - " + message + System.lineSeparator();
+        }
+
+        /**
+         * Transform a log into a JSON object.
+         *
+         * @return a JSON representation of the error log (used by LSP/IDE).
+         */
+        public JSONObject asJson() {
+            JSONObject obj = new JSONObject();
+            obj.put("message", message());
+            if (source() != null) {
+                obj.put("source", source());
+            }
+            if (column() != null) {
+                obj.put("column", column());
+            }
+            if (line() != null) {
+                obj.put("line", line());
+            }
+            return obj;
+        }
+    }
+
+    private final List<Log> contents = new LinkedList<>();
+
+    /**
+     * Record a message into the log.
+     *
+     * @param message the message to record.
+     */
+    public void record(String message) {
+        this.record(null, null, null, message);
+    }
+
+    /**
+     * Record a message into the log, from a given source.
+     *
+     * @param source the source of the error.
+     * @param message the message to record.
+     */
+    public void record(String source, String message) {
+        this.record(null, null, source, message);
+    }
+
+    /**
+     * Record a message into the log, from a given source, at a given location.
+     *
+     * @param line the line where the error was detected (null if NA).
+     * @param column the column where the error was detected (null if NA)
+     * @param source the source of the error (ce.g., compilation phase)
+     * @param message the error message
+     */
+    public void record(Integer line, Integer column, String source, String message) {
+        this.contents.add(new Log(line, column, source, message));
+    }
+
+    /**
+     * Print the contents of the error log as text message on the console.
+     *
+     * @param stream the stream to be used for printing.
+     */
+    public void printAsText(PrintStream stream) {
+        ColorPrinter printer = new ColorPrinter(stream);
+        for (Log log : contents) {
+            printer.println(log.asText());
+        }
+    }
+
+    /**
+     * Print the content of the error log as JSON elements.
+     *
+     * @param stream the stream to be used for printing.
+     */
+    public void printAsJson(PrintStream stream) {
+        JSONArray json = new JSONArray();
+        for (Log log : contents) {
+           json.put(log.asJson());
+        }
+        stream.println(json);
+    }
+}

--- a/src/main/java/ca/mcscert/jpipe/compiler/Compiler.java
+++ b/src/main/java/ca/mcscert/jpipe/compiler/Compiler.java
@@ -5,11 +5,12 @@ import ca.mcscert.jpipe.compiler.exceptions.ParsingErrorListener;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.syntax.JPipeLexer;
 import ca.mcscert.jpipe.syntax.JPipeParser;
-import java.io.FileNotFoundException;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -32,15 +33,23 @@ public final class Compiler {
      *
      * @param fileName name of the file to compile.
      * @return a Unit model element modelling the AST of the compiled file
-     * @throws FileNotFoundException if file does not exist
+     * @throws IOException if encountering IO issues
      */
-    public Unit compile(String fileName) throws FileNotFoundException {
-        try {
-            CharStream input = CharStreams.fromFileName(fileName);
-            return this.compile(input, fileName);
-        } catch (IOException e) {
-            throw new FileNotFoundException(fileName);
+    public Unit compile(Optional<File> fileName) throws IOException {
+        CharStream input;
+        String path;
+        if (fileName.isEmpty()) {
+            input = CharStreams.fromStream(System.in);
+            path = "<stdin>";
+        } else {
+            path = fileName.get().toPath().toString();
+            input = CharStreams.fromPath(fileName.get().toPath());
         }
+        return this.compile(input, path);
+    }
+
+    public Unit compile(String fileName) throws IOException {
+        return this.compile(Optional.of(new File(fileName)));
     }
 
     /**

--- a/src/main/java/ca/mcscert/jpipe/compiler/ModelCreationListener.java
+++ b/src/main/java/ca/mcscert/jpipe/compiler/ModelCreationListener.java
@@ -18,6 +18,7 @@ import ca.mcscert.jpipe.model.justification.SubConclusion;
 import ca.mcscert.jpipe.syntax.JPipeBaseListener;
 import ca.mcscert.jpipe.syntax.JPipeParser;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -254,7 +255,7 @@ public class ModelCreationListener extends JPipeBaseListener {
           justifications.put(j.name(), j);
         }
         result.merge(unit);
-      } catch (FileNotFoundException e) {
+      } catch (IOException e) {
         throw new RuntimeException(e);
       }
     }

--- a/src/main/java/ca/mcscert/jpipe/exporters/DiagramExporter.java
+++ b/src/main/java/ca/mcscert/jpipe/exporters/DiagramExporter.java
@@ -7,6 +7,7 @@ import guru.nidi.graphviz.engine.Graphviz;
 import guru.nidi.graphviz.model.MutableGraph;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,10 +23,10 @@ public class DiagramExporter implements Exportation<JustificationDiagram> {
      * run the exportation to image.
      *
      * @param j the diagram to export.
-     * @param outputFile the output file to use.
+     * @param output the output stream to use.
      */
     @Override
-    public void export(JustificationDiagram j, String outputFile, String format) {
+    public void export(JustificationDiagram j, OutputStream output, String format) {
         logger.trace("Exporting justification [" + j.name() + "]");
         ToGraph visitor = new ToGraph();
         j.accept(visitor);
@@ -34,7 +35,7 @@ public class DiagramExporter implements Exportation<JustificationDiagram> {
 
         try {
             Format fileFormat = getFormatFromString(format);
-            Graphviz.fromGraph(graph).render(fileFormat).toFile(new File(outputFile));
+            Graphviz.fromGraph(graph).render(fileFormat).toOutputStream(output);
         } catch (IOException ioe) {
             throw new ExportationError(ioe.getMessage());
         }

--- a/src/main/java/ca/mcscert/jpipe/exporters/Exportation.java
+++ b/src/main/java/ca/mcscert/jpipe/exporters/Exportation.java
@@ -1,5 +1,7 @@
 package ca.mcscert.jpipe.exporters;
 
+import java.io.OutputStream;
+
 /**
  * Generic interface to export "things" into files.
  *
@@ -11,9 +13,9 @@ public interface Exportation<T> {
      * Export element into outputFile.
      *
      * @param element the element to export (e.g., a justification diagram)
-     * @param outputFile the file where to put the result of the exportation.
+     * @param output the stream where to put the result of the exportation.
      * @param format file format to export to.
      */
-    void export(T element, String outputFile, String format);
+    void export(T element, OutputStream output, String format);
 
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
     <Appenders>
-        <Console name="Console">
+        <Console name="stderr" target="SYSTEM_ERR">
             <PatternLayout pattern="[%-5level] %c{1.}: %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>
         <Root level="error">
-            <AppenderRef ref="Console"/>
+            <AppenderRef ref="stderr"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
The compiler needs to support the use of standard inputs and outputs to support the definition of it's IDE. Instead of writing and reading from file, real-time rendering would benefit from sending directly models on stdin and getting answer on stdout. This PR is an in-depth change in the way the compiler is configured, and pave the way for better error recording.