### PR TITLE
Preserve unification aliases in JSON and Python exports

### DIFF
--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
@@ -17,6 +17,7 @@ import ca.mcscert.jpipe.model.elements.JustificationElement;
 import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
 import ca.mcscert.jpipe.visitor.DotExporter;
+import ca.mcscert.jpipe.visitor.JsonExporter;
 import ca.mcscert.jpipe.visitor.PythonExporter;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -36,6 +37,7 @@ public class CompilationSteps {
 	private JustificationModel<?> currentModel;
 	private String dotOutput;
 	private String pythonOutput;
+	private String jsonOutput;
 
 	@Given("the source file {string}")
 	public void theSourceFile(String filename) {
@@ -190,6 +192,16 @@ public class CompilationSteps {
 	@Then("the DOT output contains a node with id {string}")
 	public void theDotOutputContainsANodeWithId(String id) {
 		assertThat(dotOutput).contains("id=\"" + id + "\"");
+	}
+
+	@When("I export the current model to JSON format")
+	public void iExportTheCurrentModelToJsonFormat() {
+		jsonOutput = new JsonExporter().export(currentModel);
+	}
+
+	@Then("the JSON output contains {string}")
+	public void theJsonOutputContains(String fragment) {
+		assertThat(jsonOutput).contains(fragment);
 	}
 
 	@When("I export the current model to Python format")

--- a/jpipe-compiler/src/test/resources/features/exports.feature
+++ b/jpipe-compiler/src/test/resources/features/exports.feature
@@ -20,3 +20,22 @@ Feature: Exporting compiled models to various formats
       And the Python output has @jpipe_link for id "minimal:c" active
       And the Python output has @jpipe_link for id "minimal:s" active
       And the Python output has @jpipe_link for id "minimal:e" active
+
+  Scenario: JSON export preserves unification aliases on the merged element
+    Given the source file "011_unifying_while_compising.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "assembled_2"
+    When I export the current model to JSON format
+    Then the JSON output contains "assembled_2:unified_0"
+      And the JSON output contains "\"aliases\""
+      And the JSON output contains "assembled_2:a_claim:s1"
+      And the JSON output contains "assembled_2:another_claim:s2"
+
+  Scenario: Python export links the merged element by every original id
+    Given the source file "011_unifying_while_compising.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "assembled_2"
+    When I export the current model to Python format
+    Then the Python output has @jpipe_link for id "assembled_2:unified_0" active
+      And the Python output has @jpipe_link for id "assembled_2:a_claim:s1" active
+      And the Python output has @jpipe_link for id "assembled_2:another_claim:s2" active

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
@@ -48,6 +48,7 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 	private Conclusion conclusion;
 	private Template parent = null;
 	private final List<E> elements = new ArrayList<>();
+	private final Map<String, String> aliases = new LinkedHashMap<>();
 
 	protected JustificationModel(String name) {
 		this.name = name;
@@ -84,6 +85,23 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 					"Model '" + name + "' already has a parent template");
 		}
 		this.parent = parent;
+	}
+
+	/**
+	 * Records that {@code oldId} was merged into {@code newId} within this
+	 * model during composition/unification. Enables consumers of an exported
+	 * model to reference a merged element by any of its pre-merge ids.
+	 */
+	public void recordAlias(String oldId, String newId) {
+		aliases.put(oldId, newId);
+	}
+
+	/**
+	 * Unmodifiable view of this model's aliases. Keys are original element ids;
+	 * values are the id they were merged into.
+	 */
+	public Map<String, String> aliases() {
+		return Collections.unmodifiableMap(aliases);
 	}
 
 	/**

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/Unit.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/Unit.java
@@ -131,6 +131,7 @@ public final class Unit {
 	 */
 	public void recordAlias(String modelName, String oldId, String newId) {
 		aliases.put(modelName + "/" + oldId, newId);
+		findModel(modelName).ifPresent(m -> m.recordAlias(oldId, newId));
 	}
 
 	/**

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/AbstractModelExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/AbstractModelExporter.java
@@ -4,6 +4,10 @@ import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.JustificationModel;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Abstract base for exporters that serialise a single
@@ -44,11 +48,44 @@ public abstract class AbstractModelExporter
 	protected String currentModelName;
 
 	/**
+	 * Inverted alias map for the model currently being exported: merged element
+	 * id &rarr; the list of original ids that were merged into it. Populated by
+	 * {@link #initAliases(JustificationModel)}.
+	 */
+	private final Map<String, List<String>> aliasesByTarget = new HashMap<>();
+
+	/**
 	 * Qualifies {@code elementId} with the current model name:
 	 * {@code "currentModelName:elementId"}.
 	 */
 	protected final String qualify(String elementId) {
 		return currentModelName + ":" + elementId;
+	}
+
+	/**
+	 * Builds the inverted alias lookup for {@code model}. Subclasses that
+	 * surface aliases must call this at the start of
+	 * {@link #exportModel(JustificationModel)}, after setting
+	 * {@link #currentModelName}.
+	 */
+	protected final void initAliases(JustificationModel<?> model) {
+		aliasesByTarget.clear();
+		model.aliases().forEach((oldId, newId) -> aliasesByTarget
+				.computeIfAbsent(newId, _ -> new ArrayList<>()).add(oldId));
+	}
+
+	/**
+	 * Returns the qualified original ids that were merged into
+	 * {@code plainElementId}, or an empty list when the element is not the
+	 * target of any alias. Requires {@link #initAliases(JustificationModel)} to
+	 * have been called first.
+	 */
+	protected final List<String> qualifiedAliasesOf(String plainElementId) {
+		List<String> originals = aliasesByTarget.get(plainElementId);
+		if (originals == null) {
+			return List.of();
+		}
+		return originals.stream().map(this::qualify).toList();
 	}
 
 	/**

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/JsonExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/JsonExporter.java
@@ -9,6 +9,7 @@ import ca.mcscert.jpipe.model.elements.JustificationElement;
 import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
 import ca.mcscert.jpipe.util.LabelEscaper;
+import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -27,10 +28,16 @@ import org.json.JSONObject;
  * {
  *   "name": "...",
  *   "type": "justification" | "template",
- *   "elements": [ { "type": "...", "id": "...", "label": "..." }, ... ],
+ *   "elements": [ { "type": "...", "id": "...", "label": "...",
+ *                   "aliases": [ "..." ] }, ... ],
  *   "relations": [ { "source": "...", "target": "..." }, ... ]
  * }
  * }</pre>
+ *
+ * <p>
+ * The optional per-element {@code "aliases"} array lists the qualified original
+ * ids that were merged into the element during composition/unification; it is
+ * omitted for elements that are not the target of any alias.
  */
 public class JsonExporter extends AbstractModelExporter {
 
@@ -95,6 +102,7 @@ public class JsonExporter extends AbstractModelExporter {
 				? "justification"
 				: "template";
 		currentModelName = model.getName();
+		initAliases(model);
 		elements = new JSONArray();
 		relations = new JSONArray();
 
@@ -131,6 +139,10 @@ public class JsonExporter extends AbstractModelExporter {
 		obj.put("id", qualify(element.id()));
 		obj.put("label", element.label());
 		obj.put("escaped", LabelEscaper.toMethodName(element.label()));
+		List<String> aliases = qualifiedAliasesOf(element.id());
+		if (!aliases.isEmpty()) {
+			obj.put("aliases", new JSONArray(aliases));
+		}
 		elements.put(obj);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
@@ -18,7 +18,10 @@ import java.time.Instant;
  *
  * <ul>
  * <li>{@code @jpipe_link("<modelName:elementId>")} — links the function back to
- * the originating jPipe element.</li>
+ * the originating jPipe element. When the element resulted from a
+ * composition/unification merge, one additional {@code @jpipe_link} is emitted
+ * per original (pre-merge) id, so the function can be resolved by any of
+ * them.</li>
  * <li>{@code @jpipe(produce=[], consume=[])} — placeholder decorators to be
  * filled in by the developer.</li>
  * </ul>
@@ -107,6 +110,7 @@ public class PythonExporter extends AbstractModelExporter {
 	@Override
 	protected void exportModel(JustificationModel<?> model) {
 		currentModelName = model.getName();
+		initAliases(model);
 		model.conclusion().ifPresent(c -> c.accept(this));
 		model.getElements().forEach(e -> e.accept(this));
 	}
@@ -142,6 +146,9 @@ public class PythonExporter extends AbstractModelExporter {
 		String decoratorArgs = jpipeDecoratorArgs(element);
 
 		builder.append("@jpipe_link(\"").append(qid).append("\")\n");
+		for (String alias : qualifiedAliasesOf(element.id())) {
+			builder.append("@jpipe_link(\"").append(alias).append("\")\n");
+		}
 		builder.append("@jpipe(").append(decoratorArgs).append(")\n");
 		builder.append("def ").append(name).append("(").append(params)
 				.append(") -> bool:\n");

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/UnitAliasTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/UnitAliasTest.java
@@ -45,4 +45,27 @@ class UnitAliasTest {
 			assertThat(unit.resolveAlias("result", "b:s")).isEqualTo("s");
 		}
 	}
+
+	@Nested
+	class MirrorsOntoModel {
+
+		@Test
+		void recordingAnAliasPopulatesBothUnitAndModel() {
+			Justification model = new Justification("result");
+			unit.add(model);
+
+			unit.recordAlias("result", "a:s", "s");
+
+			assertThat(unit.aliases()).containsEntry("result/a:s", "s");
+			assertThat(model.aliases()).containsEntry("a:s", "s");
+		}
+
+		@Test
+		void aliasForUnknownModelIsRecordedOnlyOnUnit() {
+			unit.recordAlias("absent", "a:s", "s");
+
+			assertThat(unit.aliases()).containsEntry("absent/a:s", "s");
+			assertThat(unit.findModel("absent")).isEmpty();
+		}
+	}
 }

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/JsonExporterTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/JsonExporterTest.java
@@ -44,4 +44,20 @@ class JsonExporterTest {
 
 		assertThat(json).contains("\"abstract-support\"", "\"t:abs\"");
 	}
+
+	@Test
+	void export_mergedElement_carriesQualifiedAliases() {
+		String json = new JsonExporter()
+				.export(ModelFixtures.unifiedJustification());
+
+		assertThat(json).contains("\"aliases\"", "\"j:a:s\"", "\"j:b:s\"");
+	}
+
+	@Test
+	void export_withoutAliases_omitsAliasesKey() {
+		String json = new JsonExporter()
+				.export(ModelFixtures.simpleJustification());
+
+		assertThat(json).doesNotContain("\"aliases\"");
+	}
 }

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/ModelFixtures.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/ModelFixtures.java
@@ -48,6 +48,18 @@ class ModelFixtures {
 	 * <li>AbstractSupport {@code "abs"} &mdash; "Abstract step"
 	 * </ul>
 	 */
+	/**
+	 * A {@link #simpleJustification()} whose strategy {@code "s"} is the merge
+	 * target of two original ids ({@code "a:s"} and {@code "b:s"}), as recorded
+	 * during composition/unification.
+	 */
+	static Justification unifiedJustification() {
+		Justification j = simpleJustification();
+		j.recordAlias("a:s", "s");
+		j.recordAlias("b:s", "s");
+		return j;
+	}
+
 	static Template simpleTemplate() {
 		Template t = new Template("t");
 		Conclusion c = new Conclusion("c", "Conclusion");

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/ModelFixtures.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/ModelFixtures.java
@@ -38,17 +38,6 @@ class ModelFixtures {
 	}
 
 	/**
-	 * Template with a single Conclusion &larr; Strategy &larr; AbstractSupport
-	 * chain.
-	 *
-	 * <ul>
-	 * <li>name: {@code "t"}
-	 * <li>Conclusion {@code "c"} &mdash; "Conclusion"
-	 * <li>Strategy {@code "s"} &mdash; "Strategy"
-	 * <li>AbstractSupport {@code "abs"} &mdash; "Abstract step"
-	 * </ul>
-	 */
-	/**
 	 * A {@link #simpleJustification()} whose strategy {@code "s"} is the merge
 	 * target of two original ids ({@code "a:s"} and {@code "b:s"}), as recorded
 	 * during composition/unification.
@@ -60,6 +49,17 @@ class ModelFixtures {
 		return j;
 	}
 
+	/**
+	 * Template with a single Conclusion &larr; Strategy &larr; AbstractSupport
+	 * chain.
+	 *
+	 * <ul>
+	 * <li>name: {@code "t"}
+	 * <li>Conclusion {@code "c"} &mdash; "Conclusion"
+	 * <li>Strategy {@code "s"} &mdash; "Strategy"
+	 * <li>AbstractSupport {@code "abs"} &mdash; "Abstract step"
+	 * </ul>
+	 */
 	static Template simpleTemplate() {
 		Template t = new Template("t");
 		Conclusion c = new Conclusion("c", "Conclusion");

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/PythonExporterTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/PythonExporterTest.java
@@ -36,6 +36,15 @@ class PythonExporterTest {
 	}
 
 	@Test
+	void export_mergedElement_emitsExtraJpipeLinkPerAlias() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.unifiedJustification());
+
+		assertThat(py).contains("@jpipe_link(\"j:s\")",
+				"@jpipe_link(\"j:a:s\")", "@jpipe_link(\"j:b:s\")");
+	}
+
+	@Test
 	void export_decoratorArgsReflectElementRole() {
 		String py = new PythonExporter()
 				.export(ModelFixtures.simpleJustification());


### PR DESCRIPTION
This pull request introduces support for tracking and exporting unification aliases in model exports, ensuring that elements merged during composition/unification can be referenced by any of their original IDs. This is reflected in both the JSON and Python exporters, and is covered by new tests and feature scenarios.

### Alias tracking and propagation

* Added an `aliases` map to `JustificationModel`, with methods to record and expose aliases, allowing merged elements to be referenced by their original IDs (`JustificationModel.java`) [[1]](diffhunk://#diff-54ce3053251e80fa58e76adf412f299606624cea192d60272eb73253bdce3026R51) [[2]](diffhunk://#diff-54ce3053251e80fa58e76adf412f299606624cea192d60272eb73253bdce3026R90-R106).
* Updated `Unit.recordAlias` to also record the alias in the corresponding model, ensuring both unit and model are kept in sync (`Unit.java`).

### Exporter enhancements

* Updated `JsonExporter` to include an `"aliases"` array for merged elements in the exported JSON, listing all qualified original IDs; omitted when no aliases exist. Added logic to build and query the alias map during export (`JsonExporter.java`, `AbstractModelExporter.java`) [[1]](diffhunk://#diff-11e92a9db8baa030f56335d8b46b11596c7fc0b6728ed1c00fe4cd5eb169812cL30-R40) [[2]](diffhunk://#diff-11e92a9db8baa030f56335d8b46b11596c7fc0b6728ed1c00fe4cd5eb169812cR142-R145) [[3]](diffhunk://#diff-11e92a9db8baa030f56335d8b46b11596c7fc0b6728ed1c00fe4cd5eb169812cR105) [[4]](diffhunk://#diff-cecad6697a54d6a2818a1d07c628fda2f029a481042c7770e12f0b77ee443894R50-R56) [[5]](diffhunk://#diff-cecad6697a54d6a2818a1d07c628fda2f029a481042c7770e12f0b77ee443894R65-R90).
* Updated `PythonExporter` to emit an extra `@jpipe_link` decorator for each alias of a merged element, so functions can be referenced by any original ID (`PythonExporter.java`) [[1]](diffhunk://#diff-10968f59ed96455fd9e3207e26d9900cf5e9c877f0abad4020234bb228d3e133L21-R24) [[2]](diffhunk://#diff-10968f59ed96455fd9e3207e26d9900cf5e9c877f0abad4020234bb228d3e133R149-R151) [[3]](diffhunk://#diff-10968f59ed96455fd9e3207e26d9900cf5e9c877f0abad4020234bb228d3e133R113).

### Testing and feature coverage

* Added and updated tests to verify that merged elements carry aliases in JSON (`JsonExporterTest.java`, `ModelFixtures.java`), that Python exports emit the correct decorators (`PythonExporterTest.java`), and that alias recording is properly mirrored between unit and model (`UnitAliasTest.java`) [[1]](diffhunk://#diff-e170fe395ce31acc08dd7446ec3266e0bb9dcdfa6f82fe8062d1e7eb0e4d2aadR47-R62) [[2]](diffhunk://#diff-cdda6fa279c3d65e1595319be57351e93ce033e202a9a324af2870b2b18a7882R51-R62) [[3]](diffhunk://#diff-c38bae1780486a34e82020d4cea8f5ccda9ccd1eaf80f1d06adac6805b2afcbfR38-R46) [[4]](diffhunk://#diff-eb5ed3110ad405d3f4c1660b342253c64ab09d5f405cdec816609c8bca99934bR48-R70).
* Added feature scenarios to ensure that JSON and Python exports preserve and expose unification aliases as intended (`exports.feature`).

### Test step additions

* Added Cucumber steps to support JSON export and assertions in `CompilationSteps.java` [[1]](diffhunk://#diff-83ddfdef8990cd09a1e3b169d5803faed967c63f705a5cb3f2196070ff3477caR20) [[2]](diffhunk://#diff-83ddfdef8990cd09a1e3b169d5803faed967c63f705a5cb3f2196070ff3477caR40) [[3]](diffhunk://#diff-83ddfdef8990cd09a1e3b169d5803faed967c63f705a5cb3f2196070ff3477caR197-R206).