### PR TITLE
Export graphviz to maintain elements IDs

### DIFF
--- a/.github/sonarqube.yml
+++ b/.github/sonarqube.yml
@@ -1,0 +1,55 @@
+
+name: SonarQube analysis of the compiler
+
+env:
+  JAVA_ENV_VERSION: '21'      # LTS version
+
+on:
+  push:
+    paths:
+      - 'compiler/**'
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'compiler/**'
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    name: Build and analyze
+    defaults: 
+      run:
+        working-directory: './compiler'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{env.JAVA_ENV_VERSION}}
+          distribution: 'adopt' 
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ace-design_jpipe

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,39 +1,100 @@
-# jPipe Action-Based Compiler
+# jPipe Compiler
 
-- Author: Sébastien Mosser
-- Version: 2024.2
+<div align="center">
+
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ace-design_jpipe&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ace-design_jpipe)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ace-design_jpipe&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ace-design_jpipe)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ace-design_jpipe&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ace-design_jpipe)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ace-design_jpipe&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ace-design_jpipe)
+
+</div>
+
+## Installing the compiler as a user
+
+If you don't plan to contribute to the source code, the easiest way is to follow the [installation instructions](https://github.com/ace-design/jpipe/wiki/Setup) to install a stable release on your operating system. 
+
+### Installing the compiler as a jPipe developer
+
+The first step is to clone this repository on your local computer. The compiler source code is in the `compiler` directory.
+
+```
+~ $ git clone git@github.com:ace-design/jpipe.git
+~ $ cd jpipe/compiler
+compiler $
+```
+
+### Compiling the source code (aka packaging)
+
+We're using Maven to handle dependencies and build lifecycle. 
+
+```
+compiler $ mvn clean package
+```
+
+One can skip some tests execution at build time by using the following options:
+
+- `-Dskip.tests.unit` to skip unit tests execution
+- `-Dskip.tests.integration` to skip integration tests execution
+
+When packaging, the checkstyle conventions for coding are not enforced.
+
+### Executing the compiler from CLI
+
+Assuming your code is packaged, you can call the compiler using maven:
+
+```
+ compiler $ mvn -q exec:java -Dexec.mainClass="ca.mcscert.jpipe.Main" -Dexec.args="-h"
+```
+
+The `-Dexec.args` argument contains the command line argument you want to pass to the compiler (here, `-h`).
+
+### Building the compiler artefact
+
+The released compiler is built as a turn-key JAR file, `jpipe.jar`. To build such an artefact, you can use maven:
+
+```
+ compiler $ mvn install
+```
+
+When installing, maven triggers checkstyle verifications to ensure the code respects the coding conventions we agreed on for the project (a [slight variation](./src/main/resources/checkstyle/checkstyle-suppressions.xml) of the one released by Google). Maven will refuse installing the compiler until your code meet the coding convention practices. 
+
+To avoid bad surprises when installing the compiler and check these practices on the fly, you might want to configure your IDE to check these rules while you are coding. 
+
+We provide a standalone configuration file for IntelliJ (`./src/main/resources/checkstyle/google_checks_intelliJ.xml`)
 
 ### How to run the compiler?
 
-```
-$ java -jar abc-jpipe.jar --help
-```
-
-One should [read the documentation](https://github.com/ace-design/jpipe/wiki), or consider following one of our tutorials.
-
-To run the compiler in developer mode
+Once the compiler is installed, you can use it directly by invoking the JAR file from the command line and get rid of maven:
 
 ```
- $ mvn -q exec:java -Dexec.mainClass="ca.mcscert.jpipe.Main" -Dexec.args="-h"
+compiler $ java -jar jpipe.jar -h
 ```
 
-### How to contribute?
+### Running sonarqube code quality analysis
+
+to execute this manually, you need a `SONAR_TOKEN` from sonarcloud.io. If you don't have one, 
+you can just rely on the automated CI/CD pipeline that run the analysis on each pull requests.
+
+To run the analysis manually:
+
+```
+compiler $ mvn verify \
+                org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+                -Dsonar.projectKey=ace-design_jpipe 
+```
+
+## How to contribute to the compiler?
+
+Feel free to contact [Sébastien Mosser](mossers@mcmaster.ca) to discuss bout potential
+collaboration on jPipe.
 
 Before contributing, you might want to read some [_Architectural Decisions_](adr.md) recorded as Y-statements, providing some explanations on the global architecture.
 
-#### Compiling the compiler
+External contributions are accepted as pull requests.
 
-It is highly recommended to use the _released_ versions (e.g., through the VS Code marketplace or HomeBrew) rather than compiling from source. Use at your own risk.
 
-```
-$ mvn clean install
-```
+<div align="center">
 
-#### Configuring checkstyle
+[![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=ace-design_jpipe)
 
-The project adheres to Google's recommendations, automatically enforced by CheckStyle. These 
-are automatically enforced by Maven when building the project. 
-Violating them is ok at _package_ time (e.g., while developing), but is considered an error at _install_ time (e.g., when releasing).
-
-To configure your IDE to reflect these practices, use the provided local configuration file (`./src/main/resources/checkstyle/google_checks_intelliJ.xml`)
-
+</div>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -29,9 +29,10 @@
         <skip.tests.integration>false</skip.tests.integration>
         <!-- Should use latest LTS version -->
         <maven.compiler.release>21</maven.compiler.release>
+        <!-- Sonar code quality analysis (requires a SONAR_TOKEN env variable)  -->
+        <sonar.organization>ace-design</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
-
-
 
     <developers>
         <developer>
@@ -163,6 +164,25 @@
                         <id>antlr</id>
                         <goals>
                             <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -108,6 +108,12 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.23.1</version>
         </dependency>
+        <!-- JSON export library -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20250107</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/compiler/src/main/java/ca/mcscert/jpipe/actions/linking/LoadFile.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/actions/linking/LoadFile.java
@@ -1,13 +1,11 @@
 package ca.mcscert.jpipe.actions.linking;
 
 import ca.mcscert.jpipe.actions.Action;
-import ca.mcscert.jpipe.actions.ExecutionEngine;
 import ca.mcscert.jpipe.actions.MacroAction;
-import ca.mcscert.jpipe.actions.RegularAction;
 import ca.mcscert.jpipe.compiler.CompilerFactory;
 import ca.mcscert.jpipe.compiler.model.Source;
 import ca.mcscert.jpipe.compiler.model.Transformation;
-import ca.mcscert.jpipe.compiler.steps.io.FileReader;
+import ca.mcscert.jpipe.compiler.steps.io.sources.FileReader;
 import ca.mcscert.jpipe.error.SemanticError;
 import ca.mcscert.jpipe.model.Unit;
 import java.io.File;
@@ -33,23 +31,23 @@ public class LoadFile extends MacroAction {
     @Override
     public List<Action> expand(Unit context) throws Exception {
         Path p = new File(fileName).toPath().normalize();
-        canLoad(p, context);
-        context.addLoadedFile(p);
-        Transformation<InputStream, List<Action>> partial = CompilerFactory.actionProvider();
-        Source<InputStream> reader = new FileReader();
-        try (InputStream in = reader.provideFrom(p.toString())) {
-            return partial.fire(in, p.toString());
+        if (canLoad(p, context)) {
+            context.addLoadedFile(p);
+            Transformation<InputStream, List<Action>> partial = CompilerFactory.actionProvider();
+            Source<InputStream> reader = new FileReader();
+            try (InputStream in = reader.provideFrom(p.toString())) {
+                return partial.fire(in, p.toString());
+            }
+        } else {
+            return List.of(); // Nothing to do, file already loaded
         }
     }
 
-    private void canLoad(Path p, Unit context) {
-
-        if (context.isInScope(p)) {
-            throw new SemanticError("Cannot load file " + p + " as it is already loaded");
-        }
+    private boolean canLoad(Path p, Unit context) {
         if (!p.toFile().exists()) {
             throw new SemanticError("Cannot load file " + p + " (file not found or not readable)");
         }
+        return (!context.isInScope(p)); // Load only if not already loaded;
     }
 
     @Override

--- a/compiler/src/main/java/ca/mcscert/jpipe/cli/CommandLineParser.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/cli/CommandLineParser.java
@@ -16,7 +16,7 @@ import org.apache.commons.cli.ParseException;
  */
 public final class CommandLineParser {
 
-    private static final String APP_NAME = "java -jar abc-jpipe.jar";
+    private static final String APP_NAME = "java -jar jpipe.jar";
     private final String[] userGiven;
 
     /**

--- a/compiler/src/main/java/ca/mcscert/jpipe/cli/Configuration.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/cli/Configuration.java
@@ -69,14 +69,7 @@ public final class Configuration {
      */
     private void checkConsistency()  {
         logger.trace("  Checking configuration consistency");
-        // CR #1: if print mode then diagram name is provided
-        if (this.mode == Mode.PRINT) {
-            if (this.diagramName == null) {
-                ErrorManager.getInstance().fatal(
-                        new IllegalArgumentException("Print mode requires a diagram name"));
-            }
-        }
-
+        // Nothing to do right now
     }
 
     /**

--- a/compiler/src/main/java/ca/mcscert/jpipe/cli/Format.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/cli/Format.java
@@ -6,5 +6,5 @@ package ca.mcscert.jpipe.cli;
  * @author mosser
  */
 public enum Format {
-    PNG, SVG, JPIPE, GRAPHVIZ
+    PNG, SVG, DOT, JPIPE, JSON, RUNNER
 }

--- a/compiler/src/main/java/ca/mcscert/jpipe/cli/Option.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/cli/Option.java
@@ -20,7 +20,7 @@ public enum Option {
             "diagram name (default if only one)"),
 
     OUT_FORMAT("f", "format",
-            "output format in [png, svg]\n(Default: png)"),
+            "output format in [png, svg, dot, json, jd, runner]\n(Default: png)"),
 
     COMPILE_MODE("mode",
             "compiler's mode in [print, list] (default: print)"),

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
@@ -21,6 +21,7 @@ import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.JustificationModel;
 import ca.mcscert.jpipe.visitors.exporters.GraphVizExporter;
 import ca.mcscert.jpipe.visitors.exporters.JpipeExporter;
+import ca.mcscert.jpipe.visitors.exporters.JpipeRunnerExporter;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,9 +61,10 @@ public final class CompilerFactory {
             case PNG, DOT, SVG -> chain.andThen(new ModelVisit<>(new GraphVizExporter()))
                                         .andThen(new GraphVizRenderer(config.getFormat()));
             case JPIPE -> chain.andThen(new ModelVisit<>(new JpipeExporter()))
-                    .andThen(new FileWriter());
+                               .andThen(new FileWriter());
             case JSON -> throw new UnsupportedOperationException("Json not supported");
-            case RUNNER -> throw new UnsupportedOperationException("Runner not supported");
+            case RUNNER -> chain.andThen(new ModelVisit<>(new JpipeRunnerExporter()))
+                                .andThen(new FileWriter());
         };
 
     }

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
@@ -4,24 +4,26 @@ import ca.mcscert.jpipe.actions.Action;
 import ca.mcscert.jpipe.cli.Configuration;
 import ca.mcscert.jpipe.compiler.model.ChainBuilder;
 import ca.mcscert.jpipe.compiler.model.Transformation;
-import ca.mcscert.jpipe.compiler.steps.ActionListInterpretation;
-import ca.mcscert.jpipe.compiler.steps.ActionListProvider;
-import ca.mcscert.jpipe.compiler.steps.CharStreamProvider;
-import ca.mcscert.jpipe.compiler.steps.CompletenessChecker;
-import ca.mcscert.jpipe.compiler.steps.ConsistencyChecker;
-import ca.mcscert.jpipe.compiler.steps.LazyHaltAndCatchFire;
-import ca.mcscert.jpipe.compiler.steps.Lexer;
-import ca.mcscert.jpipe.compiler.steps.ModelVisit;
-import ca.mcscert.jpipe.compiler.steps.Parser;
-import ca.mcscert.jpipe.compiler.steps.ScopeFiltering;
-import ca.mcscert.jpipe.compiler.steps.io.FileReader;
-import ca.mcscert.jpipe.compiler.steps.io.FileWriter;
-import ca.mcscert.jpipe.compiler.steps.io.GraphVizRenderer;
+import ca.mcscert.jpipe.compiler.steps.checkers.CompletenessChecker;
+import ca.mcscert.jpipe.compiler.steps.checkers.ConsistencyChecker;
+import ca.mcscert.jpipe.compiler.steps.checkers.LazyHaltAndCatchFire;
+import ca.mcscert.jpipe.compiler.steps.io.sinks.GraphVizRenderer;
+import ca.mcscert.jpipe.compiler.steps.io.sinks.OutputStreamWriter;
+import ca.mcscert.jpipe.compiler.steps.io.sources.FileReader;
+import ca.mcscert.jpipe.compiler.steps.transformations.ActionListInterpretation;
+import ca.mcscert.jpipe.compiler.steps.transformations.ActionListProvider;
+import ca.mcscert.jpipe.compiler.steps.transformations.CharStreamProvider;
+import ca.mcscert.jpipe.compiler.steps.transformations.LambdaExecution;
+import ca.mcscert.jpipe.compiler.steps.transformations.Lexer;
+import ca.mcscert.jpipe.compiler.steps.transformations.ModelVisit;
+import ca.mcscert.jpipe.compiler.steps.transformations.Parser;
+import ca.mcscert.jpipe.compiler.steps.transformations.ScopeFiltering;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.JustificationModel;
 import ca.mcscert.jpipe.visitors.exporters.GraphVizExporter;
 import ca.mcscert.jpipe.visitors.exporters.JpipeExporter;
 import ca.mcscert.jpipe.visitors.exporters.JpipeRunnerExporter;
+import ca.mcscert.jpipe.visitors.exporters.JsonExporter;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,17 +41,28 @@ public final class CompilerFactory {
      * @return the expected compiler.
      */
     public static Compiler build(Configuration config) {
-
-        ChainBuilder<InputStream, Unit> unitBuilder = minimalChain()
-                .andThen(new ActionListInterpretation())
-                .andThen(new CompletenessChecker())
-                .andThen(new ConsistencyChecker());
-
         return switch (config.getMode()) {
-            case PRINT -> processPrintMode(unitBuilder, config);
-            case LIST  -> processListMode(unitBuilder, config);
+            case PRINT -> processPrintMode(unitBuilder(), config);
+            case LIST  -> processListMode(unitBuilder(), config);
         };
+    }
 
+    /**
+     * Provide a partial compilation chain to get actions out of a given filename.
+     *
+     * @return a default transformation from an input stream to a list of actions.
+     */
+    public static Transformation<InputStream, List<Action>> actionProvider() {
+        return minimalChain().asTransformation();
+    }
+
+    /**
+     * Provide a transformation that build a unit from a given input stream.
+     *
+     * @return a compiled unit.
+     */
+    public static Transformation<InputStream, Unit> loader() {
+        return unitBuilder().asTransformation();
     }
 
     private static Compiler processPrintMode(ChainBuilder<InputStream, Unit> unitBuilder,
@@ -61,10 +74,12 @@ public final class CompilerFactory {
             case PNG, DOT, SVG -> chain.andThen(new ModelVisit<>(new GraphVizExporter()))
                                         .andThen(new GraphVizRenderer(config.getFormat()));
             case JPIPE -> chain.andThen(new ModelVisit<>(new JpipeExporter()))
-                               .andThen(new FileWriter());
-            case JSON -> throw new UnsupportedOperationException("Json not supported");
+                               .andThen(new OutputStreamWriter<>());
+            case JSON -> chain.andThen(new ModelVisit<>(new JsonExporter()))
+                              .andThen(new LambdaExecution<>((json) -> json.toString(2)))
+                              .andThen(new OutputStreamWriter<>());
             case RUNNER -> chain.andThen(new ModelVisit<>(new JpipeRunnerExporter()))
-                                .andThen(new FileWriter());
+                                .andThen(new OutputStreamWriter<>());
         };
 
     }
@@ -75,38 +90,10 @@ public final class CompilerFactory {
     }
 
     /**
-     * Provide a default compilation chain.
+     * Represent the minimal compilation stapes to extract actions from a source file.
      *
-     * @param config the configuration provided by the user.
-     * @return a default instance of Compiler.
+     * @return the list of actions to execute to build the model (a unit).
      */
-    private static Compiler defaultCompiler(Configuration config) {
-        List<Throwable> errors = new ArrayList<>();
-
-        return new FileReader()
-                     .andThen(new CharStreamProvider())
-                     .andThen(new Lexer(errors))
-                     .andThen(new Parser(errors))
-                     .andThen(new LazyHaltAndCatchFire<>(errors))
-                     .andThen(new ActionListProvider())
-                     .andThen(new ActionListInterpretation())
-                     .andThen(new CompletenessChecker())
-                     .andThen(new ConsistencyChecker())
-                     .andThen(new ScopeFiltering(config.getDiagramName()))
-                     .andThen(new ModelVisit<>(new GraphVizExporter()))
-                     .andThen(new GraphVizRenderer(config.getFormat()));
-    }
-
-
-    /**
-     * Provide a partial compilation chain to get actions out of a given filename.
-     *
-     * @return a default instance of Compiler.
-     */
-    public static Transformation<InputStream, List<Action>> actionProvider() {
-        return minimalChain().asTransformation();
-    }
-
     private static ChainBuilder<InputStream, List<Action>> minimalChain() {
         List<Throwable> errors = new ArrayList<>();
         return new FileReader()
@@ -115,6 +102,18 @@ public final class CompilerFactory {
                 .andThen(new Parser(errors))
                 .andThen(new LazyHaltAndCatchFire<>(errors))
                 .andThen(new ActionListProvider());
+    }
+
+    /**
+     * Extend minimal chain by interpreting the actions and checking consistency/completeness.
+     *
+     * @return a complete and consistent unit, if any.
+     */
+    private static ChainBuilder<InputStream, Unit> unitBuilder() {
+        return minimalChain()
+                .andThen(new ActionListInterpretation())
+                .andThen(new CompletenessChecker())
+                .andThen(new ConsistencyChecker());
     }
 
 

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/ScopeFiltering.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/ScopeFiltering.java
@@ -22,7 +22,17 @@ public class ScopeFiltering extends Transformation<Unit, JustificationModel> {
 
     @Override
     protected JustificationModel run(Unit input, String source) throws Exception {
-        return input.get(this.identifier);
+        String id = this.identifier;
+        if (id == null) {
+            if (input.getContents().size() == 1) {
+                JustificationModel m = input.getContents().toArray(new JustificationModel[]{})[0];
+                id = m.getName();
+                logger.info("No diagram provided, defaulting to {}", id);
+            } else {
+                throw new IllegalArgumentException("Cannot guess which diagram to work with");
+            }
+        }
+        return input.get(id);
     }
 
 }

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/Apply.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/Apply.java
@@ -1,8 +1,7 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.checkers;
 
 import ca.mcscert.jpipe.compiler.model.Checker;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Step used for debugging purpose to run an arbitrary function on a model, without changing it.

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/CompletenessChecker.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/CompletenessChecker.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.checkers;
 
 import ca.mcscert.jpipe.compiler.model.Checker;
 import ca.mcscert.jpipe.error.ErrorManager;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/ConsistencyChecker.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/ConsistencyChecker.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.checkers;
 
 import ca.mcscert.jpipe.compiler.model.Checker;
 import ca.mcscert.jpipe.error.ErrorManager;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/LazyHaltAndCatchFire.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/LazyHaltAndCatchFire.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.checkers;
 
 import ca.mcscert.jpipe.compiler.model.Checker;
 import ca.mcscert.jpipe.error.ErrorManager;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/FileWriter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/FileWriter.java
@@ -1,0 +1,30 @@
+package ca.mcscert.jpipe.compiler.steps.io;
+
+import ca.mcscert.jpipe.cli.Configuration;
+import ca.mcscert.jpipe.compiler.model.Sink;
+import ca.mcscert.jpipe.error.ErrorManager;
+import java.io.IOException;
+import java.io.PrintStream;
+
+/**
+ * Flush the content of a string builder into a file (or stdout).
+ */
+public class FileWriter implements Sink<StringBuilder> {
+
+    @Override
+    public void pourInto(StringBuilder output, String fileName) throws IOException {
+
+        if (fileName.equals(Configuration.STDOUT_PATH)) {
+            System.out.println(output.toString());
+            System.out.flush();
+        } else {
+            try (PrintStream fos = new PrintStream(fileName)) {
+                fos.println(output.toString());
+                fos.flush();
+            } catch (IOException ioe) {
+                ErrorManager.getInstance().fatal(ioe);
+            }
+        }
+    }
+
+}

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/GraphVizRenderer.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/GraphVizRenderer.java
@@ -35,6 +35,7 @@ public class GraphVizRenderer implements Sink<MutableGraph> {
         guru.nidi.graphviz.engine.Format out = switch (this.format) {
             case PNG -> guru.nidi.graphviz.engine.Format.PNG;
             case SVG -> guru.nidi.graphviz.engine.Format.SVG;
+            case DOT -> guru.nidi.graphviz.engine.Format.DOT;
             default -> throw new IllegalArgumentException("Cannot process format ["
                                                             + format
                                                             + "] with a Graphviz renderer");

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/sinks/GraphVizRenderer.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/sinks/GraphVizRenderer.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps.io;
+package ca.mcscert.jpipe.compiler.steps.io.sinks;
 
 import ca.mcscert.jpipe.cli.Configuration;
 import ca.mcscert.jpipe.cli.Format;
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * Compiler sink, rendering a GraphViz MutableGraph as an image (file or stdout).
  */
-public class GraphVizRenderer implements Sink<MutableGraph> {
+public final class GraphVizRenderer implements Sink<MutableGraph> {
 
     private final Format format;
     private static final Logger logger = LogManager.getLogger();

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/sinks/OutputStreamWriter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/sinks/OutputStreamWriter.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps.io;
+package ca.mcscert.jpipe.compiler.steps.io.sinks;
 
 import ca.mcscert.jpipe.cli.Configuration;
 import ca.mcscert.jpipe.compiler.model.Sink;
@@ -7,13 +7,14 @@ import java.io.IOException;
 import java.io.PrintStream;
 
 /**
- * Flush the content of a string builder into a file (or stdout).
+ * Flush to an output stream any object that support a .toString() call.
+ *
+ * @param <T> the type of object we're publishing.
  */
-public class FileWriter implements Sink<StringBuilder> {
+public final class OutputStreamWriter<T> implements Sink<T> {
 
     @Override
-    public void pourInto(StringBuilder output, String fileName) throws IOException {
-
+    public final void pourInto(T output, String fileName) throws IOException {
         if (fileName.equals(Configuration.STDOUT_PATH)) {
             System.out.println(output.toString());
             System.out.flush();
@@ -26,5 +27,4 @@ public class FileWriter implements Sink<StringBuilder> {
             }
         }
     }
-
 }

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/sources/FileReader.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/io/sources/FileReader.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps.io;
+package ca.mcscert.jpipe.compiler.steps.io.sources;
 
 import ca.mcscert.jpipe.cli.Configuration;
 import ca.mcscert.jpipe.compiler.model.Source;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ActionListInterpretation.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ActionListInterpretation.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import ca.mcscert.jpipe.actions.Action;
 import ca.mcscert.jpipe.actions.ExecutionEngine;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ActionListProvider.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ActionListProvider.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import ca.mcscert.jpipe.actions.Action;
 import ca.mcscert.jpipe.actions.creation.CreateAbstractSupport;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/CharStreamProvider.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/CharStreamProvider.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import ca.mcscert.jpipe.compiler.model.Transformation;
 import java.io.IOException;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LambdaExecution.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LambdaExecution.java
@@ -1,0 +1,25 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import ca.mcscert.jpipe.compiler.model.Transformation;
+import java.util.function.Function;
+
+/**
+ * Execute a provided lambda function.
+ *
+ * @param <I> the input type of the lambda function
+ * @param <O> the output type of the lambda function
+ */
+public final class LambdaExecution<I, O> extends Transformation<I, O> {
+
+    private final Function<I, O> lambda;
+
+    public LambdaExecution(Function<I, O> lambda) {
+        this.lambda = lambda;
+    }
+
+    @Override
+    protected O run(I input, String source) throws Exception {
+        return lambda.apply(input);
+    }
+
+}

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/Lexer.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/Lexer.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.error.LexingError;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ModelVisit.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ModelVisit.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.model.Visitable;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/Parser.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/Parser.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.error.ParsingError;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/RenderAsText.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/RenderAsText.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import ca.mcscert.jpipe.compiler.model.Transformation;
 import guru.nidi.graphviz.model.MutableGraph;

--- a/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ScopeFiltering.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ScopeFiltering.java
@@ -1,4 +1,4 @@
-package ca.mcscert.jpipe.compiler.steps;
+package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.model.Unit;

--- a/compiler/src/main/java/ca/mcscert/jpipe/model/Unit.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/model/Unit.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * Define what a compilation Unit is in JPipe.
  */
-public final class Unit implements Visitable, Serializable, Cloneable {
+public final class Unit implements Visitable {
 
     private final String name;
     private final SymbolTable<JustificationModel> contents;
@@ -96,11 +96,6 @@ public final class Unit implements Visitable, Serializable, Cloneable {
     @Override
     public void accept(ModelVisitor<?> visitor) {
         visitor.visit(this);
-    }
-
-    @Override
-    protected Object clone() throws CloneNotSupportedException {
-        return super.clone();
     }
 
     @Override

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/GraphVizExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/GraphVizExporter.java
@@ -14,6 +14,7 @@ import ca.mcscert.jpipe.model.elements.Pattern;
 import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
 import ca.mcscert.jpipe.visitors.ModelVisitor;
+import guru.nidi.graphviz.attribute.Attributes;
 import guru.nidi.graphviz.attribute.Color;
 import guru.nidi.graphviz.attribute.Label;
 import guru.nidi.graphviz.attribute.Rank;
@@ -26,6 +27,8 @@ import guru.nidi.graphviz.model.MutableNode;
  * Visit a jPipe model to produce a GraphViz Mutable Graph (used for image rendering).
  */
 public class GraphVizExporter extends ModelVisitor<MutableGraph> {
+
+    private String context = "";
 
     /**
      * Creates a Mutable Graph exporter visitor. Instantiating the accumulator as a properly
@@ -46,25 +49,29 @@ public class GraphVizExporter extends ModelVisitor<MutableGraph> {
 
     @Override
     public void visit(Justification j) {
+        this.context = j.getName();
         // Setting justification name
         this.accumulator.graphAttrs().add(Label.markdown(j.getName()));
         for (JustificationElement je : j.contents()) {
             je.accept(this);
         }
+        this.context = "";
     }
 
     @Override
     public void visit(Pattern p) {
+        this.context = p.getName();
         String label = "&lt;&lt;pattern&gt;&gt;&nbsp;" + p.getName();
         this.accumulator.graphAttrs().add(Label.html(label));
         for (JustificationElement je : p.contents()) {
             je.accept(this);
         }
+        this.context = "";
     }
 
     @Override
     public void visit(Conclusion c) {
-        MutableNode n = mutNode(c.getIdentifier())
+        MutableNode n = asMutableNode(c)
                 .add(Label.markdown(c.getLabel()))
                 .add(Shape.RECT)
                 .add(Style.combine(Style.FILLED, Style.ROUNDED))
@@ -79,7 +86,7 @@ public class GraphVizExporter extends ModelVisitor<MutableGraph> {
 
     @Override
     public void visit(Evidence e) {
-        MutableNode n = mutNode(e.getIdentifier())
+        MutableNode n = asMutableNode(e)
                 .add(Label.markdown(e.getLabel()))
                 .add(Shape.NOTE)
                 .add(Color.LIGHTSKYBLUE2.fill())
@@ -90,7 +97,7 @@ public class GraphVizExporter extends ModelVisitor<MutableGraph> {
 
     @Override
     public void visit(AbstractSupport as) {
-        MutableNode n = mutNode(as.getIdentifier())
+        MutableNode n = asMutableNode(as)
                 .add(Label.html("<i>" + as.getLabel() + "</i>"))
                 .add(Shape.RECT)
                 .add(Style.DOTTED)
@@ -100,7 +107,7 @@ public class GraphVizExporter extends ModelVisitor<MutableGraph> {
 
     @Override
     public void visit(Strategy s) {
-        MutableNode n = mutNode(s.getIdentifier())
+        MutableNode n = asMutableNode(s)
                 .add(Label.markdown(s.getLabel()))
                 .add(Shape.PARALLELOGRAM)
                 .add(Style.FILLED)
@@ -114,7 +121,7 @@ public class GraphVizExporter extends ModelVisitor<MutableGraph> {
 
     @Override
     public void visit(SubConclusion sc) {
-        MutableNode n = mutNode(sc.getIdentifier())
+        MutableNode n = asMutableNode(sc)
                 .add(Label.markdown(sc.getLabel()))
                 .add(Shape.RECT)
                 .add(Color.DODGERBLUE)
@@ -123,6 +130,15 @@ public class GraphVizExporter extends ModelVisitor<MutableGraph> {
         if (sc.getStrategy() != null) {
             this.accumulator.add(node(sc.getStrategy().getIdentifier()).link(n));
         }
+    }
+
+    private MutableNode asMutableNode(JustificationElement e) {
+        return mutNode(e.getIdentifier())
+                .add(Attributes.attr("id", buildIdentifier(e)));
+    }
+
+    private String buildIdentifier(JustificationElement e) {
+        return String.format("%s:%s", this.context, e.getIdentifier());
     }
 
 }

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeExporter.java
@@ -1,0 +1,90 @@
+package ca.mcscert.jpipe.visitors.exporters;
+
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.Justification;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
+import ca.mcscert.jpipe.model.elements.JustificationModel;
+import ca.mcscert.jpipe.model.elements.Pattern;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
+import ca.mcscert.jpipe.visitors.ModelVisitor;
+
+/**
+ * Export a flat (no pattern extension or composition rule) version of a given model.
+ */
+public class JpipeExporter extends ModelVisitor<StringBuilder> {
+
+    public JpipeExporter() {
+        super(new StringBuilder());
+    }
+
+    @Override
+    public void visit(Conclusion c) {
+        exportJustificationElement("conclusion", c);
+    }
+
+    @Override
+    public void visit(Evidence e) {
+        exportJustificationElement("evidence", e);
+    }
+
+    @Override
+    public void visit(Strategy s) {
+        exportJustificationElement("strategy", s);
+    }
+
+    @Override
+    public void visit(SubConclusion sc) {
+        exportJustificationElement("sub-conclusion", sc);
+    }
+
+    @Override
+    public void visit(AbstractSupport as) {
+        exportJustificationElement("@support", as);
+    }
+
+    @Override
+    public void visit(Justification j) {
+        exportJustificationModel("justification", j);
+    }
+
+    @Override
+    public void visit(Pattern p) {
+        exportJustificationModel("pattern", p);
+    }
+
+    @Override
+    public void visit(Unit u) {
+        throw new RuntimeException("Cannot export to graphviz an entire compilation unit!");
+    }
+
+    private void exportJustificationElement(String keyword, JustificationElement e) {
+        String tpl = "%s %s is \"%s\"";
+        this.accumulator
+                .append("  ")
+                .append(String.format(tpl, keyword, e.getIdentifier(), e.getLabel()))
+                .append(System.lineSeparator());
+        for (JustificationElement je : e.getSupports()) {
+            String lnk = "%s supports %s";
+            this.accumulator.append("  ")
+                    .append(String.format(lnk, je.getIdentifier(), e.getIdentifier()))
+                    .append(System.lineSeparator());
+        }
+    }
+
+
+    private void exportJustificationModel(String keyword, JustificationModel model) {
+        String tpl = "%s %s {";
+        this.accumulator
+                .append(String.format(tpl, keyword, model.getName()))
+                .append(System.lineSeparator());
+        for (JustificationElement je : model.contents()) {
+            je.accept(this);
+        }
+        this.accumulator.append("}").append(System.lineSeparator());
+    }
+
+}

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeExporter.java
@@ -67,6 +67,9 @@ public class JpipeExporter extends ModelVisitor<StringBuilder> {
                 .append("  ")
                 .append(String.format(tpl, keyword, e.getIdentifier(), e.getLabel()))
                 .append(System.lineSeparator());
+    }
+
+    private void exportSupports(JustificationElement e) {
         for (JustificationElement je : e.getSupports()) {
             String lnk = "%s supports %s";
             this.accumulator.append("  ")
@@ -81,8 +84,13 @@ public class JpipeExporter extends ModelVisitor<StringBuilder> {
         this.accumulator
                 .append(String.format(tpl, keyword, model.getName()))
                 .append(System.lineSeparator());
+        // Exporting nodes
         for (JustificationElement je : model.contents()) {
             je.accept(this);
+        }
+        // Exporting relations
+        for (JustificationElement je : model.contents()) {
+            exportSupports(je);
         }
         this.accumulator.append("}").append(System.lineSeparator());
     }

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeRunnerExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeRunnerExporter.java
@@ -1,0 +1,7 @@
+package ca.mcscert.jpipe.visitors.exporters;
+
+/**
+ * Export a given justification for implementation in jPipe runner.
+ */
+public class JpipeRunnerExporter {
+}

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeRunnerExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeRunnerExporter.java
@@ -38,7 +38,7 @@ public class JpipeRunnerExporter extends ModelVisitor<StringBuilder> {
 
     @Override
     public void visit(Unit u) {
-        throw new RuntimeException("Cannot export to graphviz an entire compilation unit!");
+        throw new RuntimeException("Cannot export an entire compilation unit!");
     }
 
     @Override

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeRunnerExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JpipeRunnerExporter.java
@@ -1,7 +1,78 @@
 package ca.mcscert.jpipe.visitors.exporters;
 
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.Justification;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
+import ca.mcscert.jpipe.model.elements.JustificationModel;
+import ca.mcscert.jpipe.model.elements.Pattern;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
+import ca.mcscert.jpipe.visitors.ModelVisitor;
+
 /**
  * Export a given justification for implementation in jPipe runner.
  */
-public class JpipeRunnerExporter {
+@SuppressWarnings({ "checkstyle:LeftCurly", "checkstyle:RightCurly",
+                    "checkstyle:EmptyLineSeparator" })
+public class JpipeRunnerExporter extends ModelVisitor<StringBuilder> {
+
+    public JpipeRunnerExporter() { super(new StringBuilder()); }
+
+    @Override public void visit(Conclusion c) { toMethodDeclaration(c); }
+    @Override public void visit(Evidence e)   { toMethodDeclaration(e); }
+    @Override public void visit(Strategy s)   { toMethodDeclaration(s); }
+    @Override public void visit(SubConclusion sc) { /* do nothing */}
+
+    @Override
+    public void visit(AbstractSupport as) {
+        throw new RuntimeException("Cannot export an abstract support to jpipe runner!");
+    }
+
+    @Override
+    public void visit(Pattern p) {
+        throw new RuntimeException("Cannot export a pattern to jpipe runner!");
+    }
+
+    @Override
+    public void visit(Unit u) {
+        throw new RuntimeException("Cannot export to graphviz an entire compilation unit!");
+    }
+
+    @Override
+    public void visit(Justification j) {
+        toFileHeader(j);
+        for (JustificationElement e : j.contents()) {
+            e.accept(this);
+        }
+    }
+
+
+    private String toSnakeCase(String s) {
+        return s.toLowerCase().replace(" ", "_");
+    }
+
+    private void toMethodDeclaration(JustificationElement e) {
+        // header
+        this.accumulator.append("## ")
+                .append(e.getClass().getSimpleName())
+                .append(" ").append(e.getIdentifier()).append(System.lineSeparator());
+        // method signature:
+        this.accumulator.append("def ")
+                .append(toSnakeCase(e.getLabel())).append("() -> bool:")
+                .append(System.lineSeparator());
+        // scaffolding body
+        this.accumulator.append("    ").append("return True")
+                .append(System.lineSeparator()).append(System.lineSeparator());
+    }
+
+    private void toFileHeader(JustificationModel m) {
+        this.accumulator.append("######").append(System.lineSeparator())
+                .append("## ").append(m.getClass().getSimpleName())
+                .append(" ").append(m.getName()).append(System.lineSeparator())
+                .append("######").append(System.lineSeparator()).append(System.lineSeparator());
+    }
+
 }

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JsonExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JsonExporter.java
@@ -1,10 +1,72 @@
 package ca.mcscert.jpipe.visitors.exporters;
 
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.Justification;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
+import ca.mcscert.jpipe.model.elements.JustificationModel;
+import ca.mcscert.jpipe.model.elements.Pattern;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
+import ca.mcscert.jpipe.visitors.ModelVisitor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 /**
  * Export a given justification using a JSON common format.
  */
-public class JsonExporter {
+@SuppressWarnings({ "checkstyle:LeftCurly", "checkstyle:RightCurly",
+                    "checkstyle:EmptyLineSeparator" })
+public class JsonExporter extends ModelVisitor<JSONObject> {
 
+    /**
+     * Initialize the JSON object that will contain the result of the visit.
+     */
+    public JsonExporter() {
+        super(new JSONObject());
+        this.accumulator.put("elements", new JSONArray());
+        this.accumulator.put("relations", new JSONArray());
+    }
 
+    @Override public void visit(Conclusion c)       { processElement("conclusion", c);        }
+    @Override public void visit(Evidence e)         { processElement("evidence", e);          }
+    @Override public void visit(Strategy s)         { processElement("strategy", s);          }
+    @Override public void visit(SubConclusion sc)   { processElement("sub-conclusion", sc);   }
+    @Override public void visit(AbstractSupport as) { processElement("abstract-support", as); }
+    @Override public void visit(Justification j)    { processModel("justification", j);       }
+    @Override public void visit(Pattern p)          { processModel("pattern", p);             }
+
+    @Override
+    public void visit(Unit u) {
+        throw new RuntimeException("Cannot export an entire compilation unit!");
+    }
+
+    private void processElement(String type, JustificationElement e) {
+        JSONArray elements = (JSONArray) this.accumulator.get("elements");
+        JSONObject obj = new JSONObject();
+        elements.put(obj.put("type", type).put("id", e.getIdentifier()).put("label", e.getLabel()));
+    }
+
+    private void processModel(String type, JustificationModel m) {
+        this.accumulator.put("name", m.getName());
+        this.accumulator.put("type", type);
+        for (JustificationElement je : m.contents()) {  // Exporting elements
+            je.accept(this);
+        }
+        for (JustificationElement je : m.contents()) { // Exporting structure
+            for (JustificationElement supporter : je.getSupports()) {
+                processRelation(supporter, je);
+            }
+        }
+    }
+
+    private void processRelation(JustificationElement supporter, JustificationElement element) {
+        JSONArray relations = (JSONArray) this.accumulator.get("relations");
+        JSONObject obj = new JSONObject();
+        relations.put(obj.put("source", supporter.getIdentifier())
+                         .put("target", element.getIdentifier()));
+    }
 
 }

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JsonExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JsonExporter.java
@@ -4,4 +4,7 @@ package ca.mcscert.jpipe.visitors.exporters;
  * Export a given justification using a JSON common format.
  */
 public class JsonExporter {
+
+
+
 }

--- a/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JsonExporter.java
+++ b/compiler/src/main/java/ca/mcscert/jpipe/visitors/exporters/JsonExporter.java
@@ -1,0 +1,7 @@
+package ca.mcscert.jpipe.visitors.exporters;
+
+/**
+ * Export a given justification using a JSON common format.
+ */
+public class JsonExporter {
+}


### PR DESCRIPTION
Now, nodes in the exported SVGs are identified (as in "id") with "justification:element" references.