### PR TITLE
Add support for release candidate tags in CI pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,9 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           POM_VER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/-SNAPSHOT//')
-          if [ "$VERSION" != "$POM_VER" ]; then
-            echo "ERROR: tag v$VERSION does not match pom.xml version (expected $POM_VER)"
+          TAG_BASE="${VERSION%%-*}"
+          if [ "$TAG_BASE" != "$POM_VER" ]; then
+            echo "ERROR: tag v$VERSION (base: $TAG_BASE) does not match pom.xml version (expected $POM_VER)"
             exit 1
           fi
 
@@ -87,9 +88,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          PRERELEASE_FLAG=""
+          [[ "$VERSION" == *-* ]] && PRERELEASE_FLAG="--prerelease"
           gh release create "v$VERSION" \
             --title "jPipe v$VERSION" \
             --generate-notes \
+            $PRERELEASE_FLAG \
             "${{ steps.tarball.outputs.path }}" \
             "${{ steps.locate.outputs.path }}"
 
@@ -97,6 +101,7 @@ jobs:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
     needs: build-and-release
+    if: ${{ !contains(needs.build-and-release.outputs.version, '-') }}
 
     steps:
       - name: Checkout Homebrew tap
@@ -129,6 +134,7 @@ jobs:
     name: Publish to Ubuntu PPA (${{ matrix.distro }})
     runs-on: ubuntu-latest
     needs: build-and-release
+    if: ${{ !contains(needs.build-and-release.outputs.version, '-') }}
     strategy:
       matrix:
         distro: [focal, jammy, noble, questing]


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yml` to improve version handling and automate pre-release detection. The changes ensure that pre-releases (versions with a hyphen, like `1.0.0-beta`) are handled correctly, and downstream jobs (such as updating Homebrew or publishing to Ubuntu PPA) only run for stable releases.

**Release process improvements:**

* The tag version check now compares only the base version (before any hyphen) to the `pom.xml` version, allowing pre-release tags without causing errors.
* The GitHub release step now automatically sets the `--prerelease` flag if the version contains a hyphen, ensuring pre-releases are correctly marked.

**Conditional job execution:**

* The `update-homebrew` and `publish-to-ppa` jobs now only run for stable releases (versions without a hyphen), preventing pre-releases from being published to Homebrew or Ubuntu PPA. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R91-R104) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R137)- POM validation now compares the tag's base version (stripping any pre-release suffix) against the stripped pom.xml version, so v2.0.0-rc1 is valid when pom.xml contains 2.0.0-SNAPSHOT
- GitHub Release is marked --prerelease when the version contains a hyphen (rc, alpha, beta, etc.)
- Homebrew and PPA jobs are skipped for pre-release versions; they only run for stable releases (no hyphen in version)