### PR TITLE
Refactor element structure and creation commands for efficiency

### DIFF
--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/AbstractElementCreationCommand.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/AbstractElementCreationCommand.java
@@ -1,0 +1,55 @@
+package ca.mcscert.jpipe.commands.creation;
+
+import ca.mcscert.jpipe.commands.RegularCommand;
+import ca.mcscert.jpipe.model.SourceLocation;
+
+/**
+ * Abstract base for all element-creation commands. Holds the four fields shared
+ * by every creation command ({@code container}, {@code identifier},
+ * {@code label}, {@code location}) and provides their accessor implementations,
+ * eliminating the structural duplication across the five concrete commands.
+ *
+ * <p>
+ * This class is a package-private implementation detail. The sealed contract is
+ * declared on {@link ElementCreationCommand}; this class is its sole direct
+ * implementor, with the five concrete commands as its permitted subclasses.
+ */
+abstract sealed class AbstractElementCreationCommand extends RegularCommand
+		implements
+			ElementCreationCommand
+		permits CreateConclusion, CreateStrategy, CreateEvidence,
+		CreateSubConclusion, CreateAbstractSupport {
+
+	protected final String container;
+	protected final String identifier;
+	protected final String label;
+	protected final SourceLocation location;
+
+	protected AbstractElementCreationCommand(String container,
+			String identifier, String label, SourceLocation location) {
+		this.container = container;
+		this.identifier = identifier;
+		this.label = label;
+		this.location = location;
+	}
+
+	@Override
+	public String container() {
+		return container;
+	}
+
+	@Override
+	public String identifier() {
+		return identifier;
+	}
+
+	@Override
+	public String label() {
+		return label;
+	}
+
+	@Override
+	public SourceLocation location() {
+		return location;
+	}
+}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateAbstractSupport.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateAbstractSupport.java
@@ -1,19 +1,13 @@
 package ca.mcscert.jpipe.commands.creation;
 
-import ca.mcscert.jpipe.commands.RegularCommand;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.AbstractSupport;
 
 /** Creates an {@link AbstractSupport} inside a template. */
-public final class CreateAbstractSupport extends RegularCommand
-		implements
-			ElementCreationCommand {
-
-	private final String container;
-	private final String identifier;
-	private final String label;
-	private final SourceLocation location;
+public final class CreateAbstractSupport
+		extends
+			AbstractElementCreationCommand {
 
 	public CreateAbstractSupport(String container, String identifier,
 			String label) {
@@ -22,26 +16,7 @@ public final class CreateAbstractSupport extends RegularCommand
 
 	public CreateAbstractSupport(String container, String identifier,
 			String label, SourceLocation location) {
-		this.container = container;
-		this.identifier = identifier;
-		this.label = label;
-		this.location = location;
-	}
-
-	public String container() {
-		return container;
-	}
-
-	public String identifier() {
-		return identifier;
-	}
-
-	public String label() {
-		return label;
-	}
-
-	public SourceLocation location() {
-		return location;
+		super(container, identifier, label, location);
 	}
 
 	@Override

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateConclusion.java
@@ -1,19 +1,11 @@
 package ca.mcscert.jpipe.commands.creation;
 
-import ca.mcscert.jpipe.commands.RegularCommand;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.Conclusion;
 
 /** Creates a {@link Conclusion} inside a justification or template. */
-public final class CreateConclusion extends RegularCommand
-		implements
-			ElementCreationCommand {
-
-	private final String container;
-	private final String identifier;
-	private final String label;
-	private final SourceLocation location;
+public final class CreateConclusion extends AbstractElementCreationCommand {
 
 	public CreateConclusion(String container, String identifier, String label) {
 		this(container, identifier, label, SourceLocation.UNKNOWN);
@@ -21,26 +13,7 @@ public final class CreateConclusion extends RegularCommand
 
 	public CreateConclusion(String container, String identifier, String label,
 			SourceLocation location) {
-		this.container = container;
-		this.identifier = identifier;
-		this.label = label;
-		this.location = location;
-	}
-
-	public String container() {
-		return container;
-	}
-
-	public String identifier() {
-		return identifier;
-	}
-
-	public String label() {
-		return label;
-	}
-
-	public SourceLocation location() {
-		return location;
+		super(container, identifier, label, location);
 	}
 
 	@Override

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateEvidence.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateEvidence.java
@@ -1,19 +1,11 @@
 package ca.mcscert.jpipe.commands.creation;
 
-import ca.mcscert.jpipe.commands.RegularCommand;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.Evidence;
 
 /** Creates an {@link Evidence} inside a justification. */
-public final class CreateEvidence extends RegularCommand
-		implements
-			ElementCreationCommand {
-
-	private final String container;
-	private final String identifier;
-	private final String label;
-	private final SourceLocation location;
+public final class CreateEvidence extends AbstractElementCreationCommand {
 
 	public CreateEvidence(String container, String identifier, String label) {
 		this(container, identifier, label, SourceLocation.UNKNOWN);
@@ -21,26 +13,7 @@ public final class CreateEvidence extends RegularCommand
 
 	public CreateEvidence(String container, String identifier, String label,
 			SourceLocation location) {
-		this.container = container;
-		this.identifier = identifier;
-		this.label = label;
-		this.location = location;
-	}
-
-	public String container() {
-		return container;
-	}
-
-	public String identifier() {
-		return identifier;
-	}
-
-	public String label() {
-		return label;
-	}
-
-	public SourceLocation location() {
-		return location;
+		super(container, identifier, label, location);
 	}
 
 	@Override

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateStrategy.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateStrategy.java
@@ -1,19 +1,11 @@
 package ca.mcscert.jpipe.commands.creation;
 
-import ca.mcscert.jpipe.commands.RegularCommand;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.Strategy;
 
 /** Creates a {@link Strategy} inside a justification. */
-public final class CreateStrategy extends RegularCommand
-		implements
-			ElementCreationCommand {
-
-	private final String container;
-	private final String identifier;
-	private final String label;
-	private final SourceLocation location;
+public final class CreateStrategy extends AbstractElementCreationCommand {
 
 	public CreateStrategy(String container, String identifier, String label) {
 		this(container, identifier, label, SourceLocation.UNKNOWN);
@@ -21,26 +13,7 @@ public final class CreateStrategy extends RegularCommand
 
 	public CreateStrategy(String container, String identifier, String label,
 			SourceLocation location) {
-		this.container = container;
-		this.identifier = identifier;
-		this.label = label;
-		this.location = location;
-	}
-
-	public String container() {
-		return container;
-	}
-
-	public String identifier() {
-		return identifier;
-	}
-
-	public String label() {
-		return label;
-	}
-
-	public SourceLocation location() {
-		return location;
+		super(container, identifier, label, location);
 	}
 
 	@Override

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateSubConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateSubConclusion.java
@@ -1,19 +1,11 @@
 package ca.mcscert.jpipe.commands.creation;
 
-import ca.mcscert.jpipe.commands.RegularCommand;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
 
 /** Creates a {@link SubConclusion} inside a justification. */
-public final class CreateSubConclusion extends RegularCommand
-		implements
-			ElementCreationCommand {
-
-	private final String container;
-	private final String identifier;
-	private final String label;
-	private final SourceLocation location;
+public final class CreateSubConclusion extends AbstractElementCreationCommand {
 
 	public CreateSubConclusion(String container, String identifier,
 			String label) {
@@ -22,26 +14,7 @@ public final class CreateSubConclusion extends RegularCommand
 
 	public CreateSubConclusion(String container, String identifier,
 			String label, SourceLocation location) {
-		this.container = container;
-		this.identifier = identifier;
-		this.label = label;
-		this.location = location;
-	}
-
-	public String container() {
-		return container;
-	}
-
-	public String identifier() {
-		return identifier;
-	}
-
-	public String label() {
-		return label;
-	}
-
-	public SourceLocation location() {
-		return location;
+		super(container, identifier, label, location);
 	}
 
 	@Override

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/ElementCreationCommand.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/ElementCreationCommand.java
@@ -21,8 +21,7 @@ import ca.mcscert.jpipe.model.elements.ElementView;
  * in live model objects.
  */
 public sealed interface ElementCreationCommand extends Command, ElementView
-		permits CreateConclusion, CreateStrategy, CreateEvidence,
-		CreateSubConclusion, CreateAbstractSupport {
+		permits AbstractElementCreationCommand {
 
 	/** Name of the model this command adds an element to. */
 	String container();

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/AbstractSupportedElement.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/AbstractSupportedElement.java
@@ -1,0 +1,53 @@
+package ca.mcscert.jpipe.model.elements;
+
+import java.util.Optional;
+
+/**
+ * Package-private abstract base for {@link Conclusion} and
+ * {@link SubConclusion}. Holds the shared {@code id}, {@code label}, and
+ * {@code supporter} state and provides the common method implementations,
+ * eliminating the structural duplication between the two classes.
+ *
+ * <p>
+ * This class is an implementation detail — it is not part of any sealed
+ * interface hierarchy and carries no domain semantics of its own. The sealed
+ * contracts ({@link CommonElement}, {@link StrategyBacked}) are declared
+ * directly on the concrete subclasses.
+ */
+abstract class AbstractSupportedElement {
+
+	private final String id;
+	private final String label;
+	private Strategy supporter;
+
+	protected AbstractSupportedElement(String id, String label) {
+		this.id = id;
+		this.label = label;
+	}
+
+	public String id() {
+		return id;
+	}
+
+	public String label() {
+		return label;
+	}
+
+	public void addSupport(Strategy supporter) {
+		if (this.supporter != null) {
+			throw new IllegalStateException(getClass().getSimpleName()
+					+ " already has a supporting strategy");
+		}
+		this.supporter = supporter;
+	}
+
+	public Optional<Strategy> getSupport() {
+		return Optional.ofNullable(supporter);
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "{id='" + id + "', label='" + label
+				+ "'}";
+	}
+}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Conclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Conclusion.java
@@ -1,43 +1,12 @@
 package ca.mcscert.jpipe.model.elements;
 
-import java.util.Optional;
-
 /** The top-level conclusion that a justification aims to establish. */
-public final class Conclusion implements CommonElement {
-
-	private final String id;
-	private final String label;
-	private Strategy supporter;
+public final class Conclusion extends AbstractSupportedElement
+		implements
+			CommonElement,
+			StrategyBacked {
 
 	public Conclusion(String id, String label) {
-		this.id = id;
-		this.label = label;
-	}
-
-	@Override
-	public String id() {
-		return id;
-	}
-
-	@Override
-	public String label() {
-		return label;
-	}
-
-	public void addSupport(Strategy supporter) {
-		if (this.supporter != null) {
-			throw new IllegalStateException(
-					"Conclusion already has a supporting strategy");
-		}
-		this.supporter = supporter;
-	}
-
-	public Optional<Strategy> getSupport() {
-		return Optional.ofNullable(supporter);
-	}
-
-	@Override
-	public String toString() {
-		return "Conclusion{id='" + id + "', label='" + label + "'}";
+		super(id, label);
 	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/StrategyBacked.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/StrategyBacked.java
@@ -1,0 +1,28 @@
+package ca.mcscert.jpipe.model.elements;
+
+import java.util.Optional;
+
+/**
+ * Sealed interface for elements that receive support from exactly one
+ * {@link Strategy}. The symmetric counterpart to {@link SupportLeaf}: where
+ * {@code SupportLeaf} marks elements that <em>provide</em> support, this
+ * interface marks elements that <em>receive</em> it.
+ *
+ * <p>
+ * Only {@link Conclusion} and {@link SubConclusion} may implement this
+ * interface. Note that {@link SubConclusion} implements both — it is a
+ * {@code SupportLeaf} (it can support a strategy chain) and a
+ * {@code StrategyBacked} (it is itself supported by a strategy).
+ */
+public sealed interface StrategyBacked permits Conclusion, SubConclusion {
+
+	/**
+	 * Registers {@code supporter} as the single strategy backing this element.
+	 */
+	void addSupport(Strategy supporter);
+
+	/**
+	 * Returns the strategy backing this element, if one has been registered.
+	 */
+	Optional<Strategy> getSupport();
+}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/SubConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/SubConclusion.java
@@ -1,43 +1,13 @@
 package ca.mcscert.jpipe.model.elements;
 
-import java.util.Optional;
-
 /** An intermediate conclusion within a justification. */
-public final class SubConclusion implements CommonElement, SupportLeaf {
-
-	private final String id;
-	private final String label;
-	private Strategy supporter;
+public final class SubConclusion extends AbstractSupportedElement
+		implements
+			CommonElement,
+			StrategyBacked,
+			SupportLeaf {
 
 	public SubConclusion(String id, String label) {
-		this.id = id;
-		this.label = label;
-	}
-
-	@Override
-	public String id() {
-		return id;
-	}
-
-	@Override
-	public String label() {
-		return label;
-	}
-
-	public void addSupport(Strategy supporter) {
-		if (this.supporter != null) {
-			throw new IllegalStateException(
-					"SubConclusion already has a supporting strategy");
-		}
-		this.supporter = supporter;
-	}
-
-	public Optional<Strategy> getSupport() {
-		return Optional.ofNullable(supporter);
-	}
-
-	@Override
-	public String toString() {
-		return "SubConclusion{id='" + id + "', label='" + label + "'}";
+		super(id, label);
 	}
 }

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/creation/CreationCommandsTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/creation/CreationCommandsTest.java
@@ -38,6 +38,27 @@ class CreationCommandsTest {
 	}
 
 	// -------------------------------------------------------------------------
+	// ElementCreationCommand shared accessor contract
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class ElementCreationCommandContractTest {
+		private final SourceLocation loc = new SourceLocation(1, 0);
+		private final ElementCreationCommand cmd = new CreateConclusion(
+				"myContainer", "myId", "myLabel", loc);
+
+		@Test
+		void accessorsReturnConstructorArguments() {
+			assertThat(cmd)
+					.extracting(ElementCreationCommand::container,
+							ElementCreationCommand::identifier,
+							ElementCreationCommand::label,
+							ElementCreationCommand::location)
+					.containsExactly("myContainer", "myId", "myLabel", loc);
+		}
+	}
+
+	// -------------------------------------------------------------------------
 	// Unit-level creation commands
 	// -------------------------------------------------------------------------
 

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/elements/JustificationElementTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/elements/JustificationElementTest.java
@@ -1,6 +1,7 @@
 package ca.mcscert.jpipe.model.elements;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ca.mcscert.jpipe.visitor.JustificationVisitor;
 import ca.mcscert.jpipe.model.Justification;
@@ -71,6 +72,27 @@ class JustificationElementTest {
 		void acceptDispatchesToVisitor() {
 			assertThat(conclusion.accept(visitor)).isEqualTo(Conclusion.class);
 		}
+		@Test
+		void addSupportRegistersStrategy() {
+			Conclusion c = new Conclusion("c1", "conclusion");
+			Strategy s = new Strategy("s1", "strategy");
+			c.addSupport(s);
+			assertThat(c.getSupport()).isPresent().contains(s);
+		}
+		@Test
+		void addSupportThrowsWhenAlreadySet() {
+			Conclusion c = new Conclusion("c1", "conclusion");
+			Strategy s = new Strategy("s1", "strategy");
+			c.addSupport(s);
+			assertThatThrownBy(() -> c.addSupport(s))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Conclusion");
+		}
+		@Test
+		void toStringContainsIdAndLabel() {
+			assertThat(conclusion)
+					.hasToString("Conclusion{id='c1', label='my conclusion'}");
+		}
 	}
 
 	@Nested
@@ -90,6 +112,27 @@ class JustificationElementTest {
 		void acceptDispatchesToVisitor() {
 			assertThat(subConclusion.accept(visitor))
 					.isEqualTo(SubConclusion.class);
+		}
+		@Test
+		void addSupportRegistersStrategy() {
+			SubConclusion sc = new SubConclusion("sc1", "sub-conclusion");
+			Strategy s = new Strategy("s1", "strategy");
+			sc.addSupport(s);
+			assertThat(sc.getSupport()).isPresent().contains(s);
+		}
+		@Test
+		void addSupportThrowsWhenAlreadySet() {
+			SubConclusion sc = new SubConclusion("sc1", "sub-conclusion");
+			Strategy s = new Strategy("s1", "strategy");
+			sc.addSupport(s);
+			assertThatThrownBy(() -> sc.addSupport(s))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("SubConclusion");
+		}
+		@Test
+		void toStringContainsIdAndLabel() {
+			assertThat(subConclusion).hasToString(
+					"SubConclusion{id='sc1', label='my sub-conclusion'}");
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,10 @@
         <checkstyle.version>13.3.0</checkstyle.version>
         <jacoco-plugin.version>0.8.14</jacoco-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-        <sonar-plugin.version>5.0.0.4389</sonar-plugin.version>
+        <sonar-plugin.version>5.6.0.6792</sonar-plugin.version>
 
         <!-- SonarCloud -->
+        <sonar.projectKey>jpipe-mcscert_jpipe-compiler</sonar.projectKey>
         <sonar.organization>jpipe-mcscert</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
@@ -269,6 +270,12 @@
                             <phase>verify</phase>
                         </execution>
                     </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>${sonar-plugin.version}</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,10 @@
 
         <plugins>
             <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
This pull request refactors the element creation commands and related model classes to reduce code duplication and improve maintainability. It introduces new abstract base classes for common logic and updates the implementation hierarchy for element creation commands. Additionally, it updates the Maven configuration for SonarCloud integration.

### Refactoring of element creation commands

* Introduced `AbstractElementCreationCommand` as a package-private abstract base class for all element creation commands, consolidating shared fields and accessor methods. All concrete creation commands (`CreateConclusion`, `CreateStrategy`, `CreateEvidence`, `CreateSubConclusion`, `CreateAbstractSupport`) now extend this class instead of duplicating these members. (`jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/AbstractElementCreationCommand.java` [[1]](diffhunk://#diff-4472cd517f8c2a02afb91b114ec24c098d4b0bd516a2171fcb9083ad593e1e0eR1-R55) and updates in respective command files [[2]](diffhunk://#diff-fa98c7ac744f4b0acf0239c8205afd96c93ed75bbc4c191b24df5db9a41e0f8dL3-R16) [[3]](diffhunk://#diff-83168e60d68a641e9a2cc6d38975d656c63ec9b15b835b1b58ac32324f775a70L3-R16) [[4]](diffhunk://#diff-fca96ddde1256e0317ad2c2f7c2bc869d130c7fd9e9b81a1e44c5efc560ec030L3-R16) [[5]](diffhunk://#diff-82fc7e64e6445debf15f17a45958cc874a9caa9703c368e632cbe025c76c6a1bL3-R8) [[6]](diffhunk://#diff-5d2b516ecb3c8bc20b5144bc5a35e9fe25645e92a9acce2c0dfb67369ff35570L3-R10)
* Updated the `ElementCreationCommand` sealed interface to permit only the new abstract base class, rather than each concrete class. (`jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/ElementCreationCommand.java` [jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/ElementCreationCommand.javaL24-R24](diffhunk://#diff-2a1f5fdb43ae95dec8ef8987638564a82993d971b340f035a2382319a82e9879L24-R24))

### Refactoring of model elements

* Added `AbstractSupportedElement` as a package-private abstract base class for `Conclusion` and `SubConclusion`, consolidating shared state and methods related to support from `Strategy`. (`jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/AbstractSupportedElement.java` [jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/AbstractSupportedElement.javaR1-R53](diffhunk://#diff-cb738c1566decbc9a856b46bad79b0abb21961c9dee2e41812d24c4b814a89a0R1-R53))
* Introduced the sealed interface `StrategyBacked` to mark elements that receive support from a single `Strategy`, implemented by both `Conclusion` and `SubConclusion`. (`jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/StrategyBacked.java` [jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/StrategyBacked.javaR1-R28](diffhunk://#diff-a90d825806d32b1483b51f81f5b2d47b1efcc2d7b74946dcd6a916c6428684aeR1-R28))
* Refactored `Conclusion` and `SubConclusion` to extend `AbstractSupportedElement` and implement `StrategyBacked`, removing duplicated code. (`jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Conclusion.java` [[1]](diffhunk://#diff-ea7d5616d531543fbb4d4299b0bad351b6bc008b1a97d7fe017bc56576f7f67cL3-R10) `jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/SubConclusion.java` [[2]](diffhunk://#diff-fc9ed0858983cf66c4957a9e45787e928d700b2f119918087ac36c70d4bc0f3aL3-R11)

### Build and configuration updates

* Upgraded the SonarCloud Maven plugin version and added explicit configuration for SonarCloud project key and plugin in the Maven `pom.xml`. (`pom.xml` [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L95-R98) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R275-R280)…ation commands

* Introduces StrategyBacked sealed interface as the missing domain concept for elements that receive support from exactly one Strategy (symmetric counterpart to SupportLeaf). Backs it with a package-private AbstractSupportedElement base class, reducing Conclusion and SubConclusion to their essential declarations.

* Introduces AbstractElementCreationCommand as the sole implementor of the ElementCreationCommand sealed interface, holding the four shared fields and accessors that were duplicated across all five Create* commands.

* Also pins sonar-maven-plugin version in pluginManagement and adds org.sonarsource.scanner.maven to plugin groups so that mvn sonar:sonar resolves the correct plugin without requiring the fully-qualified artifact id.