### PR TITLE
Align download-artifact versions and update main branch reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     name: Publish unstable release
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: write
 
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download fat JAR artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: jpipe-cli-${{ github.sha }}
           path: dist
@@ -80,6 +80,6 @@ jobs:
 
           gh release create unstable jpipe-cli.jar \
             --title "Unstable build ($(date -u '+%Y-%m-%d %H:%M UTC'))" \
-            --notes $'This pre-release is rebuilt on every push to `master`.\n\nIt tracks the latest code and is **not intended for production use**.' \
+            --notes $'This pre-release is rebuilt on every push to `main`.\n\nIt tracks the latest code and is **not intended for production use**.' \
             --prerelease \
             --target "$GITHUB_SHA"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and publishing unstable releases. The main changes are to align the workflow with the `main` branch and update the action versions for better reliability.

Workflow updates:

* Changed the branch condition in `.github/workflows/build.yml` so that unstable releases are published on pushes to the `main` branch instead of `master`.
* Updated the release notes to reference pushes to `main` rather than `master`.

Dependency updates:

* Upgraded the `actions/download-artifact` action from version 4 to version 7 for downloading build artifacts.- download-artifact@v4 is incompatible with upload-artifact@v7; bump download to @v7 so both jobs use the same artifact backend
- unstable release job was gated on refs/heads/master — branch is main
- update release notes to reference main instead of master