### PR TITLE
Enhance unit test coverage and refine operator error handling

### DIFF
--- a/examples/invalid/016_unknown_hook_element.jd
+++ b/examples/invalid/016_unknown_hook_element.jd
@@ -1,0 +1,19 @@
+justification base {
+    conclusion c is "A conclusion"
+    strategy   s is "A strategy"
+    evidence   e is "An evidence"
+    s supports c
+    e supports s
+}
+
+justification refinement {
+    conclusion c is "elaborated"
+    strategy   s is "A strategy"
+    evidence   e is "An evidence"
+    s supports c
+    e supports s
+}
+
+justification bad is refine(base, refinement) {
+    hook: "nonexistent"
+}

--- a/jpipe-compiler/src/test/resources/features/operators.feature
+++ b/jpipe-compiler/src/test/resources/features/operators.feature
@@ -110,3 +110,9 @@ Feature: Composition operators
     When I compile it into a unit
     Then the compilation has validation errors
     And a validation error is reported for rule "execution-error"
+
+  Scenario: unknown hook element reports an execution error
+    Given the source file "invalid/016_unknown_hook_element.jd"
+    When I compile it into a unit
+    Then the compilation has validation errors
+    And a validation error is reported for rule "execution-error"

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/OverrideAbstractSupportTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/OverrideAbstractSupportTest.java
@@ -1,0 +1,144 @@
+package ca.mcscert.jpipe.commands.linking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.mcscert.jpipe.commands.ExecutionEngine;
+import ca.mcscert.jpipe.commands.creation.CreateAbstractSupport;
+import ca.mcscert.jpipe.commands.creation.CreateConclusion;
+import ca.mcscert.jpipe.commands.creation.CreateJustification;
+import ca.mcscert.jpipe.commands.creation.CreateStrategy;
+import ca.mcscert.jpipe.commands.creation.CreateTemplate;
+import ca.mcscert.jpipe.model.Justification;
+import ca.mcscert.jpipe.model.SourceLocation;
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OverrideAbstractSupportTest {
+
+	private ExecutionEngine engine;
+
+	@BeforeEach
+	void setUp() {
+		engine = new ExecutionEngine();
+	}
+
+	/**
+	 * Builds a unit with template t (tc←ts←as) and justification j implements
+	 * t.
+	 */
+	private Unit unitWithAbstractSupport() {
+		return engine.spawn("src", List.of(new CreateTemplate("t"),
+				new CreateConclusion("t", "tc", "Template conclusion"),
+				new CreateStrategy("t", "ts", "Template strategy"),
+				new CreateAbstractSupport("t", "as", "Placeholder"),
+				new AddSupport("t", "ts", "as"),
+				new AddSupport("t", "tc", "ts"), new CreateJustification("j"),
+				new CreateConclusion("j", "c", "My conclusion"),
+				new ImplementsTemplate("j", "t")));
+	}
+
+	// ── accessors ────────────────────────────────────────────────────────────
+
+	@Nested
+	class Accessors {
+
+		@Test
+		void container() {
+			var cmd = new OverrideAbstractSupport("j", "t:as", "evidence",
+					"label");
+			assertThat(cmd.container()).isEqualTo("j");
+		}
+
+		@Test
+		void qualifiedId() {
+			var cmd = new OverrideAbstractSupport("j", "t:as", "evidence",
+					"label");
+			assertThat(cmd.qualifiedId()).isEqualTo("t:as");
+		}
+
+		@Test
+		void newType() {
+			var cmd = new OverrideAbstractSupport("j", "t:as", "evidence",
+					"label");
+			assertThat(cmd.newType()).isEqualTo("evidence");
+		}
+
+		@Test
+		void label() {
+			var cmd = new OverrideAbstractSupport("j", "t:as", "evidence",
+					"my label");
+			assertThat(cmd.label()).isEqualTo("my label");
+		}
+
+		@Test
+		void locationDefaultsToUnknown() {
+			var cmd = new OverrideAbstractSupport("j", "t:as", "evidence",
+					"label");
+			assertThat(cmd.location()).isEqualTo(SourceLocation.UNKNOWN);
+		}
+
+		@Test
+		void toStringContainsKeyFields() {
+			var cmd = new OverrideAbstractSupport("j", "t:as", "evidence",
+					"label");
+			assertThat(cmd)
+					.hasToString("override('j', 't:as', evidence, 'label')");
+		}
+	}
+
+	// ── condition ────────────────────────────────────────────────────────────
+
+	@Nested
+	class Condition {
+
+		@Test
+		void falseWhenModelAbsent() {
+			Unit unit = engine.spawn("src", List.of());
+			var cmd = new OverrideAbstractSupport("missing", "t:as", "evidence",
+					"label");
+			assertThat(cmd.condition().test(unit)).isFalse();
+		}
+
+		@Test
+		void falseWhenAbstractSupportNotYetPresent() {
+			Unit unit = engine.spawn("src",
+					List.of(new CreateJustification("j"),
+							new CreateConclusion("j", "c", "C")));
+			var cmd = new OverrideAbstractSupport("j", "t:as", "evidence",
+					"label");
+			assertThat(cmd.condition().test(unit)).isFalse();
+		}
+	}
+
+	// ── expand ───────────────────────────────────────────────────────────────
+
+	@Nested
+	class Expand {
+
+		@Test
+		void replacesAbstractSupportWithSubConclusion() {
+			Unit unit = unitWithAbstractSupport();
+			engine.enrich(unit, List.of(new OverrideAbstractSupport("j", "t:as",
+					"sub-conclusion", "Refined")));
+
+			Justification j = (Justification) unit.get("j");
+			assertThat(j.findById("t:as")).isPresent().get()
+					.isInstanceOf(SubConclusion.class);
+		}
+
+		@Test
+		void unknownTypeThrowsIllegalArgumentException() {
+			Unit unit = unitWithAbstractSupport();
+			var cmd = new OverrideAbstractSupport("j", "t:as", "strategy",
+					"label");
+			assertThatThrownBy(() -> cmd.expand(unit))
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining("strategy");
+		}
+	}
+}

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/NoOpJustificationVisitorTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/NoOpJustificationVisitorTest.java
@@ -1,0 +1,63 @@
+package ca.mcscert.jpipe.visitor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.mcscert.jpipe.model.Justification;
+import ca.mcscert.jpipe.model.Template;
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
+import org.junit.jupiter.api.Test;
+
+class NoOpJustificationVisitorTest {
+
+	private static final class ConcreteVisitor
+			extends
+				NoOpJustificationVisitor<String> {
+	}
+
+	private final ConcreteVisitor visitor = new ConcreteVisitor();
+
+	@Test
+	void visitUnitReturnsNull() {
+		assertThat(visitor.visit(new Unit("src"))).isNull();
+	}
+
+	@Test
+	void visitJustificationReturnsNull() {
+		assertThat(visitor.visit(new Justification("j"))).isNull();
+	}
+
+	@Test
+	void visitTemplateReturnsNull() {
+		assertThat(visitor.visit(new Template("t"))).isNull();
+	}
+
+	@Test
+	void visitConclusionReturnsNull() {
+		assertThat(visitor.visit(new Conclusion("c", "label"))).isNull();
+	}
+
+	@Test
+	void visitSubConclusionReturnsNull() {
+		assertThat(visitor.visit(new SubConclusion("sc", "label"))).isNull();
+	}
+
+	@Test
+	void visitStrategyReturnsNull() {
+		assertThat(visitor.visit(new Strategy("s", "label"))).isNull();
+	}
+
+	@Test
+	void visitEvidenceReturnsNull() {
+		assertThat(visitor.visit(new Evidence("e", "label"))).isNull();
+	}
+
+	@Test
+	void visitAbstractSupportReturnsNull() {
+		assertThat(visitor.visit(new AbstractSupport("as", "label"))).isNull();
+	}
+}

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/CompositionOperator.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/CompositionOperator.java
@@ -242,6 +242,28 @@ public abstract class CompositionOperator {
 			commands.addAll(merge.merge(resultName, group, aliases));
 		}
 
+		// Carry forward transitive aliases from source models.
+		// For each prior alias "sourceName/oldId → intermId" (recorded in a
+		// previous composition step), resolve "sourceName:intermId" through the
+		// current local registry to find the final id in this result, then
+		// register "sourceName:oldId → finalId" so callers can still reach
+		// the element under its pre-composition name.
+		for (JustificationModel<?> source : sources) {
+			String prefix = source.getName() + "/";
+			for (Map.Entry<String, String> entry : knownAliases.entrySet()) {
+				if (!entry.getKey().startsWith(prefix)) {
+					continue;
+				}
+				String oldId = entry.getKey().substring(prefix.length());
+				String qualOldId = qualId(source, oldId);
+				String qualIntermId = qualId(source, entry.getValue());
+				String finalId = aliases.resolve(qualIntermId);
+				if (!qualOldId.equals(finalId)) {
+					aliases.register(finalId, qualOldId);
+				}
+			}
+		}
+
 		// Persist aliases to Unit via RegisterAlias commands
 		aliases.aliases().forEach((oldId, newId) -> commands
 				.add(new RegisterAlias(resultName, oldId, newId)));

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/builtin/RefineOperator.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/builtin/RefineOperator.java
@@ -78,14 +78,17 @@ public final class RefineOperator extends CompositionOperator {
 		String hookElementId = arguments.get("hook");
 		// Resolve through the unit alias map: the element may have been renamed
 		// by a prior composition step (e.g. unification after assemble).
-		String resolvedHookId = knownAliases.getOrDefault(
+		String aliasedHookId = knownAliases.getOrDefault(
 				base.getName() + "/" + hookElementId, hookElementId);
-		if (base.findById(resolvedHookId).isEmpty()) {
-			throw new InvalidOperatorCallException(
-					"[execution-error] hook element '" + hookElementId
-							+ "' not found in base model '" + base.getName()
-							+ "'");
-		}
+		// Normalize to the actual stored id via findById (which has a suffix
+		// fallback). This ensures isHookPair's id comparison matches even when
+		// the hook is referenced by its plain short id (e.g. "s" -> "t:s").
+		String resolvedHookId = base.findById(aliasedHookId)
+				.map(JustificationElement::id)
+				.orElseThrow(() -> new InvalidOperatorCallException(
+						"[execution-error] hook element '" + hookElementId
+								+ "' not found in base model '" + base.getName()
+								+ "'"));
 
 		return (a, b) -> a instanceof SourcedElement sa
 				&& b instanceof SourcedElement sb

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/builtin/RefineOperator.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/builtin/RefineOperator.java
@@ -80,6 +80,12 @@ public final class RefineOperator extends CompositionOperator {
 		// by a prior composition step (e.g. unification after assemble).
 		String resolvedHookId = knownAliases.getOrDefault(
 				base.getName() + "/" + hookElementId, hookElementId);
+		if (base.findById(resolvedHookId).isEmpty()) {
+			throw new InvalidOperatorCallException(
+					"[execution-error] hook element '" + hookElementId
+							+ "' not found in base model '" + base.getName()
+							+ "'");
+		}
 
 		return (a, b) -> a instanceof SourcedElement sa
 				&& b instanceof SourcedElement sb

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/ApplyOperatorTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/ApplyOperatorTest.java
@@ -1,0 +1,207 @@
+package ca.mcscert.jpipe.operators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.mcscert.jpipe.commands.Command;
+import ca.mcscert.jpipe.commands.ExecutionEngine;
+import ca.mcscert.jpipe.commands.creation.CreateJustification;
+import ca.mcscert.jpipe.model.JustificationModel;
+import ca.mcscert.jpipe.model.SourceLocation;
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.operators.equivalences.SameLabel;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApplyOperatorTest {
+
+	// ── minimal concrete operator ────────────────────────────────────────────
+
+	private static final class NoOpOperator extends CompositionOperator {
+
+		private final ModelKind kind;
+
+		NoOpOperator(ModelKind kind) {
+			this.kind = kind;
+		}
+
+		@Override
+		protected EquivalenceRelation equivalenceRelation(
+				List<JustificationModel<?>> sources,
+				Map<String, String> arguments,
+				Map<String, String> knownAliases) {
+			return (a, b) -> false;
+		}
+
+		@Override
+		protected MergeFunction mergeFunction(
+				List<JustificationModel<?>> sources,
+				Map<String, String> arguments) {
+			return (r, g, a) -> List.of();
+		}
+
+		@Override
+		protected Command createResultModel(String name,
+				SourceLocation location, List<JustificationModel<?>> sources,
+				Map<String, String> arguments) {
+			return new CreateJustification(name);
+		}
+
+		@Override
+		public ModelKind resultKind(List<JustificationModel<?>> sources,
+				Map<String, String> args) {
+			return kind;
+		}
+	}
+
+	// ── setup ────────────────────────────────────────────────────────────────
+
+	private OperatorRegistry operators;
+	private UnificationEquivalenceRegistry unification;
+	private ExecutionEngine engine;
+
+	@BeforeEach
+	void setUp() {
+		operators = new OperatorRegistry();
+		operators.register("noop", new NoOpOperator(ModelKind.JUSTIFICATION));
+		operators.register("template-op", new NoOpOperator(ModelKind.TEMPLATE));
+		unification = new UnificationEquivalenceRegistry();
+		unification.register("sameLabel", new SameLabel());
+		engine = new ExecutionEngine();
+	}
+
+	private Unit unitWithModels(String... names) {
+		List<Command> cmds = new java.util.ArrayList<>();
+		for (String name : names) {
+			cmds.add(new CreateJustification(name));
+		}
+		return engine.spawn("src", cmds);
+	}
+
+	private ApplyOperator applyOperator(String resultName, String opName,
+			List<String> sources, Map<String, String> args,
+			ModelKind declared) {
+		OperatorCallConfig config = new OperatorCallConfig(resultName, opName,
+				sources, args, SourceLocation.UNKNOWN, declared);
+		return new ApplyOperator(config, operators, unification);
+	}
+
+	// ── accessors ────────────────────────────────────────────────────────────
+
+	@Nested
+	class Accessors {
+
+		@Test
+		void resultName() {
+			var op = applyOperator("out", "noop", List.of(), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThat(op.resultName()).isEqualTo("out");
+		}
+
+		@Test
+		void operatorName() {
+			var op = applyOperator("out", "noop", List.of(), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThat(op.operatorName()).isEqualTo("noop");
+		}
+
+		@Test
+		void sourceNames() {
+			var op = applyOperator("out", "noop", List.of("a", "b"), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThat(op.sourceNames()).containsExactly("a", "b");
+		}
+
+		@Test
+		void arguments() {
+			var op = applyOperator("out", "noop", List.of(),
+					Map.of("key", "val"), ModelKind.JUSTIFICATION);
+			assertThat(op.arguments()).containsEntry("key", "val");
+		}
+
+		@Test
+		void location() {
+			var op = applyOperator("out", "noop", List.of(), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThat(op.location()).isEqualTo(SourceLocation.UNKNOWN);
+		}
+
+		@Test
+		void toStringContainsResultNameOperatorNameAndSources() {
+			var op = applyOperator("out", "noop", List.of("a", "b"), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThat(op).hasToString("applyOperator('out', 'noop', [a, b]).");
+		}
+	}
+
+	// ── condition ────────────────────────────────────────────────────────────
+
+	@Nested
+	class Condition {
+
+		@Test
+		void trueWhenAllSourcesPresent() {
+			Unit unit = unitWithModels("a", "b");
+			var op = applyOperator("out", "noop", List.of("a", "b"), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThat(op.condition().test(unit)).isTrue();
+		}
+
+		@Test
+		void falseWhenSourceMissing() {
+			Unit unit = unitWithModels("a");
+			var op = applyOperator("out", "noop", List.of("a", "b"), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThat(op.condition().test(unit)).isFalse();
+		}
+
+		@Test
+		void trueWithNoSources() {
+			Unit unit = unitWithModels();
+			var op = applyOperator("out", "noop", List.of(), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThat(op.condition().test(unit)).isTrue();
+		}
+	}
+
+	// ── expand ───────────────────────────────────────────────────────────────
+
+	@Nested
+	class Expand {
+
+		@Test
+		void happyPathCreatesResultModel() {
+			Unit unit = unitWithModels("a");
+			var op = applyOperator("out", "noop", List.of("a"), Map.of(),
+					ModelKind.JUSTIFICATION);
+			List<Command> cmds = op.expand(unit);
+			Unit result = engine.spawn("out2", new java.util.ArrayList<>(cmds));
+			assertThat(result.findModel("out")).isPresent();
+		}
+
+		@Test
+		void unknownOperatorThrows() {
+			Unit unit = unitWithModels("a");
+			var op = applyOperator("out", "no-such-op", List.of("a"), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThatThrownBy(() -> op.expand(unit))
+					.isInstanceOf(InvalidOperatorCallException.class)
+					.hasMessageContaining("no-such-op");
+		}
+
+		@Test
+		void kindMismatchThrows() {
+			Unit unit = unitWithModels("a");
+			// operator returns TEMPLATE but declared kind is JUSTIFICATION
+			var op = applyOperator("out", "template-op", List.of("a"), Map.of(),
+					ModelKind.JUSTIFICATION);
+			assertThatThrownBy(() -> op.expand(unit))
+					.isInstanceOf(InvalidOperatorCallException.class)
+					.hasMessageContaining("template")
+					.hasMessageContaining("justification");
+		}
+	}
+}

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/CompositionOperatorTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/CompositionOperatorTest.java
@@ -250,6 +250,39 @@ class CompositionOperatorTest {
 					List.of(j), Map.of());
 			assertThat(commands).isUnmodifiable();
 		}
+
+		@Test
+		void transitiveAliasesFromSourceModelsAreCarriedForward() {
+			// Simulate a source model "src" whose element "c" was previously
+			// unified into "unified_0". The knownAliases map records
+			// "src/c" -> "unified_0" (as would be produced by a prior
+			// assemble).
+			// The operator then merges "unified_0" into a new id. After
+			// apply(),
+			// the result must contain a RegisterAlias entry so that the
+			// original
+			// pre-assemble id "src:c" (= "result/src:c") is reachable under
+			// its final name in the new model.
+			Justification src = buildJustification("src",
+					List.of(new CreateConclusion("src", "unified_0", "C")));
+
+			Map<String, String> knownAliases = Map.of("src/c", "unified_0");
+
+			List<Command> commands = new TestOperator().apply("result",
+					List.of(src), Map.of(), SourceLocation.UNKNOWN, Map.of(),
+					knownAliases);
+
+			// The TestOperator merges by short-id: "unified_0" stays as
+			// "unified_0".
+			// The transitive alias chain: src/c -> unified_0 -> result element
+			// "unified_0" (via src:unified_0). So "result" must register that
+			// "src:c" is an alias for "unified_0".
+			List<RegisterAlias> aliasCommands = commands.stream()
+					.filter(RegisterAlias.class::isInstance)
+					.map(RegisterAlias.class::cast).toList();
+			assertThat(aliasCommands).anySatisfy(
+					ra -> assertThat(ra.oldId()).isEqualTo("src:c"));
+		}
 	}
 
 	@Nested

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/ModelReplicatorTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/ModelReplicatorTest.java
@@ -8,12 +8,14 @@ import ca.mcscert.jpipe.commands.creation.CreateConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateEvidence;
 import ca.mcscert.jpipe.commands.creation.CreateJustification;
 import ca.mcscert.jpipe.commands.creation.CreateStrategy;
+import ca.mcscert.jpipe.commands.creation.CreateSubConclusion;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
 import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.Conclusion;
 import ca.mcscert.jpipe.model.elements.Evidence;
 import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -119,6 +121,87 @@ class ModelReplicatorTest {
 					.extracting(Conclusion::id).isEqualTo("c");
 			assertThat(result.get("out").strategies()).extracting(Strategy::id)
 					.containsExactly("s");
+		}
+
+		@Test
+		void nullPrefixKeepsOriginalIds() {
+			Justification src = simpleJustification("j");
+			Unit result = engine.spawn("out",
+					List.of(new CreateJustification("out")));
+			engine.enrich(result, ModelReplicator.replicate("out", src, null));
+
+			assertThat(result.get("out").conclusion()).isPresent().get()
+					.extracting(Conclusion::id).isEqualTo("c");
+		}
+	}
+
+	@Nested
+	class WithSubConclusion {
+
+		/**
+		 * Builds: conclusion c ← strategy s ← sub-conclusion sc ← strategy s2
+		 */
+		private Justification justificationWithSubConclusion(String name) {
+			Unit unit = engine.spawn("src",
+					List.of(new CreateJustification(name),
+							new CreateConclusion(name, "c", "the conclusion"),
+							new CreateStrategy(name, "s", "the strategy"),
+							new CreateSubConclusion(name, "sc",
+									"the sub-conclusion"),
+							new CreateStrategy(name, "s2", "inner strategy"),
+							new CreateEvidence(name, "e", "evidence"),
+							new AddSupport(name, "c", "s"),
+							new AddSupport(name, "s", "sc"),
+							new AddSupport(name, "sc", "s2"),
+							new AddSupport(name, "s2", "e")));
+			return (Justification) unit.get(name);
+		}
+
+		@Test
+		void replicatesSubConclusionWithPrefix() {
+			Justification src = justificationWithSubConclusion("j");
+			Unit result = engine.spawn("out",
+					List.of(new CreateJustification("out")));
+			engine.enrich(result, ModelReplicator.replicate("out", src, "j"));
+
+			assertThat(result.get("out").subConclusions())
+					.extracting(SubConclusion::id).containsExactly("j:sc");
+		}
+
+		@Test
+		void replicatesSubConclusionSupportEdge() {
+			Justification src = justificationWithSubConclusion("j");
+			Unit result = engine.spawn("out",
+					List.of(new CreateJustification("out")));
+			engine.enrich(result, ModelReplicator.replicate("out", src, "j"));
+
+			Justification out = (Justification) result.get("out");
+			SubConclusion sc = out.subConclusions().get(0);
+			assertThat(sc.getSupport()).isPresent().get()
+					.extracting(Strategy::id).isEqualTo("j:s2");
+		}
+	}
+
+	@Nested
+	class AlreadyQualifiedIds {
+
+		@Test
+		void alreadyQualifiedIdIsNotDoubleQualified() {
+			// Build a justification whose strategy already has a qualified id
+			Unit unit = engine.spawn("src",
+					List.of(new CreateJustification("j"),
+							new CreateConclusion("j", "c", "C"),
+							new CreateStrategy("j", "ns:s", "S"),
+							new AddSupport("j", "c", "ns:s")));
+			Justification src = (Justification) unit.get("j");
+
+			Unit result = engine.spawn("out",
+					List.of(new CreateJustification("out")));
+			engine.enrich(result, ModelReplicator.replicate("out", src, "j"));
+
+			// "ns:s" already contains ":" so prefix "j" must not be prepended
+			assertThat(result.get("out").strategies()).extracting(Strategy::id)
+					.containsExactly("ns:s");
 		}
 	}
 

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/builtin/RefineOperatorTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/builtin/RefineOperatorTest.java
@@ -181,6 +181,50 @@ class RefineOperatorTest {
 		}
 
 		@Test
+		void hookCanBeReferencedByShortId() {
+			// "minimal" stores evidence as "e"; hook "e" triggers the suffix
+			// fallback in findById — the actual stored id is "e" here, but the
+			// fix normalizes to the element's real id so isHookPair matches.
+			var minimal = buildMinimal();
+			var refinement = buildRefinement();
+			List<Command> cmds = refine.apply("refined",
+					List.of(minimal, refinement), Map.of("hook", "e"));
+			Unit unit = engine.spawn("out", cmds);
+			Justification result = (Justification) unit.get("refined");
+
+			assertThat(result.subConclusions()).hasSize(1);
+			assertThat(result.subConclusions().get(0).id())
+					.isEqualTo(RefineOperator.HOOK_ID);
+		}
+
+		@Test
+		void hookReferencedByShortIdWhenStoredAsQualifiedId() {
+			// Simulates a base model where the evidence is stored as "base:e"
+			// (a qualified id, as produced after template expansion). The hook
+			// argument is just "e". findById's suffix fallback resolves "e" to
+			// "base:e", and after normalization isHookPair must still match.
+			List<Command> baseCmds = new ArrayList<>();
+			baseCmds.add(new CreateJustification("base"));
+			baseCmds.add(new CreateConclusion("base", "c", "A conclusion"));
+			baseCmds.add(new CreateStrategy("base", "s", "A strategy"));
+			baseCmds.add(new CreateEvidence("base", "base:e", "An evidence"));
+			baseCmds.add(new AddSupport("base", "c", "s"));
+			baseCmds.add(new AddSupport("base", "s", "base:e"));
+			Unit baseUnit = engine.spawn("src", baseCmds);
+			Justification base = (Justification) baseUnit.get("base");
+
+			var refinement = buildRefinement();
+			List<Command> cmds = refine.apply("refined",
+					List.of(base, refinement), Map.of("hook", "e"));
+			Unit unit = engine.spawn("out", cmds);
+			Justification result = (Justification) unit.get("refined");
+
+			assertThat(result.subConclusions()).hasSize(1);
+			assertThat(result.subConclusions().get(0).id())
+					.isEqualTo(RefineOperator.HOOK_ID);
+		}
+
+		@Test
 		void hookCanBeReferencedByAlias() {
 			// Simulates refine(src, refinement) when "e" in src was unified
 			// into "unified_0" by a prior composition step. The alias map

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/builtin/RefineOperatorTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/builtin/RefineOperatorTest.java
@@ -224,5 +224,16 @@ class RefineOperatorTest {
 					.isInstanceOf(InvalidOperatorCallException.class)
 					.hasMessageContaining("2 sources");
 		}
+
+		@Test
+		void throwsWhenHookElementNotFoundInBaseModel() {
+			List<JustificationModel<?>> sources = List.of(buildMinimal(),
+					buildRefinement());
+			Map<String, String> args = Map.of("hook", "nonexistent");
+			assertThatThrownBy(() -> refine.apply("refined", sources, args))
+					.isInstanceOf(InvalidOperatorCallException.class)
+					.hasMessageContaining("nonexistent")
+					.hasMessageContaining("minimal");
+		}
 	}
 }


### PR DESCRIPTION
This pull request introduces several enhancements and new tests for the composition operators, model replication, and visitor patterns in the codebase. The most significant changes include improved error handling for unknown hook elements during refinement, more robust alias propagation in composition, expanded model replication to support sub-conclusions, and the addition of comprehensive unit tests for key operator and visitor behaviors.

**Operator logic and error handling improvements:**

* The `RefineOperator` now throws an `InvalidOperatorCallException` if the specified hook element is not found in the base model, providing clearer error messages for invalid refinement calls.
* The composition operator logic in `CompositionOperator` has been updated to carry forward transitive aliases from source models, ensuring that original element IDs remain accessible after multiple composition steps.

**Model replication enhancements:**

* The `ModelReplicatorTest` has been extended to verify correct replication of sub-conclusions, support edges, and handling of already qualified IDs, as well as maintaining original IDs when no prefix is provided. [[1]](diffhunk://#diff-200729c8a8d34d20d3b71bcf14ef7ba4a9e5d8c44ecfdf685ae055da8101bf78R11-R18) [[2]](diffhunk://#diff-200729c8a8d34d20d3b71bcf14ef7ba4a9e5d8c44ecfdf685ae055da8101bf78R125-R205)

**Testing and validation:**

* New tests have been added for the `ApplyOperator` class, covering accessor methods, condition logic, and error scenarios such as unknown operators and kind mismatches.
* The `OverrideAbstractSupportTest` class has been introduced to test the behavior of overriding abstract supports in justifications.
* A new test for `NoOpJustificationVisitor` ensures that all visit methods return null as expected.
* The feature test suite now includes a scenario to validate that an unknown hook element in a refinement triggers an execution error. [[1]](diffhunk://#diff-41b91f52dbd8f9010696c6737e4da5d924c51950bd569f3fb188cf1f38a29c49R113-R118) [[2]](diffhunk://#diff-217445a39754db00d3562655135406aba51f79e6d3ce2279439049ef9a7e6e55R1-R19)
* Additional test coverage for alias propagation in composition operators has been added.
* The `RefineOperatorTest` now includes a test to verify that missing hook elements are correctly reported as errors.

**Test data and scenario additions:**

* A new invalid example file demonstrates a refinement with an unknown hook element for use in validation tests.

These changes collectively improve the robustness, correctness, and test coverage of the operator and model manipulation logic.