### PR TITLE
Support glob patterns in load directive and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ site/
 # Local agent instructions
 CLAUDE.md
 GEMINI.md
+
+# Local MCP server configuration (machine-specific paths)
+.mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,3 +253,42 @@ should pass the plain id when possible.
   suppression. Suppressions that are legitimately unavoidable (e.g. generated
   code, functional-interface `throws` boundaries) must still be approved and must
   carry an explanatory comment.
+
+<!-- code-review-graph MCP tools -->
+## MCP Tools: code-review-graph
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+| ------ | ---------- |
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.

--- a/docs/adr/0022-glob-patterns-in-load.md
+++ b/docs/adr/0022-glob-patterns-in-load.md
@@ -1,0 +1,122 @@
+# ADR-0022: Glob Patterns in the `load` Directive
+
+**Date:** 2026-07-15
+**Status:** Accepted
+
+## Context
+
+ADR-0017 introduced `load` as a compiler step (`LoadResolver`) that expands a
+single `load "path" as ns` directive into the commands of the referenced file.
+Each `load` imports exactly **one** file. Projects that split their models
+across many `.jd` files must enumerate every file with its own `load` line:
+
+```
+load "models/a.jd" as lib
+load "models/b.jd" as lib
+load "models/c.jd" as lib
+```
+
+This is verbose and easy to forget to update when a file is added. We want a
+single directive to pull in a whole set of files matched by a pattern, e.g.
+`load "models/*.jd" as lib`.
+
+Two questions drove the design:
+
+1. **Does this need a new grammar construct?**
+2. **What matching syntax — regular expressions or globs?**
+
+## Decision
+
+### Same `load` command — no grammar change
+
+The `load` rule is already pattern-agnostic:
+
+```antlr
+load   : LOAD path=STRING (AS namespace=ID)?;
+STRING : '"' STRING_CHAR* '"' | '\'' STRING_CHAR* '\'' ; // any char except CR/LF
+```
+
+`path` is a free-form `STRING`, so `load "models/*.jd"` is *already*
+syntactically valid. We keep the same `load` production — no new keyword, no new
+rule, no lexer change. This extends ADR-0017's model naturally: `load` was
+already a macro expanding one directive into many *commands*; it now expands one
+directive into many *files* worth of commands.
+
+### Glob syntax (not regex)
+
+Matching uses **glob** patterns via Java's native
+`FileSystems.getDefault().getPathMatcher("glob:" + pattern)`. Globs are the
+idiomatic, familiar way to match files, are safe, and require no manual tree
+walking beyond a `Files.walk`. True regular expressions on file paths are
+unusual and were rejected.
+
+Standard Java NIO glob semantics apply, matched against each candidate's path
+*relative to the declaring file's directory*:
+
+| Pattern         | Matches                                                    |
+|-----------------|------------------------------------------------------------|
+| `models/*.jd`   | `.jd` files directly in `models/` (one level, no descent)  |
+| `models/**/*.jd`| `.jd` files in **sub**directories of `models/` only        |
+| `models/**.jd`  | every `.jd` under `models/`, at any depth (incl. top level)|
+
+### Backward compatibility
+
+A path with no glob metacharacters (`*`, `?`, `[`, `{`) is treated as a literal
+path and takes exactly the historical single-file code path — including the
+`Cannot open loaded file` FATAL when the file is missing. Existing `load`
+directives are unaffected.
+
+### Namespace on a multi-match: shared
+
+When a pattern matches several files and an `as ns` alias is given, **all**
+matched files' models are imported under the single namespace `ns`. Two matched
+files that declare a model with the same name collide at interpretation time —
+identical to flat-importing two files that share a name today (ADR-0017). No
+per-file sub-namespace is derived.
+
+### Zero matches: FATAL
+
+A pattern that matches no file is almost always a typo or a wrong path, so it is
+reported as a FATAL diagnostic (`No file matches load pattern '<pattern>'`),
+consistent with the existing behavior for a missing literal path.
+
+### Deterministic order
+
+Matched paths are sorted lexicographically before expansion, so compilation
+output does not depend on filesystem enumeration order.
+
+## Implementation
+
+The change is localized to `LoadResolver`
+(`ca.mcscert.jpipe.compiler.steps.transformations.LoadResolver`):
+
+- `expand(LoadDirective, …)` now computes the base directory, and:
+  - for a literal path, calls the extracted per-file helper `expandOne` once;
+  - for a glob, matches via `matchGlob`, FATALs on zero matches, otherwise calls
+    `expandOne` for each matched path and concatenates the results.
+- `expandOne(Path, …)` holds the unchanged per-file body from ADR-0017 (cycle
+  detection via the `visited` set, duplicate suppression via the `loaded` set,
+  sub-file parsing, recursive resolution, namespace prefixing, diagnostic
+  forwarding). Because these checks are per file, they work identically for a
+  literal load and for every match of a glob.
+
+`ActionListProvider.enterLoad` is unchanged: it still emits a single
+`LoadDirective(pattern, namespace)`; the `path` field now simply may hold a
+glob.
+
+## Consequences
+
+- Cycle detection and idempotent-load suppression apply per matched file, so a
+  glob that (transitively) re-includes a file already in progress is still
+  flagged as a cycle, and a file matched twice under the same namespace is
+  loaded once.
+- Because Java glob is used verbatim, `**/*.jd` matches nested files **only**;
+  `**.jd` is the pattern for "every `.jd` at any depth". This is documented in
+  the table above and in `examples/022_load_glob_recursive.jd`.
+- A shared namespace over many files can surface name collisions at
+  interpretation time; this is intentional and matches existing flat-import
+  semantics.
+- Globbing walks the declaring file's directory subtree. For very large trees a
+  single-level `*.jd` still walks the whole subtree and filters; this is
+  acceptable at the current project scale and can be optimized later with a
+  `DirectoryStream` fast path for non-`**` patterns if needed.

--- a/docs/design/steps.md
+++ b/docs/design/steps.md
@@ -169,6 +169,12 @@ When `load "path" as ns` carries a namespace alias, every model-name reference
 in the expanded sub-list is qualified with `ns:` so that loaded models do not
 collide with locally declared ones.
 
+A `load` path may also be a **glob pattern** (e.g. `load "models/*.jd" as lib`),
+in which case one directive expands into every matched file, each resolved by
+the same per-file logic (cycle detection, deduplication, prefixing). Matches are
+sorted for deterministic order; an empty match set is a FATAL. A literal path
+(no glob metacharacters) keeps the single-file behavior. See ADR-0022.
+
 ---
 
 ### Model-building steps

--- a/examples/020_load_glob_flat.jd
+++ b/examples/020_load_glob_flat.jd
@@ -1,0 +1,11 @@
+// A single glob load expands into every matching file, imported flat.
+// "globs/*.jd" matches model_alpha.jd and model_beta.jd (not the nested one).
+load "globs/*.jd"
+
+justification alpha_justification implements alpha {
+    evidence alpha:abs is "A concrete evidence for alpha"
+}
+
+justification beta_justification implements beta {
+    evidence beta:abs is "A concrete evidence for beta"
+}

--- a/examples/021_load_glob_namespace.jd
+++ b/examples/021_load_glob_namespace.jd
@@ -1,0 +1,10 @@
+// A glob load with "as": every matched file's models share the one namespace.
+load "globs/*.jd" as lib
+
+justification alpha_justification implements lib:alpha {
+    evidence lib:alpha:abs is "A concrete evidence for alpha"
+}
+
+justification beta_justification implements lib:beta {
+    evidence lib:beta:abs is "A concrete evidence for beta"
+}

--- a/examples/022_load_glob_recursive.jd
+++ b/examples/022_load_glob_recursive.jd
@@ -1,0 +1,9 @@
+// A recursive glob ("**") matches .jd files at any depth. Following Java NIO
+// glob semantics, "globs/**.jd" matches every .jd under globs/ including nested
+// ones (model_alpha.jd, model_beta.jd and nested/model_gamma.jd), whereas
+// "globs/**/*.jd" would match only the nested files.
+load "globs/**.jd" as lib
+
+justification gamma_justification implements lib:gamma {
+    evidence lib:gamma:abs is "A concrete evidence for gamma"
+}

--- a/examples/globs/model_alpha.jd
+++ b/examples/globs/model_alpha.jd
@@ -1,0 +1,9 @@
+// A glob-loaded model (matched by "globs/*.jd").
+template alpha {
+    conclusion c is "Alpha conclusion"
+    strategy s   is "Alpha strategy"
+    @support abs is "Alpha abstract support"
+
+    s   supports c
+    abs supports s
+}

--- a/examples/globs/model_beta.jd
+++ b/examples/globs/model_beta.jd
@@ -1,0 +1,9 @@
+// A glob-loaded model (matched by "globs/*.jd").
+template beta {
+    conclusion c is "Beta conclusion"
+    strategy s   is "Beta strategy"
+    @support abs is "Beta abstract support"
+
+    s   supports c
+    abs supports s
+}

--- a/examples/globs/nested/model_gamma.jd
+++ b/examples/globs/nested/model_gamma.jd
@@ -1,0 +1,9 @@
+// A nested glob-loaded model (matched only by the recursive "globs/**/*.jd").
+template gamma {
+    conclusion c is "Gamma conclusion"
+    strategy s   is "Gamma strategy"
+    @support abs is "Gamma abstract support"
+
+    s   supports c
+    abs supports s
+}

--- a/examples/invalid/020_load_glob_nomatch.jd
+++ b/examples/invalid/020_load_glob_nomatch.jd
@@ -1,0 +1,6 @@
+// A glob that matches no file is a fatal error (likely a typo or wrong path).
+load "globs/none_*.jd" as lib
+
+justification j implements lib:alpha {
+    evidence lib:alpha:abs is "unreachable"
+}

--- a/examples/invalid/021_load_glob_invalid.jd
+++ b/examples/invalid/021_load_glob_invalid.jd
@@ -1,0 +1,7 @@
+// A malformed glob pattern (unbalanced '[') is a fatal error, reported as a
+// diagnostic rather than crashing the compiler.
+load "globs/[.jd" as lib
+
+justification j implements lib:alpha {
+    evidence lib:alpha:abs is "unreachable"
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
@@ -23,13 +23,17 @@ import ca.mcscert.jpipe.model.Unit;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 /**
@@ -141,9 +145,34 @@ public final class LoadResolver
 			Set<Path> visited, Set<String> loaded) {
 		logger.debug("Expanding load [{}] as [{}]", load.path(),
 				load.namespace());
-		Path resolved = Paths.get(ctx.sourcePath()).toAbsolutePath().normalize()
-				.getParent().resolve(load.path()).normalize();
+		Path base = Paths.get(ctx.sourcePath()).toAbsolutePath().normalize()
+				.getParent();
 
+		if (!isGlob(load.path())) {
+			Path resolved = base.resolve(load.path()).normalize();
+			return expandOne(resolved, load, ctx, visited, loaded);
+		}
+
+		List<Path> matches = matchGlob(base, load.path());
+		if (matches.isEmpty()) {
+			ctx.fatal("No file matches load pattern '" + load.path() + "'");
+			return List.of();
+		}
+		List<Command> result = new ArrayList<>();
+		for (Path resolved : matches) {
+			result.addAll(expandOne(resolved, load, ctx, visited, loaded));
+		}
+		return result;
+	}
+
+	/**
+	 * Expands a single resolved file into its (recursively resolved and
+	 * optionally namespace-prefixed) command list. Cycle detection and
+	 * duplicate suppression are performed here, per file, so they work
+	 * identically for a literal load and for each match of a glob pattern.
+	 */
+	private List<Command> expandOne(Path resolved, LoadDirective load,
+			CompilationContext ctx, Set<Path> visited, Set<String> loaded) {
 		if (visited.contains(resolved)) {
 			logger.debug("Circular load detected: [{}], skipping", resolved);
 			ctx.fatal("Circular load detected: " + resolved);
@@ -181,6 +210,36 @@ public final class LoadResolver
 			return List.of();
 		} finally {
 			subCtx.diagnostics().forEach(ctx::report);
+		}
+	}
+
+	/**
+	 * Tells whether a load path is a glob pattern (rather than a literal path).
+	 * A literal path keeps the historical single-file behavior, including the
+	 * "Cannot open loaded file" fatal error when it does not exist.
+	 */
+	private static boolean isGlob(String path) {
+		return path.chars()
+				.anyMatch(c -> c == '*' || c == '?' || c == '[' || c == '{');
+	}
+
+	/**
+	 * Resolves a glob pattern against {@code base}, returning the matching
+	 * regular files as absolute, normalized paths in a deterministic
+	 * (lexicographic) order. Standard glob semantics apply: {@code *} does not
+	 * cross directory boundaries, while {@code **} does.
+	 */
+	private static List<Path> matchGlob(Path base, String pattern) {
+		PathMatcher matcher = FileSystems.getDefault()
+				.getPathMatcher("glob:" + pattern);
+		try (Stream<Path> walk = Files.walk(base)) {
+			return walk.filter(Files::isRegularFile)
+					.filter(p -> matcher.matches(base.relativize(p)))
+					.map(p -> p.toAbsolutePath().normalize()).sorted().toList();
+		} catch (IOException e) {
+			logger.debug("Cannot walk '{}' for pattern '{}': {}", base, pattern,
+					e.getMessage());
+			return List.of();
 		}
 	}
 

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
@@ -23,6 +23,7 @@ import ca.mcscert.jpipe.model.Unit;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import org.antlr.v4.runtime.tree.ParseTree;
 
@@ -153,7 +155,18 @@ public final class LoadResolver
 			return expandOne(resolved, load, ctx, visited, loaded);
 		}
 
-		List<Path> matches = matchGlob(base, load.path());
+		List<Path> matches;
+		try {
+			matches = matchGlob(base, load.path());
+		} catch (PatternSyntaxException e) {
+			ctx.fatal("Invalid glob in load pattern '" + load.path() + "': "
+					+ e.getDescription());
+			return List.of();
+		} catch (IOException | UncheckedIOException e) {
+			ctx.fatal("Cannot expand load pattern '" + load.path() + "': "
+					+ e.getMessage());
+			return List.of();
+		}
 		if (matches.isEmpty()) {
 			ctx.fatal("No file matches load pattern '" + load.path() + "'");
 			return List.of();
@@ -228,18 +241,22 @@ public final class LoadResolver
 	 * regular files as absolute, normalized paths in a deterministic
 	 * (lexicographic) order. Standard glob semantics apply: {@code *} does not
 	 * cross directory boundaries, while {@code **} does.
+	 *
+	 * @throws PatternSyntaxException
+	 *             if {@code pattern} is not a valid glob (e.g. an unbalanced
+	 *             {@code [}); reported as a FATAL by the caller.
+	 * @throws IOException
+	 *             if walking {@code base} fails; reported as a FATAL by the
+	 *             caller so an IO failure is not misclassified as a no-match.
 	 */
-	private static List<Path> matchGlob(Path base, String pattern) {
+	private static List<Path> matchGlob(Path base, String pattern)
+			throws IOException {
 		PathMatcher matcher = FileSystems.getDefault()
 				.getPathMatcher("glob:" + pattern);
 		try (Stream<Path> walk = Files.walk(base)) {
 			return walk.filter(Files::isRegularFile)
 					.filter(p -> matcher.matches(base.relativize(p)))
 					.map(p -> p.toAbsolutePath().normalize()).sorted().toList();
-		} catch (IOException e) {
-			logger.debug("Cannot walk '{}' for pattern '{}': {}", base, pattern,
-					e.getMessage());
-			return List.of();
 		}
 	}
 

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
@@ -91,6 +91,18 @@ class LoadResolverGlobTest {
 	}
 
 	@Test
+	void invalidGlobSyntaxIsAFatalErrorAndDoesNotThrow() throws IOException {
+		writeTemplate("a.jd", "alpha");
+
+		// "[.jd" is an unbalanced glob; it must not crash compilation.
+		CompilationContext ctx = compile("[.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isTrue();
+		assertThat(fatalMessages(ctx))
+				.anyMatch(m -> m.contains("Invalid glob in load pattern"));
+	}
+
+	@Test
 	void globMatchingTheSourceFileIsReportedAsACycle() throws IOException {
 		writeTemplate("root.jd", "root");
 

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
@@ -1,0 +1,145 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.mcscert.jpipe.commands.Command;
+import ca.mcscert.jpipe.commands.creation.CreateTemplate;
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.Diagnostic;
+import ca.mcscert.jpipe.operators.OperatorRegistry;
+import ca.mcscert.jpipe.operators.UnificationEquivalenceRegistry;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LoadResolverGlobTest {
+
+	@TempDir
+	private Path dir;
+
+	@Test
+	void globExpandsIntoEveryMatchingFileInSortedOrder() throws IOException {
+		writeTemplate("c.jd", "gamma");
+		writeTemplate("a.jd", "alpha");
+		writeTemplate("b.jd", "beta");
+
+		CompilationContext ctx = compile("*.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("alpha", "beta", "gamma");
+	}
+
+	@Test
+	void singleStarDoesNotCrossDirectoryBoundaries() throws IOException {
+		writeTemplate("top.jd", "top");
+		writeTemplate("nested/deep.jd", "deep");
+
+		CompilationContext ctx = compile("*.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("top");
+	}
+
+	@Test
+	void doubleStarSlashMatchesNestedFilesOnly() throws IOException {
+		writeTemplate("top.jd", "top");
+		writeTemplate("nested/deep.jd", "deep");
+
+		// Java NIO glob: "**/*.jd" requires a directory segment, so a
+		// top-level file does not match.
+		CompilationContext ctx = compile("**/*.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("deep");
+	}
+
+	@Test
+	void doubleStarMatchesEveryDepthIncludingTopLevel() throws IOException {
+		writeTemplate("top.jd", "top");
+		writeTemplate("nested/deep.jd", "deep");
+
+		// Java NIO glob: "**.jd" matches any .jd at any depth.
+		CompilationContext ctx = compile("**.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("deep", "top");
+	}
+
+	@Test
+	void sharedNamespaceIsAppliedToEveryMatchedFile() throws IOException {
+		writeTemplate("a.jd", "alpha");
+		writeTemplate("b.jd", "beta");
+
+		CompilationContext ctx = compile("*.jd", "lib");
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("lib:alpha", "lib:beta");
+	}
+
+	@Test
+	void zeroMatchesIsAFatalError() throws IOException {
+		writeTemplate("a.jd", "alpha");
+
+		CompilationContext ctx = compile("none_*.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isTrue();
+		assertThat(fatalMessages(ctx))
+				.anyMatch(m -> m.contains("No file matches load pattern"));
+	}
+
+	@Test
+	void globMatchingTheSourceFileIsReportedAsACycle() throws IOException {
+		writeTemplate("root.jd", "root");
+
+		CompilationContext ctx = compile("root.jd", null,
+				dir.resolve("root.jd").toString());
+
+		assertThat(ctx.hasFatalErrors()).isTrue();
+		assertThat(fatalMessages(ctx))
+				.anyMatch(m -> m.contains("Circular load detected"));
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private List<Command> result;
+
+	private CompilationContext compile(String pattern, String namespace)
+			throws IOException {
+		return compile(pattern, namespace, dir.resolve("main.jd").toString());
+	}
+
+	private CompilationContext compile(String pattern, String namespace,
+			String sourcePath) {
+		CompilationContext ctx = new CompilationContext(sourcePath);
+		LoadResolver resolver = new LoadResolver(new OperatorRegistry(),
+				new UnificationEquivalenceRegistry());
+		List<Command> input = List
+				.of(new LoadResolver.LoadDirective(pattern, namespace));
+		this.result = resolver.fire(input, ctx);
+		return ctx;
+	}
+
+	private List<String> templateNames() {
+		return result.stream().filter(CreateTemplate.class::isInstance)
+				.map(CreateTemplate.class::cast).map(CreateTemplate::identifier)
+				.toList();
+	}
+
+	private static List<String> fatalMessages(CompilationContext ctx) {
+		return ctx.diagnostics().stream().filter(Diagnostic::isFatal)
+				.map(Diagnostic::message).toList();
+	}
+
+	private void writeTemplate(String relativePath, String name)
+			throws IOException {
+		Path file = dir.resolve(relativePath);
+		Files.createDirectories(file.getParent());
+		Files.writeString(file,
+				"template " + name + " { conclusion c is \"c\" }\n");
+	}
+}

--- a/jpipe-compiler/src/test/resources/features/load.feature
+++ b/jpipe-compiler/src/test/resources/features/load.feature
@@ -97,3 +97,9 @@ Feature: Load directive
     When I compile it into a unit
     Then the compilation fails with a fatal error
       And a fatal error mentions "No file matches load pattern"
+
+  Scenario: a malformed glob pattern is a fatal error, not a crash
+    Given the source file "invalid/021_load_glob_invalid.jd"
+    When I compile it into a unit
+    Then the compilation fails with a fatal error
+      And a fatal error mentions "Invalid glob in load pattern"

--- a/jpipe-compiler/src/test/resources/features/load.feature
+++ b/jpipe-compiler/src/test/resources/features/load.feature
@@ -64,3 +64,36 @@ Feature: Load directive
     When I compile it into a unit
     Then the compilation has validation errors
       And a validation error is reported for rule "execution-error"
+
+  Scenario: a glob load expands into every matching file, imported flat
+    Given the source file "020_load_glob_flat.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+      And the unit contains a template named "alpha"
+      And the unit contains a template named "beta"
+      And the unit contains a justification named "alpha_justification"
+      And the unit contains a justification named "beta_justification"
+
+  Scenario: a glob load with a namespace shares that namespace across matches
+    Given the source file "021_load_glob_namespace.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+      And the unit contains a template named "lib:alpha"
+      And the unit contains a template named "lib:beta"
+      And the unit contains a justification named "alpha_justification"
+      And the unit contains a justification named "beta_justification"
+
+  Scenario: a recursive glob load also matches nested directories
+    Given the source file "022_load_glob_recursive.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+      And the unit contains a template named "lib:alpha"
+      And the unit contains a template named "lib:beta"
+      And the unit contains a template named "lib:gamma"
+      And the unit contains a justification named "gamma_justification"
+
+  Scenario: a glob load that matches no file is a fatal error
+    Given the source file "invalid/020_load_glob_nomatch.jd"
+    When I compile it into a unit
+    Then the compilation fails with a fatal error
+      And a fatal error mentions "No file matches load pattern"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,8 @@ nav:
       - adr/0018-composition-operators.md
       - adr/0019-ai-assisted-development.md
       - adr/0020-tag-triggered-release-pipeline.md
+      - adr/0021-pin-runtime-binary-to-declared-dependency.md
+      - adr/0022-glob-patterns-in-load.md
 plugins:
   - search
 


### PR DESCRIPTION
This pull request introduces support for glob patterns in the `load` directive, allowing users to import multiple files matching a pattern in a single line, greatly simplifying project configuration and maintenance. The implementation uses Java NIO glob semantics and ensures backward compatibility, deterministic ordering, and proper error handling. Comprehensive documentation, examples, and tests have been added to cover the new behavior.

**Glob pattern support in `load` directive:**

* [`jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java`](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1L144-R175): Refactored the `expand` method to detect glob patterns and expand them into all matching files. Added `isGlob` and `matchGlob` helpers for pattern detection and matching, ensuring matched files are processed with cycle detection, deduplication, and namespace handling. [[1]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1L144-R175) [[2]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1R216-R245) [[3]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1R26-R36)

**Documentation and design updates:**

* [`docs/adr/0022-glob-patterns-in-load.md`](diffhunk://#diff-500e36170f9da69c6522c151456b658da96835052a45fbed43f53865d5281258R1-R122): Added a new ADR describing the rationale, design decisions, and implementation details for glob patterns in `load`.
* [`docs/design/steps.md`](diffhunk://#diff-b27206f7bb411dac51596bac9d7d9c98856e4e355e66240973f9cddabd6b284fR172-R177): Updated to document glob pattern support, error handling, and deterministic order.
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R50-R51): Registered the new ADR in the documentation navigation.

**Examples and test cases:**

* Added example files and scenarios demonstrating flat and recursive glob loads, namespace sharing, and error cases: `examples/020_load_glob_flat.jd`, `examples/021_load_glob_namespace.jd`, `examples/022_load_glob_recursive.jd`, `examples/invalid/020_load_glob_nomatch.jd`, and supporting model files under `examples/globs/`. [[1]](diffhunk://#diff-724b6a17c72abedeba4038a482e08c511ab70405cde57d0819456fb094d15699R1-R11) [[2]](diffhunk://#diff-8c499f926b7574a266f7ed16822185c47e5220b8c82e6c58c5ca34ba549512beR1-R10) [[3]](diffhunk://#diff-a7c73b55aac6ad6cb331d3c7a3fcd5c1ed2154822359d753ba40a49c0d8ba93fR1-R9) [[4]](diffhunk://#diff-735785169ed9c5e9c08055ef92d34ee2fc3feb58d61faf240b826e69a56e6f9dR1-R6) [[5]](diffhunk://#diff-cc843cecf9c09bee62c106e19ca3c7ee12914315123627ebd539bb68bf3f99d5R1-R9) [[6]](diffhunk://#diff-a395c29c4e749a55df223df57ed12e0f96f9a3dd3c36bbadd3191d57c1c54bdcR1-R9) [[7]](diffhunk://#diff-276428419aa1fda59e1ce7194e366ac1c754bf636b98ddcf4395629f0525d350R1-R9)
* [`jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java`](diffhunk://#diff-889802d0061e2203424e01f60ee829e5defb4032df28b6191805842c12c30883R1-R145): Added unit tests covering all glob behaviors, including matching, ordering, namespace handling, and error conditions.
* [`jpipe-compiler/src/test/resources/features/load.feature`](diffhunk://#diff-65a1ce18d596faebd516ae6ed287f52d594b2a1ff3fd51548615304c403f1f2bR67-R99): Added feature tests for the new glob loading scenarios and error handling.

**Developer workflow guidance:**

* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R256-R294): Added a section emphasizing the use of code-review-graph MCP tools for efficient codebase navigation and review.