### PR TITLE
Refine CI artifact naming and upload behavior

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           name: jpipe-cli-${{ steps.mvn_version.outputs.version }}.jar
           path: ${{ steps.locate.outputs.path }}
+          archive: false
           if-no-files-found: error
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           name: jpipe-cli-${{ steps.mvn_version.outputs.version }}.jar
           path: ${{ steps.locate.outputs.path }}
-          archive: false
           if-no-files-found: error
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           name: jpipe-cli-${{ steps.mvn_version.outputs.version }}
           path: ${{ steps.locate.outputs.path }}
-          archive: false
           if-no-files-found: error
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,9 @@ jobs:
       - name: Upload fat JAR artifact
         uses: actions/upload-artifact@v7
         with:
-          name: jpipe-cli-${{ steps.mvn_version.outputs.version }}
+          name: jpipe-cli-${{ steps.mvn_version.outputs.version }}.jar
           path: ${{ steps.locate.outputs.path }}
+          archive: false
           if-no-files-found: error
 
 
@@ -69,7 +70,7 @@ jobs:
       - name: Download fat JAR artifact
         uses: actions/download-artifact@v7
         with:
-          name: jpipe-cli-${{ needs.build.outputs.version }}
+          name: jpipe-cli-${{ needs.build.outputs.version }}.jar
           path: dist
 
       - name: Publish unstable release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Extract Maven version
         id: mvn_version
-        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION="$(mvn -B help:evaluate -Dexpression=project.version -q -DforceStdout | head -n 1 | tr -d '\r' | tr ':/' '-')"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build and test
         run: mvn -B package


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve the handling and naming of the Maven build artifact. The main changes ensure that the extracted Maven version is sanitized and that the uploaded and downloaded artifact consistently uses the `.jar` extension.

**Workflow improvements:**

* Improved Maven version extraction to sanitize the output by removing problematic characters and ensuring only the version string is used. (`.github/workflows/build.yml`)

**Artifact naming consistency:**

* Updated the artifact upload step to include the `.jar` extension in the artifact name, ensuring clarity and consistency. (`.github/workflows/build.yml`)
* Updated the artifact download step to match the new artifact name with the `.jar` extension. (`.github/workflows/build.yml`)