### PR TITLE
Pin launcher to Java 25 dependency and update packaging details

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
     if: ${{ !contains(needs.build-and-release.outputs.version, '-') }}
     strategy:
       matrix:
-        distro: [focal, jammy, noble, questing]
+        distro: [jammy, noble, questing, resolute]
 
     steps:
       - uses: actions/checkout@v6

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/jpipe-mcscert/jpipe-compiler
 
 Package: jpipe
 Architecture: all
-Depends: ${misc:Depends}, openjdk-25-jre, graphviz
+Depends: ${misc:Depends}, openjdk-25-jre-headless, graphviz
 Description: Justified Pipeline compiler
  jPipe is a compiler and language environment for defining justifications
  that support software maintenance and CI/CD activities.

--- a/debian/postinst
+++ b/debian/postinst
@@ -3,12 +3,13 @@ set -e
 
 case "$1" in
     configure)
-        JAVA_BIN=$(update-alternatives --list java | grep 'java-25' | head -1)
-        if [ -z "$JAVA_BIN" ]; then
-            echo "jpipe: could not locate Java 25 binary via update-alternatives" >&2
+        JAVA_BIN=$(dpkg-query -L openjdk-25-jre-headless | grep '/bin/java$' | head -1)
+        if [ -z "$JAVA_BIN" ] || [ ! -x "$JAVA_BIN" ]; then
+            echo "jpipe: could not locate Java 25 binary from openjdk-25-jre-headless" >&2
             exit 1
         fi
-        sed -i "s|@@JAVA@@|$JAVA_BIN|g" /usr/bin/jpipe
+        sed -i "s|which java > /dev/null|test -x '${JAVA_BIN}'|g" /usr/bin/jpipe
+        sed -i "s|@@JAVA@@|${JAVA_BIN}|g" /usr/bin/jpipe
         ;;
 esac
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        JAVA_BIN=$(update-alternatives --list java | grep 'java-25' | head -1)
+        if [ -z "$JAVA_BIN" ]; then
+            echo "jpipe: could not locate Java 25 binary via update-alternatives" >&2
+            exit 1
+        fi
+        sed -i "s|@@JAVA@@|$JAVA_BIN|g" /usr/bin/jpipe
+        ;;
+esac
+
+#DEBHELPER#

--- a/debian/rules
+++ b/debian/rules
@@ -8,5 +8,4 @@ override_dh_auto_build:
 override_dh_auto_install:
 	install -Dm644 jpipe.jar debian/jpipe/usr/share/jpipe/jpipe.jar
 	install -Dm755 bin/jpipe debian/jpipe/usr/bin/jpipe
-	sed -i 's|@@JAVA@@|java|g' debian/jpipe/usr/bin/jpipe
 	sed -i 's|@@PREFIX@@|/usr/share/jpipe|g' debian/jpipe/usr/bin/jpipe

--- a/docs/adr/0021-pin-runtime-binary-to-declared-dependency.md
+++ b/docs/adr/0021-pin-runtime-binary-to-declared-dependency.md
@@ -43,15 +43,22 @@ minimal correct dependency for a CLI tool with no GUI components). The `@@JAVA@@
 placeholder is resolved at **install time** by a `debian/postinst` script:
 
 ```sh
-JAVA_BIN=$(update-alternatives --list java | grep 'java-25' | head -1)
-sed -i "s|@@JAVA@@|$JAVA_BIN|g" /usr/bin/jpipe
+JAVA_BIN=$(dpkg-query -L openjdk-25-jre-headless | grep '/bin/java$' | head -1)
+sed -i "s|which java > /dev/null|test -x '${JAVA_BIN}'|g" /usr/bin/jpipe
+sed -i "s|@@JAVA@@|${JAVA_BIN}|g" /usr/bin/jpipe
 ```
 
-`update-alternatives` is the authoritative registry for runtime binary alternatives
-on Debian/Ubuntu. Querying it avoids hardcoding an architecture-specific path (e.g.
-`/usr/lib/jvm/java-25-openjdk-amd64/bin/java`) while remaining pinned to the
-declared version. The substitution happens at install time, where the dependency is
-guaranteed present, rather than at build time, where it may not be installed.
+`dpkg-query -L openjdk-25-jre-headless` lists exactly the files owned by the
+declared dependency, returning a single deterministic path regardless of how many
+other Java providers are installed. The substitution happens at install time, where
+the dependency is guaranteed present, rather than at build time, where it may not
+be installed.
+
+The `postinst` also patches the launcher's pre-flight check (`which java`) to
+validate the specific binary path (`test -x '$JAVA_BIN'`). Without this, the check
+and the actual invocation would test different binaries, and the script would abort
+on systems where `java` is not on `PATH` even though the declared runtime is
+available.
 
 ## Rationale
 
@@ -59,9 +66,11 @@ guaranteed present, rather than at build time, where it may not be installed.
   global setting that can change independently of the package. The declared
   dependency is meaningless if the launcher ignores it.
 - **Each channel has a native resolution mechanism.** Homebrew provides
-  `Formula[...].opt_bin`; Debian/Ubuntu provides `update-alternatives`. Using
-  these avoids fragile path guessing and keeps the solution idiomatic for each
-  platform.
+  `Formula[...].opt_bin`; Debian/Ubuntu provides `dpkg-query -L` on the declared
+  package. Using these avoids fragile path guessing and keeps the solution
+  idiomatic for each platform. `update-alternatives` was considered for Debian but
+  rejected: it requires filtering by provider name and is non-deterministic when
+  multiple Java 25 providers are installed.
 - **Headless is the correct Debian dependency.** `openjdk-25-jre` adds AWT/Swing
   display libraries that jPipe, as a CLI compiler, does not use. Depending on the
   minimal sufficient package reduces the installation footprint.
@@ -69,13 +78,17 @@ guaranteed present, rather than at build time, where it may not be installed.
 ## Consequences
 
 - `debian/postinst` is introduced; the `@@JAVA@@` sed line is removed from
-  `debian/rules`.
+  `debian/rules`. The postinst performs two substitutions: it replaces the
+  `which java` pre-flight check with `test -x '$JAVA_BIN'`, and replaces
+  `@@JAVA@@` with the resolved binary path. Both the check and the invocation
+  therefore validate and use the same binary.
 - The Homebrew formula in `jpipe-mcscert/homebrew-mcscert` must use
   `Formula["openjdk@25"].opt_bin/"java"` in its `inreplace` call rather than the
   string `"java"`.
 - Any future packaging format (RPM `%post`, AppImage, etc.) must apply the same
   principle: resolve the runtime binary path from the package manager's own
   registry rather than using an unqualified command name.
-- The launcher's pre-flight `which java` check remains as a developer convenience
-  for running the script outside a packaged installation; it does not affect the
-  installed path.
+- The launcher's pre-flight `which java` check remains intact in `bin/jpipe` for
+  developer convenience (running the script outside a packaged installation).
+  The packaged copy at `/usr/bin/jpipe` has it replaced with `test -x '$JAVA_BIN'`
+  by `postinst`.

--- a/docs/adr/0021-pin-runtime-binary-to-declared-dependency.md
+++ b/docs/adr/0021-pin-runtime-binary-to-declared-dependency.md
@@ -1,0 +1,81 @@
+# ADR-0021: Pin Runtime Binary to Declared Dependency Version
+
+**Date:** 2026-05-20
+**Status:** Accepted
+
+## Context
+
+jPipe is distributed through two packaging channels, each of which declares Java 25
+as a runtime dependency and installs a launcher script (`bin/jpipe`) that contains
+an `@@JAVA@@` placeholder resolved at package-install time:
+
+- **Homebrew** — `jpipe.rb` declares `depends_on "openjdk@25"` and installs the
+  launcher via the formula's `install` step.
+- **Debian/Ubuntu PPA** — `debian/control` declares `openjdk-25-jre[-headless]`
+  and installs the launcher via `debian/rules`.
+
+In both cases the `@@JAVA@@` placeholder was previously replaced with the bare
+`java` command, which resolves to whichever JVM is the current system default —
+not necessarily Java 25. On a machine with multiple JDKs installed this silently
+runs jPipe under the wrong runtime version, defeating the version guarantee that
+the declared dependency is meant to provide.
+
+## Decision
+
+Installation scripts must invoke the **exact binary provided by the declared
+dependency**, not a system default alias. Each packaging channel uses the
+resolution mechanism native to its package manager:
+
+**Homebrew** — the formula's `install` step replaces `@@JAVA@@` using Homebrew's
+own reference to the declared dependency:
+
+```ruby
+inreplace bin/"jpipe", "@@JAVA@@", Formula["openjdk@25"].opt_bin/"java"
+```
+
+`Formula["openjdk@25"].opt_bin` is the canonical Homebrew path for the declared
+dependency's binaries. It is architecture-aware and does not depend on PATH or any
+system-level alternative.
+
+**Debian/Ubuntu** — the dependency is tightened from `openjdk-25-jre` to
+`openjdk-25-jre-headless` (the sub-package that owns the `java` binary, and the
+minimal correct dependency for a CLI tool with no GUI components). The `@@JAVA@@`
+placeholder is resolved at **install time** by a `debian/postinst` script:
+
+```sh
+JAVA_BIN=$(update-alternatives --list java | grep 'java-25' | head -1)
+sed -i "s|@@JAVA@@|$JAVA_BIN|g" /usr/bin/jpipe
+```
+
+`update-alternatives` is the authoritative registry for runtime binary alternatives
+on Debian/Ubuntu. Querying it avoids hardcoding an architecture-specific path (e.g.
+`/usr/lib/jvm/java-25-openjdk-amd64/bin/java`) while remaining pinned to the
+declared version. The substitution happens at install time, where the dependency is
+guaranteed present, rather than at build time, where it may not be installed.
+
+## Rationale
+
+- **Correctness over convenience.** The bare `java` alias binds the launcher to a
+  global setting that can change independently of the package. The declared
+  dependency is meaningless if the launcher ignores it.
+- **Each channel has a native resolution mechanism.** Homebrew provides
+  `Formula[...].opt_bin`; Debian/Ubuntu provides `update-alternatives`. Using
+  these avoids fragile path guessing and keeps the solution idiomatic for each
+  platform.
+- **Headless is the correct Debian dependency.** `openjdk-25-jre` adds AWT/Swing
+  display libraries that jPipe, as a CLI compiler, does not use. Depending on the
+  minimal sufficient package reduces the installation footprint.
+
+## Consequences
+
+- `debian/postinst` is introduced; the `@@JAVA@@` sed line is removed from
+  `debian/rules`.
+- The Homebrew formula in `jpipe-mcscert/homebrew-mcscert` must use
+  `Formula["openjdk@25"].opt_bin/"java"` in its `inreplace` call rather than the
+  string `"java"`.
+- Any future packaging format (RPM `%post`, AppImage, etc.) must apply the same
+  principle: resolve the runtime binary path from the package manager's own
+  registry rather than using an unqualified command name.
+- The launcher's pre-flight `which java` check remains as a developer convenience
+  for running the script outside a packaged installation; it does not affect the
+  installed path.


### PR DESCRIPTION
This pull request improves how the jPipe launcher script selects its Java runtime, ensuring it always uses the exact Java 25 binary provided by the declared package dependency, rather than relying on the system default. This guarantees that jPipe runs under the correct Java version, even on systems with multiple JDKs installed. The changes also introduce a new Debian post-installation script to resolve the Java binary path at install time, and update documentation to reflect these improvements.

**Dependency and runtime resolution improvements:**

* Changed the Debian package dependency from `openjdk-25-jre` to `openjdk-25-jre-headless` in `debian/control`, ensuring the package only depends on the minimal required Java runtime for a CLI tool.
* Updated the launcher installation process by removing the build-time substitution of the `@@JAVA@@` placeholder in `debian/rules` and introducing a new `debian/postinst` script. The script uses `update-alternatives` to locate the correct Java 25 binary and substitutes it into `/usr/bin/jpipe` at install time, guaranteeing the launcher uses the declared dependency. [[1]](diffhunk://#diff-889c5495b68d2a0c0d1f238818716a71939918499efbc0fc6d2994319624fc67L11) [[2]](diffhunk://#diff-2db24480058f7aaaee957b463ec9c8bcb83c508aeac36a78f08c152fa50f622eR1-R15)

**Documentation and policy:**

* Added ADR-0021 (`docs/adr/0021-pin-runtime-binary-to-declared-dependency.md`), documenting the rationale, decision, and consequences of pinning the runtime binary to the declared dependency version for both Debian and Homebrew packaging channels. This establishes a clear policy for future packaging work.

**Packaging and compatibility:**

* Updated the supported Ubuntu/Debian distributions in the GitHub Actions release workflow to add `resolute` and remove `focal`, ensuring builds target currently supported releases.