### PR TITLE
Use Maven version for artifact name in CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.mvn_version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v6
@@ -28,6 +30,10 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Extract Maven version
+        id: mvn_version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+
       - name: Build and test
         run: mvn -B package
 
@@ -42,7 +48,7 @@ jobs:
       - name: Upload fat JAR artifact
         uses: actions/upload-artifact@v7
         with:
-          name: jpipe-cli-${{ github.sha }}
+          name: jpipe-cli-${{ steps.mvn_version.outputs.version }}
           path: ${{ steps.locate.outputs.path }}
           archive: false
           if-no-files-found: error
@@ -62,7 +68,7 @@ jobs:
       - name: Download fat JAR artifact
         uses: actions/download-artifact@v7
         with:
-          name: jpipe-cli-${{ github.sha }}
+          name: jpipe-cli-${{ needs.build.outputs.version }}
           path: dist
 
       - name: Publish unstable release


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/build.yml` to improve artifact naming and version tracking by extracting the Maven project version and using it consistently throughout the workflow. The main changes are grouped below:

**Artifact Versioning Improvements:**

* Added a step to extract the Maven project version and expose it as a workflow output, making the version available for downstream jobs and steps. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R33-R36) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R14-R15)
* Updated the artifact upload step to use the Maven project version in the artifact name instead of the Git commit SHA, ensuring artifacts are easier to identify by their version.
* Updated the artifact download step in dependent jobs to use the Maven version output from the build job, ensuring consistency in artifact retrieval.Artifact name jpipe-cli-<sha> was fragile and opaque. Using the Maven project version (e.g. jpipe-cli-2.0.0-SNAPSHOT) makes the artifact name stable, predictable, and human-readable.

Expose the version as a build job output so the release job can reference it directly when downloading the artifact.