### PR TITLE
Fix template instantiation issues and adopt new branching model

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,6 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.mvn_version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v6
@@ -54,43 +52,3 @@ jobs:
           name: jpipe-cli-${{ steps.mvn_version.outputs.version }}
           path: ${{ steps.locate.outputs.path }}
           if-no-files-found: error
-
-
-  release:
-    name: Publish unstable release
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Download fat JAR artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: jpipe-cli-${{ needs.build.outputs.version }}
-          path: dist
-
-      - name: Publish unstable release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          JAR_FILE="dist/jpipe-cli-${VERSION}.jar"
-          [ -f "$JAR_FILE" ] || { echo "ERROR: $JAR_FILE not found"; find dist -maxdepth 2 || echo "dist dir missing"; exit 1; }
-          cp "$JAR_FILE" jpipe-cli.jar
-
-          # Re-point the unstable tag to this commit
-          git tag -f unstable
-          git push origin unstable --force
-
-          # Delete the existing pre-release (ignore error if it does not exist yet)
-          gh release delete unstable --yes 2>/dev/null || true
-
-          gh release create unstable jpipe-cli.jar \
-            --title "Unstable build ($(date -u '+%Y-%m-%d %H:%M UTC'))" \
-            --notes $'This pre-release is rebuilt on every push to `dev`.\n\nIt tracks the latest integrated code and is **not intended for production use**.' \
-            --prerelease \
-            --target "$GITHUB_SHA"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
     name: Publish unstable release
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
     permissions:
       contents: write
 
@@ -91,6 +91,6 @@ jobs:
 
           gh release create unstable jpipe-cli.jar \
             --title "Unstable build ($(date -u '+%Y-%m-%d %H:%M UTC'))" \
-            --notes $'This pre-release is rebuilt on every push to `main`.\n\nIt tracks the latest code and is **not intended for production use**.' \
+            --notes $'This pre-release is rebuilt on every push to `dev`.\n\nIt tracks the latest integrated code and is **not intended for production use**.' \
             --prerelease \
             --target "$GITHUB_SHA"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - main
+      - dev
 
 permissions:
   contents: write

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     types: [opened, synchronize, reopened]
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,23 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- A model implementing a template may now only override the template's
+  `@support` placeholders; referencing a template-internal element (a strategy
+  or conclusion) is rejected with a `[reference-into-template]` error.
+
 ### Changed
 - PPA packages are now published for Ubuntu `noble` (24.04 LTS), `resolute`
   (26.04 LTS), and `stonking` per the new Ubuntu release target policy
   (ADR-0023); `jammy` (22.04 LTS) and `questing` (25.10) are no longer targeted.
+
+### Fixed
+- DOT export now quotes template cluster ids, so a namespaced template name
+  (e.g. loaded via `load "…" as ns`) no longer produces a malformed Graphviz
+  graph.
+- Overriding a template's `@support` with an evidence no longer leaves a stale
+  placeholder reference on the inherited strategy, which could render a
+  duplicate arrow in DOT export.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+---
+
+## [2.2.0] — 2026-07-18
+
 ### Added
 - A model implementing a template may now only override the template's
   `@support` placeholders; referencing a template-internal element (a strategy
@@ -27,6 +31,11 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 - PPA packages are now published for Ubuntu `noble` (24.04 LTS), `resolute`
   (26.04 LTS), and `stonking` per the new Ubuntu release target policy
   (ADR-0023); `jammy` (22.04 LTS) and `questing` (25.10) are no longer targeted.
+
+### Removed
+- The rolling `unstable` GitHub pre-release and its force-pushed `unstable` tag
+  are retired (ADR-0024); use the tip of `dev` or a per-run CI build artifact for
+  the latest integrated build.
 
 ### Fixed
 - DOT export now quotes template cluster ids, so a namespaced template name
@@ -258,7 +267,8 @@ server.
 ### Added
 - Initial commit: first version of the compiler.
 
-[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.4...v2.1.0
 [2.0.4]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.2...v2.0.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,11 @@ The repository uses a two-tier branching model (ADR-0024):
 - **Hotfixes** — branch from `main`, merge into `main`, release via a patch tag,
   then merge back into `dev`.
 
-CI follows the model: the `unstable` rolling pre-release (`build.yml`) and docs
-deploy (`docs.yml`) track `dev`; `sonar.yml` analyses both branches;
-`release.yml` triggers on tags and requires the tag to be on `main`.
+CI follows the model: `build.yml` runs on every push/PR (fat JAR available as a
+per-run artifact); docs deploy (`docs.yml`) tracks `dev`; `sonar.yml` analyses
+both branches; `release.yml` triggers on tags and requires the tag to be on
+`main`. There is no rolling `unstable` pre-release — the tip of `dev` is the
+latest integrated build (ADR-0024).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,32 @@ This file provides guidance to Claude Code when working with this repository.
 ## Critical Rules
 
 - **Never commit or push code without explicit user consent.** Always show the diff and ask before running any `git commit` or `git push` command.
+- **Never commit directly to `main`.** `main` is release-only (see [Git Workflow](#git-workflow)). All feature and fix work branches off `dev` and merges back into `dev`.
+
+---
+
+## Git Workflow
+
+The repository uses a two-tier branching model (ADR-0024):
+
+- **`main` — release-only.** Every commit on `main` is a released, tagged
+  version; `main@HEAD` always equals the latest published release. Never commit
+  or merge feature work directly to `main`.
+- **`dev` — integration branch.** The default target for all day-to-day work.
+  It holds "everything merged since the last release," and the `CHANGELOG.md`
+  `## [Unreleased]` section lives on `dev`.
+- **Topic branches** — `feat/…`, `fix/…`, `chore/…`, `docs/…`. Branch **from
+  `dev`**, merge back **into `dev`** (normally via PR). Merging into `dev` is
+  what adds the change to `[Unreleased]`.
+- **Releasing** — merge `dev` → `main`, rename `[Unreleased]` to the version,
+  push a `vX.Y.Z` tag on `main` (this triggers `release.yml`, ADR-0020), then
+  merge `main` back into `dev`.
+- **Hotfixes** — branch from `main`, merge into `main`, release via a patch tag,
+  then merge back into `dev`.
+
+CI follows the model: the `unstable` rolling pre-release (`build.yml`) and docs
+deploy (`docs.yml`) track `dev`; `sonar.yml` analyses both branches;
+`release.yml` triggers on tags and requires the tag to be on `main`.
 
 ---
 
@@ -167,6 +193,8 @@ Architecture decisions live in `docs/adr/`. Notable ones:
 | ADR-0012 | Qualified ids and template expansion |
 | ADR-0016 | Error management |
 | ADR-0018 | Composition operators |
+| ADR-0020 | Tag-triggered release pipeline |
+| ADR-0024 | Git branching model (`dev` integration, `main` release-only) |
 
 ---
 
@@ -208,9 +236,11 @@ Rules:
 - **How:** Write one concise, user-facing sentence describing the *effect*, not
   the implementation. Reference the PR or issue number when there is one
   (e.g. `(#136)`). Match the tone and style of existing entries.
-- **Releasing (maintainer action):** When cutting a release, rename
+- **Releasing (maintainer action):** Cutting a release is a `dev` → `main`
+  merge (see [Git Workflow](#git-workflow)). As part of it, rename
   `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, add the git-compare link at
-  the bottom, and open a fresh empty `## [Unreleased]` section above it.
+  the bottom, and open a fresh empty `## [Unreleased]` section above it. The
+  `vX.Y.Z` tag is pushed on `main`.
 
 Do not edit already-released sections except to correct an error.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 - **Never commit or push code without explicit user consent.** Always show the diff and ask before running any `git commit` or `git push` command.
 - **Never commit directly to `main`.** `main` is release-only (see [Git Workflow](#git-workflow)). All feature and fix work branches off `dev` and merges back into `dev`.
+- **Never merge a pull request or push a git tag.** Merging (including the release `dev`→`main` merge) and tagging (`vX.Y.Z`) are **human-only** actions. Claude prepares the branch/PR and hands off; it does not run `gh pr merge`, merge branches into `dev`/`main`, or push tags.
 
 ---
 
@@ -24,7 +25,9 @@ The repository uses a two-tier branching model (ADR-0024):
   what adds the change to `[Unreleased]`.
 - **Releasing** — merge `dev` → `main`, rename `[Unreleased]` to the version,
   push a `vX.Y.Z` tag on `main` (this triggers `release.yml`, ADR-0020), then
-  merge `main` back into `dev`.
+  merge `main` back into `dev`. **The `dev`→`main` merge and the tag push are
+  human-only actions** (see Critical Rules); Claude only prepares the
+  release-prep branch/PR (changelog finalization, version bump).
 - **Hotfixes** — branch from `main`, merge into `main`, release via a patch tag,
   then merge back into `dev`.
 
@@ -239,10 +242,11 @@ Rules:
   the implementation. Reference the PR or issue number when there is one
   (e.g. `(#136)`). Match the tone and style of existing entries.
 - **Releasing (maintainer action):** Cutting a release is a `dev` → `main`
-  merge (see [Git Workflow](#git-workflow)). As part of it, rename
-  `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, add the git-compare link at
-  the bottom, and open a fresh empty `## [Unreleased]` section above it. The
-  `vX.Y.Z` tag is pushed on `main`.
+  merge (see [Git Workflow](#git-workflow)). Claude prepares a release-prep
+  branch that renames `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, adds the
+  git-compare link at the bottom, and opens a fresh empty `## [Unreleased]`
+  section above it. **The maintainer (human) performs the `dev`→`main` merge and
+  pushes the `vX.Y.Z` tag on `main`** — Claude does not merge or tag.
 
 Do not edit already-released sections except to correct an error.
 

--- a/docs/adr/0024-git-branching-model.md
+++ b/docs/adr/0024-git-branching-model.md
@@ -14,9 +14,9 @@ bug fixes, chores, and release-preparation commits all landed directly on
   `release.yml` already verifies that the tag points at a commit on `main`.
   Nothing else about `main` distinguishes "released" commits from
   "work-in-progress" commits — the branch is a mix of both.
-- **`main` also drives the rolling `unstable` snapshot.** The `publish-unstable`
-  job in `build.yml` re-points the `unstable` pre-release on every push to
-  `main`. So `main` is simultaneously the integration branch *and* the release
+- **`main` also drives the rolling `unstable` snapshot.** A job in `build.yml`
+  re-points the `unstable` pre-release on every push to `main`. So `main` is
+  simultaneously the integration branch *and* the release
   branch, and the `CHANGELOG.md` `[Unreleased]` section accumulates directly on
   the same branch that is supposed to represent shipped software.
 
@@ -54,8 +54,9 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
 
 ### CI consequences (applied in this change)
 
-- **`build.yml` `publish-unstable` is removed.** With `dev` in place, the tip of
-  `dev` *is* the rolling "latest integrated" state, so a separate `unstable`
+- **The `unstable` pre-release job in `build.yml` is removed.** With `dev` in
+  place, the tip of `dev` *is* the rolling "latest integrated" state, so a
+  separate `unstable`
   GitHub pre-release (and its force-pushed `unstable` tag) is redundant. This
   supersedes the `unstable` pre-release introduced by
   [ADR-0020](0020-tag-triggered-release-pipeline.md); per-run fat-JAR artifacts

--- a/docs/adr/0024-git-branching-model.md
+++ b/docs/adr/0024-git-branching-model.md
@@ -1,0 +1,101 @@
+# ADR-0024: Git Branching Model — `dev` for Integration, `main` for Releases
+
+**Date:** 2026-07-18
+**Status:** Accepted
+
+## Context
+
+Until now the repository used a single long-lived branch, `main`. Feature work,
+bug fixes, chores, and release-preparation commits all landed directly on
+`main`, interleaved. Two forces make this arrangement increasingly awkward:
+
+- **Releases are tag-driven.** [ADR-0020](0020-tag-triggered-release-pipeline.md)
+  publishes a stable release only when a `v*.*.*` tag is pushed, and
+  `release.yml` already verifies that the tag points at a commit on `main`.
+  Nothing else about `main` distinguishes "released" commits from
+  "work-in-progress" commits — the branch is a mix of both.
+- **`main` also drives the rolling `unstable` snapshot.** The `publish-unstable`
+  job in `build.yml` re-points the `unstable` pre-release on every push to
+  `main`. So `main` is simultaneously the integration branch *and* the release
+  branch, and the `CHANGELOG.md` `[Unreleased]` section accumulates directly on
+  the same branch that is supposed to represent shipped software.
+
+There is no branch whose state answers the question "what is the latest
+*released* version?" without inspecting tags, and no branch that represents
+"everything merged since the last release" other than `main` itself.
+
+## Decision
+
+Adopt a two-tier long-lived branch model.
+
+- **`main` is release-only.** Every commit on `main` corresponds to a released,
+  tagged version. `main` moves *only* when a release is cut. Its `HEAD` always
+  equals the most recent published release. No feature or fix is committed to
+  `main` directly.
+- **`dev` is the integration branch.** It is the default target for day-to-day
+  work and always contains "everything merged since the last release." The
+  `CHANGELOG.md` `[Unreleased]` section lives and grows on `dev`.
+- **Feature branches** (`feat/…`, `fix/…`, `chore/…`, `docs/…`) branch **from
+  `dev`** and merge back **into `dev`**, normally via pull request. Merging a
+  branch into `dev` is what adds its entry to `[Unreleased]`.
+- **Releasing is `dev` → `main` + tag.** To release, `dev` is merged into
+  `main`, the release-preparation commit renames `[Unreleased]` to
+  `## [X.Y.Z] — YYYY-MM-DD` (see the changelog policy in `CLAUDE.md`), and a
+  `vX.Y.Z` tag is pushed on `main`. The tag triggers `release.yml`
+  (ADR-0020). After the release, `main` is merged back into `dev` so the two
+  branches share the release commit.
+- **Hotfixes** for an already-released version branch from `main` (`fix/…`),
+  merge into `main`, are released via a patch tag, and are then merged back into
+  `dev`.
+
+Version numbering (semantic versioning, [ADR-0001](0001-semver-versioning.md))
+and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
+*which branch* carries integration versus release state.
+
+### CI consequences (applied in this change)
+
+- **`build.yml` `publish-unstable`** now triggers on push to **`dev`** instead
+  of `main` — the rolling snapshot tracks the integration branch, which is where
+  continuous merges now happen. (`main` would otherwise only move at release
+  time, making the "unstable" snapshot stale.)
+- **`sonar.yml`** runs its push analysis on both `main` and `dev` so the
+  integration branch is quality-gated.
+- **`docs.yml`** deploys documentation from **`dev`**, so ADRs and design docs
+  publish when they are integrated rather than only at release time.
+- **`release.yml`** is unchanged: it still triggers on `v*.*.*` tags and still
+  requires the tag to be an ancestor of `main`.
+
+## Rationale
+
+- **`main` becomes a truthful release ledger.** `git log main` is exactly the
+  release history; `main@HEAD` is exactly what users get from Homebrew / the PPA.
+  This mirrors the intent already encoded in `release.yml`'s "tag must be on
+  main" check, and makes it structural rather than incidental.
+- **`[Unreleased]` gets a natural home.** The changelog's unreleased section is,
+  by definition, "merged but not released" — precisely the contents of `dev`.
+  Keeping it off `main` removes the oddity of a shipped branch carrying an
+  `[Unreleased]` heading between releases.
+- **Deliberate releases, continuous integration.** Work still flows
+  continuously (into `dev`, with an `unstable` snapshot), while releasing stays
+  an explicit, low-frequency act (a `dev` → `main` merge plus a tag), consistent
+  with ADR-0020's "releases are deliberate" rationale.
+- **Low ceremony.** Two long-lived branches and short-lived topic branches is
+  the smallest model that separates integration from release; it does not
+  require release branches or a full git-flow.
+
+## Consequences
+
+- A `dev` branch is created from the current `main` and becomes the default
+  branch for development; branch protection should require PRs into `dev` and
+  forbid direct pushes to `main`.
+- Contributors branch from `dev`, not `main`. The default branch on the remote
+  should be set to `dev` so clones and PRs target it by default.
+- The release checklist gains a first step: merge `dev` into `main` before
+  tagging (and merge `main` back into `dev` afterwards). The existing
+  ADR-0020 / ADR-0023 release steps follow unchanged.
+- The `unstable` GitHub pre-release now reflects `dev`. Its notes ("rebuilt on
+  every push") are updated to reference `dev`.
+- Published documentation tracks `dev`; a doc fix is visible once merged, not
+  only after the next release.
+- Existing open work branched from `main` (e.g. the branch introducing this
+  ADR) is retargeted onto `dev`.

--- a/docs/adr/0024-git-branching-model.md
+++ b/docs/adr/0024-git-branching-model.md
@@ -54,10 +54,12 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
 
 ### CI consequences (applied in this change)
 
-- **`build.yml` `publish-unstable`** now triggers on push to **`dev`** instead
-  of `main` — the rolling snapshot tracks the integration branch, which is where
-  continuous merges now happen. (`main` would otherwise only move at release
-  time, making the "unstable" snapshot stale.)
+- **`build.yml` `publish-unstable` is removed.** With `dev` in place, the tip of
+  `dev` *is* the rolling "latest integrated" state, so a separate `unstable`
+  GitHub pre-release (and its force-pushed `unstable` tag) is redundant. This
+  supersedes the `unstable` pre-release introduced by
+  [ADR-0020](0020-tag-triggered-release-pipeline.md); per-run fat-JAR artifacts
+  remain available on each Actions run.
 - **`sonar.yml`** runs its push analysis on both `main` and `dev` so the
   integration branch is quality-gated.
 - **`docs.yml`** deploys documentation from **`dev`**, so ADRs and design docs
@@ -76,9 +78,9 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
   Keeping it off `main` removes the oddity of a shipped branch carrying an
   `[Unreleased]` heading between releases.
 - **Deliberate releases, continuous integration.** Work still flows
-  continuously (into `dev`, with an `unstable` snapshot), while releasing stays
-  an explicit, low-frequency act (a `dev` → `main` merge plus a tag), consistent
-  with ADR-0020's "releases are deliberate" rationale.
+  continuously into `dev` (whose `HEAD` is the latest integrated code), while
+  releasing stays an explicit, low-frequency act (a `dev` → `main` merge plus a
+  tag), consistent with ADR-0020's "releases are deliberate" rationale.
 - **Low ceremony.** Two long-lived branches and short-lived topic branches is
   the smallest model that separates integration from release; it does not
   require release branches or a full git-flow.
@@ -93,8 +95,8 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
 - The release checklist gains a first step: merge `dev` into `main` before
   tagging (and merge `main` back into `dev` afterwards). The existing
   ADR-0020 / ADR-0023 release steps follow unchanged.
-- The `unstable` GitHub pre-release now reflects `dev`. Its notes ("rebuilt on
-  every push") are updated to reference `dev`.
+- The `unstable` GitHub pre-release and its `unstable` tag are retired; users who
+  want the latest build take the tip of `dev` or a per-run Actions artifact.
 - Published documentation tracks `dev`; a doc fix is visible once merged, not
   only after the next release.
 - Existing open work branched from `main` (e.g. the branch introducing this

--- a/examples/invalid/022_reference_into_template.jd
+++ b/examples/invalid/022_reference_into_template.jd
@@ -1,0 +1,29 @@
+/*********************************
+ * jPipe  -  Reference Examples  *
+ * @author   Sebastien Mosser    *
+ * @compiler 2.x                 *
+ *********************************/
+
+// A valid template exposing two abstract supports.
+template quality {
+  conclusion ready is "Version 2.0 is ready to ship"
+  strategy gates is "All release gates pass"
+  gates supports ready
+
+  @support tested is "Testing is demonstrated"
+  tested supports gates
+
+  @support documented is "Documentation is demonstrated"
+  documented supports gates
+}
+
+// This justification is only allowed to override the @support placeholders.
+// Referencing "quality:gates" (a template-internal strategy) reaches inside
+// the parent template and must be rejected.
+justification readiness implements quality {
+  evidence quality:tested is "The test suite passes"
+  quality:tested supports quality:gates
+
+  evidence quality:documented is "CHANGELOG.md updated in this PR"
+  quality:documented supports quality:gates
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticCodes.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticCodes.java
@@ -34,6 +34,13 @@ public final class DiagnosticCodes {
 	/** An {@code implements} directive could not be applied. */
 	public static final String IMPLEMENTS_ERROR = "[implements-error]";
 
+	/**
+	 * A model implementing a template references a template-internal element (a
+	 * strategy or conclusion) instead of only overriding its {@code @support}
+	 * placeholders.
+	 */
+	public static final String REFERENCE_INTO_TEMPLATE = "[reference-into-template]";
+
 	// ---- support / element resolution ---------------------------------------
 
 	/**

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ExecutionFailureDiagnostics.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ExecutionFailureDiagnostics.java
@@ -4,6 +4,7 @@ import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
 import ca.mcscert.jpipe.commands.linking.ImplementsTemplate;
 import ca.mcscert.jpipe.commands.linking.OverrideAbstractSupport;
+import ca.mcscert.jpipe.commands.linking.ReferenceIntoTemplateException;
 import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import ca.mcscert.jpipe.compiler.model.DiagnosticCodes;
 import ca.mcscert.jpipe.model.SourceLocation;
@@ -74,8 +75,12 @@ final class ExecutionFailureDiagnostics {
 							+ cause.getMessage());
 				}
 			}
-			case AddSupport c -> error(ctx, c.location(),
-					DiagnosticCodes.INVALID_SUPPORT + " " + cause.getMessage());
+			case AddSupport c -> {
+				String code = cause instanceof ReferenceIntoTemplateException
+						? DiagnosticCodes.REFERENCE_INTO_TEMPLATE
+						: DiagnosticCodes.INVALID_SUPPORT;
+				error(ctx, c.location(), code + " " + cause.getMessage());
+			}
 			default -> ctx.error(DiagnosticCodes.EXECUTION_ERROR + " " + cmd
 					+ ": " + cause.getMessage());
 		}

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
@@ -244,4 +244,11 @@ public class CompilationSteps {
 				.extracting(Diagnostic::message)
 				.anySatisfy(msg -> assertThat(msg).contains("[" + rule + "]"));
 	}
+
+	@Then("a validation error mentions {string}")
+	public void aValidationErrorMentions(String text) {
+		assertThat(ctx.diagnostics()).filteredOn(Diagnostic::isError)
+				.extracting(Diagnostic::message)
+				.anySatisfy(msg -> assertThat(msg).contains(text));
+	}
 }

--- a/jpipe-compiler/src/test/resources/features/invalid_models.feature
+++ b/jpipe-compiler/src/test/resources/features/invalid_models.feature
@@ -60,6 +60,13 @@ Feature: Consistency and completeness validation
     Then the compilation has validation errors
     And a validation error is reported for rule "acyclic-support"
 
+  Scenario: referencing a template-internal element from an implementor causes a semantic error
+    Given the source file "invalid/022_reference_into_template.jd"
+    When I compile it into a unit
+    Then the compilation has validation errors
+    And a validation error is reported for rule "reference-into-template"
+    And a validation error mentions "quality:gates"
+
   Scenario: mutually implementing templates causes a semantic error
     Given the source file "invalid/010_implements_cycle.jd"
     When I compile it into a unit

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/AddSupport.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/AddSupport.java
@@ -84,11 +84,14 @@ public final class AddSupport extends RegularCommand {
 				.orElseThrow(() -> new NoSuchElementException(
 						"No element with id: " + supporterId));
 
-		if (model.isInheritedNonSupport(supportableId)) {
-			throw new ReferenceIntoTemplateException(supportableId, container);
+		// Check the resolved element ids (findById resolves plain ids to their
+		// qualified form), otherwise a plain id would bypass the restriction.
+		if (model.isInheritedNonSupport(supportable.id())) {
+			throw new ReferenceIntoTemplateException(supportable.id(),
+					container);
 		}
-		if (model.isInheritedNonSupport(supporterId)) {
-			throw new ReferenceIntoTemplateException(supporterId, container);
+		if (model.isInheritedNonSupport(supporter.id())) {
+			throw new ReferenceIntoTemplateException(supporter.id(), container);
 		}
 
 		switch (supportable) {

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/AddSupport.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/AddSupport.java
@@ -84,6 +84,13 @@ public final class AddSupport extends RegularCommand {
 				.orElseThrow(() -> new NoSuchElementException(
 						"No element with id: " + supporterId));
 
+		if (model.isInheritedNonSupport(supportableId)) {
+			throw new ReferenceIntoTemplateException(supportableId, container);
+		}
+		if (model.isInheritedNonSupport(supporterId)) {
+			throw new ReferenceIntoTemplateException(supporterId, container);
+		}
+
 		switch (supportable) {
 			case Conclusion c when supporter instanceof Strategy s ->
 				c.addSupport(s);

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/ReferenceIntoTemplateException.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/ReferenceIntoTemplateException.java
@@ -1,0 +1,18 @@
+package ca.mcscert.jpipe.commands.linking;
+
+/**
+ * Raised when a model implementing a template references a template-internal
+ * element (a strategy or conclusion) instead of only overriding the template's
+ * {@code @support} placeholders. Carries a ready-to-report message; the
+ * compiler layer maps it to a located diagnostic.
+ */
+public final class ReferenceIntoTemplateException extends RuntimeException {
+
+	public ReferenceIntoTemplateException(String referencedId,
+			String container) {
+		super("cannot reference template-internal element '" + referencedId
+				+ "' from '" + container
+				+ "'; a model implementing a template may only override its"
+				+ " @support placeholders");
+	}
+}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
@@ -291,6 +291,23 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 	}
 
 	/**
+	 * Returns {@code true} when {@code id} names an ancestor-template element
+	 * that is <em>not</em> an {@link AbstractSupport} placeholder — i.e.
+	 * template-internal structure (a strategy or conclusion) that a model
+	 * implementing the template must not reference. A model may only override
+	 * the template's {@code @support} placeholders, never reach inside its
+	 * structure.
+	 *
+	 * <p>
+	 * Returns {@code false} for template {@code @support} ids (whether
+	 * overridden or not) and for ids local to this model.
+	 */
+	public boolean isInheritedNonSupport(String id) {
+		Class<? extends JustificationElement> type = ancestorTypes().get(id);
+		return type != null && type != AbstractSupport.class;
+	}
+
+	/**
 	 * Builds a map from qualified element id to its runtime class for every
 	 * element (including the conclusion) in the direct parent template. Because
 	 * the parent's element list was already flattened by its own

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
@@ -292,15 +292,16 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 
 	/**
 	 * Returns {@code true} when {@code id} names an ancestor-template element
-	 * that is <em>not</em> an {@link AbstractSupport} placeholder — i.e.
-	 * template-internal structure (a strategy or conclusion) that a model
-	 * implementing the template must not reference. A model may only override
-	 * the template's {@code @support} placeholders, never reach inside its
-	 * structure.
+	 * of any type <em>other than</em> an {@link AbstractSupport} placeholder (a
+	 * strategy, conclusion, sub-conclusion, or evidence inherited from the
+	 * template) — template-internal structure that a model implementing the
+	 * template must not reference. A model may only override the template's
+	 * {@code @support} placeholders, never reach inside its structure.
 	 *
 	 * <p>
 	 * Returns {@code false} for template {@code @support} ids (whether
-	 * overridden or not) and for ids local to this model.
+	 * overridden or not) and for ids local to this model. The {@code id} must
+	 * be the resolved (qualified) element id.
 	 */
 	public boolean isInheritedNonSupport(String id) {
 		Class<? extends JustificationElement> type = ancestorTypes().get(id);

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
@@ -26,8 +26,19 @@ public final class Strategy implements CommonElement {
 		return label;
 	}
 
+	/**
+	 * Adds {@code supporter} to this strategy. A strategy can never
+	 * legitimately be supported twice by the same element id, so the call is
+	 * idempotent by id: if a supporter with the same id is already present,
+	 * nothing is added.
+	 */
 	public void addSupport(SupportLeaf supporter) {
-		this.supporters.add(supporter);
+		String id = ((JustificationElement) supporter).id();
+		boolean present = supporters.stream()
+				.anyMatch(s -> ((JustificationElement) s).id().equals(id));
+		if (!present) {
+			this.supporters.add(supporter);
+		}
 	}
 
 	public List<SupportLeaf> getSupports() {
@@ -35,13 +46,19 @@ public final class Strategy implements CommonElement {
 	}
 
 	/**
-	 * Replaces {@code oldSupport} with {@code newSupport} in the list of
-	 * supporters.
+	 * Replaces the supporter sharing {@code oldSupport}'s id with
+	 * {@code newSupport}. Matching is by id rather than object identity so that
+	 * an {@link AbstractSupport} placeholder can be swapped for the concrete
+	 * element that overrides it (both share the same qualified id but are
+	 * different objects and types).
 	 */
 	public void replaceSupport(SupportLeaf oldSupport, SupportLeaf newSupport) {
-		int index = supporters.indexOf(oldSupport);
-		if (index != -1) {
-			supporters.set(index, newSupport);
+		String oldId = ((JustificationElement) oldSupport).id();
+		for (int i = 0; i < supporters.size(); i++) {
+			if (((JustificationElement) supporters.get(i)).id().equals(oldId)) {
+				supporters.set(i, newSupport);
+				return;
+			}
 		}
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
@@ -33,9 +33,9 @@ public final class Strategy implements CommonElement {
 	 * nothing is added.
 	 */
 	public void addSupport(SupportLeaf supporter) {
-		String id = ((JustificationElement) supporter).id();
-		boolean present = supporters.stream()
-				.anyMatch(s -> ((JustificationElement) s).id().equals(id));
+		String supporterId = ((JustificationElement) supporter).id();
+		boolean present = supporters.stream().anyMatch(
+				s -> ((JustificationElement) s).id().equals(supporterId));
 		if (!present) {
 			this.supporters.add(supporter);
 		}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/DotExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/DotExporter.java
@@ -239,8 +239,9 @@ public class DotExporter extends AbstractModelExporter {
 			String indent) {
 		String ancName = ancestor.getName();
 
-		builder.append(indent).append("subgraph cluster_").append(ancName)
-				.append(" {").append(System.lineSeparator());
+		builder.append(indent).append("subgraph ")
+				.append(DotLabel.quoted("cluster_" + ancName)).append(" {")
+				.append(System.lineSeparator());
 		builder.append(indent).append(INDENT).append(CLUSTER_ATTRS)
 				.append(System.lineSeparator());
 		builder.append(indent).append(INDENT).append("label=")

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/AddSupportTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/AddSupportTest.java
@@ -12,8 +12,11 @@ import ca.mcscert.jpipe.commands.creation.CreateStrategy;
 import ca.mcscert.jpipe.commands.creation.CreateSubConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateTemplate;
 import ca.mcscert.jpipe.model.Justification;
+import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
 import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
 import ca.mcscert.jpipe.model.elements.JustificationElement;
 import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
@@ -132,6 +135,72 @@ class AddSupportTest {
 			var cmd = new AddSupport("j1", "e1", "s1");
 			assertThatThrownBy(() -> cmd.execute(unit))
 					.isInstanceOf(IllegalArgumentException.class);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Template encapsulation — an implementor may only override @support
+	// placeholders, never reference the parent template's own structure.
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class TemplateEncapsulation {
+
+		@Test
+		void rejectsInheritedStrategyReferencedByQualifiedId() {
+			Unit unit = unitWithImplementation();
+			var cmd = new AddSupport("j", "t:s", "local");
+
+			assertThatThrownBy(() -> cmd.execute(unit))
+					.isInstanceOf(ReferenceIntoTemplateException.class)
+					.hasMessageContaining("t:s");
+		}
+
+		@Test
+		void rejectsInheritedStrategyReferencedByPlainId() {
+			// findById resolves the plain id "s" to the qualified "t:s"; the
+			// restriction must apply to the resolved id, not the raw one.
+			Unit unit = unitWithImplementation();
+			var cmd = new AddSupport("j", "s", "local");
+
+			assertThatThrownBy(() -> cmd.execute(unit))
+					.isInstanceOf(ReferenceIntoTemplateException.class)
+					.hasMessageContaining("t:s");
+		}
+
+		@Test
+		void rejectsInheritedElementUsedAsSupporter() {
+			Unit unit = unitWithImplementation();
+			var cmd = new AddSupport("j", "local", "t:s");
+
+			assertThatThrownBy(() -> cmd.execute(unit))
+					.isInstanceOf(ReferenceIntoTemplateException.class)
+					.hasMessageContaining("t:s");
+		}
+
+		/**
+		 * A unit with template {@code t} (conclusion c, strategy s, @support
+		 * abs) and a justification {@code j} that inlines it and adds a local
+		 * evidence.
+		 */
+		private static Unit unitWithImplementation() {
+			Unit unit = new Unit("src");
+			Template t = new Template("t");
+			Conclusion tc = new Conclusion("c", "conclusion");
+			t.setConclusion(tc);
+			Strategy ts = new Strategy("s", "strategy");
+			t.addElement(ts);
+			AbstractSupport abs = new AbstractSupport("abs", "abstract");
+			t.addElement(abs);
+			ts.addSupport(abs);
+			tc.addSupport(ts);
+			unit.add(t);
+
+			Justification j = new Justification("j");
+			j.inline(t, "t");
+			j.addElement(new Evidence("local", "local evidence"));
+			unit.add(j);
+			return unit;
 		}
 	}
 

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/AddSupportTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/AddSupportTest.java
@@ -23,6 +23,8 @@ import ca.mcscert.jpipe.model.elements.SubConclusion;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class AddSupportTest {
 
@@ -146,32 +148,19 @@ class AddSupportTest {
 	@Nested
 	class TemplateEncapsulation {
 
-		@Test
-		void rejectsInheritedStrategyReferencedByQualifiedId() {
+		/**
+		 * Every reference to the parent template's own strategy {@code t:s} is
+		 * rejected, whether it appears as the supportable or the supporter, and
+		 * whether it is written qualified ({@code t:s}) or as a plain id
+		 * ({@code s}) — {@code findById} resolves the plain id, so the
+		 * restriction must apply to the resolved id.
+		 */
+		@ParameterizedTest
+		@CsvSource({"t:s, local", "s, local", "local, t:s"})
+		void rejectsReferenceToTemplateInternalStructure(String supportable,
+				String supporter) {
 			Unit unit = unitWithImplementation();
-			var cmd = new AddSupport("j", "t:s", "local");
-
-			assertThatThrownBy(() -> cmd.execute(unit))
-					.isInstanceOf(ReferenceIntoTemplateException.class)
-					.hasMessageContaining("t:s");
-		}
-
-		@Test
-		void rejectsInheritedStrategyReferencedByPlainId() {
-			// findById resolves the plain id "s" to the qualified "t:s"; the
-			// restriction must apply to the resolved id, not the raw one.
-			Unit unit = unitWithImplementation();
-			var cmd = new AddSupport("j", "s", "local");
-
-			assertThatThrownBy(() -> cmd.execute(unit))
-					.isInstanceOf(ReferenceIntoTemplateException.class)
-					.hasMessageContaining("t:s");
-		}
-
-		@Test
-		void rejectsInheritedElementUsedAsSupporter() {
-			Unit unit = unitWithImplementation();
-			var cmd = new AddSupport("j", "local", "t:s");
+			var cmd = new AddSupport("j", supportable, supporter);
 
 			assertThatThrownBy(() -> cmd.execute(unit))
 					.isInstanceOf(ReferenceIntoTemplateException.class)

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/ImplementsTemplateTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/ImplementsTemplateTest.java
@@ -247,9 +247,14 @@ class ImplementsTemplateTest {
 			assertThat(j.findById("t:as")).isPresent().get()
 					.isInstanceOf(Evidence.class);
 			Strategy ts = (Strategy) j.findById("t:ts").orElseThrow();
-			assertThat(ts.getSupports())
+			// The override must actually replace the abstract placeholder in
+			// the
+			// strategy's supporter list with the concrete evidence (no stale
+			// AbstractSupport reference left behind).
+			assertThat(ts.getSupports()).singleElement()
+					.isInstanceOf(Evidence.class)
 					.extracting(sl -> ((JustificationElement) sl).id())
-					.contains("t:as");
+					.isEqualTo("t:as");
 		}
 
 		@Test

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/JustificationModelTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/JustificationModelTest.java
@@ -392,8 +392,10 @@ class JustificationModelTest {
 		void isInheritedNonSupportAllowsSupportsAndLocals() {
 			Template child = new Template("child");
 			child.inline(template(), "t");
+			child.addElement(new Strategy("local", "a local strategy"));
 
 			assertThat(child.isInheritedNonSupport("t:abs")).isFalse();
+			assertThat(child.isInheritedNonSupport("local")).isFalse();
 			assertThat(child.isInheritedNonSupport("nonexistent")).isFalse();
 		}
 

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/JustificationModelTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/JustificationModelTest.java
@@ -378,6 +378,35 @@ class JustificationModelTest {
 		}
 
 		@Test
+		@DisplayName("isInheritedNonSupport: true for inherited strategy and conclusion")
+		void isInheritedNonSupportFlagsTemplateStructure() {
+			Template child = new Template("child");
+			child.inline(template(), "t");
+
+			assertThat(child.isInheritedNonSupport("t:s")).isTrue();
+			assertThat(child.isInheritedNonSupport("t:c")).isTrue();
+		}
+
+		@Test
+		@DisplayName("isInheritedNonSupport: false for @support, local, and unknown ids")
+		void isInheritedNonSupportAllowsSupportsAndLocals() {
+			Template child = new Template("child");
+			child.inline(template(), "t");
+
+			assertThat(child.isInheritedNonSupport("t:abs")).isFalse();
+			assertThat(child.isInheritedNonSupport("nonexistent")).isFalse();
+		}
+
+		@Test
+		@DisplayName("isInheritedNonSupport: false when the model has no parent")
+		void isInheritedNonSupportFalseWithoutParent() {
+			Justification j = new Justification("j");
+			j.addElement(new Strategy("s", "strategy"));
+
+			assertThat(j.isInheritedNonSupport("s")).isFalse();
+		}
+
+		@Test
 		@DisplayName("after inline into Justification: CommonElement copies are inherited")
 		void inlinedCommonElementsAreInheritedInJustification() {
 			// Template with no AbstractSupport — safe to inline into

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/elements/StrategyTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/elements/StrategyTest.java
@@ -1,0 +1,47 @@
+package ca.mcscert.jpipe.model.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class StrategyTest {
+
+	@Test
+	void addSupport_appendsDistinctSupporters() {
+		Strategy s = new Strategy("s", "S");
+		Evidence e1 = new Evidence("e1", "One");
+		Evidence e2 = new Evidence("e2", "Two");
+
+		s.addSupport(e1);
+		s.addSupport(e2);
+
+		assertThat(s.getSupports()).containsExactly(e1, e2);
+	}
+
+	@Test
+	void addSupport_isIdempotentById() {
+		// A strategy can never legitimately be supported twice by the same id.
+		Strategy s = new Strategy("s", "S");
+		AbstractSupport abs = new AbstractSupport("x", "Abstract");
+		Evidence sameId = new Evidence("x", "Concrete with same id");
+
+		s.addSupport(abs);
+		s.addSupport(sameId);
+
+		assertThat(s.getSupports()).containsExactly(abs);
+	}
+
+	@Test
+	void replaceSupport_matchesByIdNotObjectIdentity() {
+		// The abstract placeholder and its concrete override share the same id
+		// but are different objects/types; replaceSupport must still swap them.
+		Strategy s = new Strategy("s", "S");
+		AbstractSupport abs = new AbstractSupport("x", "Abstract");
+		Evidence concrete = new Evidence("x", "Concrete");
+		s.addSupport(abs);
+
+		s.replaceSupport(concrete, concrete);
+
+		assertThat(s.getSupports()).containsExactly(concrete);
+	}
+}

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/DotExporterTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/DotExporterTest.java
@@ -68,7 +68,7 @@ class DotExporterTest {
 
 		String dot = new DotExporter().export(j);
 
-		assertThat(dot).contains("subgraph cluster_t");
+		assertThat(dot).contains("subgraph \"cluster_t\"");
 	}
 
 	@Test
@@ -85,7 +85,7 @@ class DotExporterTest {
 
 		// Local evidence node must appear before any cluster block
 		int evidencePos = dot.indexOf("id=\"j:e\"");
-		int clusterPos = dot.indexOf("subgraph cluster_t");
+		int clusterPos = dot.indexOf("subgraph \"cluster_t\"");
 		assertThat(evidencePos).isLessThan(clusterPos);
 	}
 
@@ -149,14 +149,61 @@ class DotExporterTest {
 
 		String dot = new DotExporter().export(j);
 
-		assertThat(dot).contains("subgraph cluster_t2", "subgraph cluster_t1",
-				"id=\"j:t2:s2\"", "id=\"j:t1:s1\"");
+		assertThat(dot).contains("subgraph \"cluster_t2\"",
+				"subgraph \"cluster_t1\"", "id=\"j:t2:s2\"", "id=\"j:t1:s1\"");
 		// Nesting: cluster_t1 must appear after cluster_t2 opens and before
 		// cluster_t2 closes — no closing brace between the two headers
-		int t2Idx = dot.indexOf("subgraph cluster_t2");
-		int t1Idx = dot.indexOf("subgraph cluster_t1");
+		int t2Idx = dot.indexOf("subgraph \"cluster_t2\"");
+		int t1Idx = dot.indexOf("subgraph \"cluster_t1\"");
 		assertThat(t1Idx).isGreaterThan(t2Idx);
 		String between = dot.substring(t2Idx, t1Idx);
 		assertThat(between).doesNotContain("\n}");
+	}
+
+	@Test
+	void export_overriddenSupportWiredToStrategyProducesSingleEdge() {
+		// Reproduces the duplicate-arrow bug: an @support overridden by an
+		// evidence that is also wired to the inherited strategy must not draw
+		// the
+		// ghost -> strategy edge twice.
+		Template t = new Template("a_template");
+		t.setConclusion(new Conclusion("c", "A conclusion"));
+		Strategy templateStrategy = new Strategy("s", "A strategy");
+		t.addElement(templateStrategy);
+		AbstractSupport abs = new AbstractSupport("abs", "An abstract support");
+		t.addElement(abs);
+		templateStrategy.addSupport(abs);
+
+		Justification j = new Justification("immediate");
+		j.inline(t, "a_template");
+		j.removeElement("a_template:abs");
+		Evidence ev = new Evidence("a_template:abs", "An immediate evidence");
+		j.addElement(ev);
+		// Simulate "a_template:abs supports a_template:s": wire the concrete
+		// evidence onto the inherited strategy that still holds the abstract.
+		Strategy inherited = (Strategy) j.findById("a_template:s")
+				.orElseThrow();
+		inherited.addSupport(ev);
+
+		String dot = new DotExporter().export(j);
+
+		assertThat(dot).containsOnlyOnce("\"immediate:a_template:abs@abstract\""
+				+ " -> \"immediate:a_template:s\"");
+	}
+
+	@Test
+	void export_qualifiedTemplateNameProducesQuotedClusterId() {
+		// A namespaced template name contains ':', which Graphviz reads as a
+		// port separator unless the cluster id is quoted.
+		Template t = new Template("ns:t");
+		t.setConclusion(new Conclusion("c", "System correct"));
+		t.addElement(new Strategy("s", "Testing"));
+
+		Justification j = new Justification("j");
+		j.inline(t, "ns:t");
+
+		String dot = new DotExporter().export(j);
+
+		assertThat(dot).contains("subgraph \"cluster_ns:t\"");
 	}
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - adr/0021-pin-runtime-binary-to-declared-dependency.md
       - adr/0022-glob-patterns-in-load.md
       - adr/0023-ubuntu-release-target-policy.md
+      - adr/0024-git-branching-model.md
 plugins:
   - search
 


### PR DESCRIPTION
This pull request introduces a new two-tier git branching model (ADR-0024), separating day-to-day integration work (`dev` branch) from release history (`main` branch). It updates CI workflows and documentation to match, and enforces a new semantic rule: when implementing a template, models may only override `@support` placeholders, not reference template-internal elements (strategies or conclusions). This is enforced with new compiler diagnostics and tested with new examples.

**Branching Model & CI Workflow Changes:**

- **Adopted a two-branch model:** `main` is now release-only (tagged, published versions), while `dev` is the integration branch for all ongoing work. Documentation, changelog, and contributing guidelines are updated to reflect this. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R8-R33) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R196-R197) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L211-R243) [[4]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295R1-R101)
- **CI workflows updated:** 
  - `build.yml` unstable pre-release now triggers on `dev` instead of `main`, and its release notes reference `dev`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L63-R63) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L94-R94)
  - `docs.yml` deploys from `dev` instead of `main`.
  - `sonar.yml` now analyzes both `main` and `dev`.

**Template Implementation Semantics:**

- **New semantic restriction:** Models implementing a template may only override the template’s `@support` placeholders; referencing template-internal elements (strategies/conclusions) is now a validation error. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R38) [[2]](diffhunk://#diff-20923a50cfe1d492416199e183f42de0b1838b865f90deead606ef19a1f3f7ddR37-R43) [[3]](diffhunk://#diff-029c58cb967b636e2381794e48f2e94c1b77e831ab2d9b2fa8218010192f5c11R87-R93) [[4]](diffhunk://#diff-54ce3053251e80fa58e76adf412f299606624cea192d60272eb73253bdce3026R293-R309) [[5]](diffhunk://#diff-40d2e549ccd3f1e9077a9bbda27c973466afed79594d291ce322ed42ec52f5a3L77-R83) [[6]](diffhunk://#diff-40d2e549ccd3f1e9077a9bbda27c973466afed79594d291ce322ed42ec52f5a3R7) [[7]](diffhunk://#diff-f7351f93745c1185f4a7a2d9dc5ea642a2cfc426df4b71d99a059c7412fed0fbR1-R18)
- **Improved error reporting:** Introduces `ReferenceIntoTemplateException` and a new diagnostic code `[reference-into-template]` to clearly report these errors. [[1]](diffhunk://#diff-20923a50cfe1d492416199e183f42de0b1838b865f90deead606ef19a1f3f7ddR37-R43) [[2]](diffhunk://#diff-40d2e549ccd3f1e9077a9bbda27c973466afed79594d291ce322ed42ec52f5a3L77-R83) [[3]](diffhunk://#diff-f7351f93745c1185f4a7a2d9dc5ea642a2cfc426df4b71d99a059c7412fed0fbR1-R18)
- **Test coverage:** Adds an invalid example (`022_reference_into_template.jd`) and feature tests to ensure the new rule is enforced and errors are reported as expected. [[1]](diffhunk://#diff-bb2219e5e3d34a424373c5ef05f3bc82f30f9714170b723fbbded3c3947eee5bR1-R29) [[2]](diffhunk://#diff-83ddfdef8990cd09a1e3b169d5803faed967c63f705a5cb3f2196070ff3477caR247-R253) [[3]](diffhunk://#diff-1ccd75925c1035db57f54e8a274f72e259f5af4af3a79da5bb603e75abf6517dR63-R69)

**Bug Fixes & Minor Improvements:**

- **DOT export fixes:** Template cluster ids are now quoted to handle namespaced templates, preventing malformed Graphviz output. [[1]](diffhunk://#diff-e930873581cae8aa50f5dece9ab7406739da6ce355e929b437fba38c155c78f6L242-R244) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R38)
- **Support override fix:** Overriding a template’s `@support` with evidence no longer leaves a stale placeholder reference, preventing duplicate arrows in DOT export. [[1]](diffhunk://#diff-5629d1a07af52b08963b796c3d3dcd1cf16b60370f74ace6b4eeef716daf089cR29-R61) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R38)

**Documentation:**

- **ADR-0024 added:** Documents the new branching model and its rationale.
- **CLAUDE.md and changelog policies:** Updated to match the new workflow and release process. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R8-R33) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R196-R197) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L211-R243)

This change clarifies release management, enforces best practices for template use, and improves CI reliability and error reporting.