### PR TITLE
chore: remove redundant unstable pre-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,6 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.mvn_version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v6
@@ -54,43 +52,3 @@ jobs:
           name: jpipe-cli-${{ steps.mvn_version.outputs.version }}
           path: ${{ steps.locate.outputs.path }}
           if-no-files-found: error
-
-
-  release:
-    name: Publish unstable release
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Download fat JAR artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: jpipe-cli-${{ needs.build.outputs.version }}
-          path: dist
-
-      - name: Publish unstable release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          JAR_FILE="dist/jpipe-cli-${VERSION}.jar"
-          [ -f "$JAR_FILE" ] || { echo "ERROR: $JAR_FILE not found"; find dist -maxdepth 2 || echo "dist dir missing"; exit 1; }
-          cp "$JAR_FILE" jpipe-cli.jar
-
-          # Re-point the unstable tag to this commit
-          git tag -f unstable
-          git push origin unstable --force
-
-          # Delete the existing pre-release (ignore error if it does not exist yet)
-          gh release delete unstable --yes 2>/dev/null || true
-
-          gh release create unstable jpipe-cli.jar \
-            --title "Unstable build ($(date -u '+%Y-%m-%d %H:%M UTC'))" \
-            --notes $'This pre-release is rebuilt on every push to `dev`.\n\nIt tracks the latest integrated code and is **not intended for production use**.' \
-            --prerelease \
-            --target "$GITHUB_SHA"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,11 @@ The repository uses a two-tier branching model (ADR-0024):
 - **Hotfixes** — branch from `main`, merge into `main`, release via a patch tag,
   then merge back into `dev`.
 
-CI follows the model: the `unstable` rolling pre-release (`build.yml`) and docs
-deploy (`docs.yml`) track `dev`; `sonar.yml` analyses both branches;
-`release.yml` triggers on tags and requires the tag to be on `main`.
+CI follows the model: `build.yml` runs on every push/PR (fat JAR available as a
+per-run artifact); docs deploy (`docs.yml`) tracks `dev`; `sonar.yml` analyses
+both branches; `release.yml` triggers on tags and requires the tag to be on
+`main`. There is no rolling `unstable` pre-release — the tip of `dev` is the
+latest integrated build (ADR-0024).
 
 ---
 

--- a/docs/adr/0024-git-branching-model.md
+++ b/docs/adr/0024-git-branching-model.md
@@ -14,9 +14,9 @@ bug fixes, chores, and release-preparation commits all landed directly on
   `release.yml` already verifies that the tag points at a commit on `main`.
   Nothing else about `main` distinguishes "released" commits from
   "work-in-progress" commits — the branch is a mix of both.
-- **`main` also drives the rolling `unstable` snapshot.** The `publish-unstable`
-  job in `build.yml` re-points the `unstable` pre-release on every push to
-  `main`. So `main` is simultaneously the integration branch *and* the release
+- **`main` also drives the rolling `unstable` snapshot.** A job in `build.yml`
+  re-points the `unstable` pre-release on every push to `main`. So `main` is
+  simultaneously the integration branch *and* the release
   branch, and the `CHANGELOG.md` `[Unreleased]` section accumulates directly on
   the same branch that is supposed to represent shipped software.
 
@@ -54,8 +54,9 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
 
 ### CI consequences (applied in this change)
 
-- **`build.yml` `publish-unstable` is removed.** With `dev` in place, the tip of
-  `dev` *is* the rolling "latest integrated" state, so a separate `unstable`
+- **The `unstable` pre-release job in `build.yml` is removed.** With `dev` in
+  place, the tip of `dev` *is* the rolling "latest integrated" state, so a
+  separate `unstable`
   GitHub pre-release (and its force-pushed `unstable` tag) is redundant. This
   supersedes the `unstable` pre-release introduced by
   [ADR-0020](0020-tag-triggered-release-pipeline.md); per-run fat-JAR artifacts

--- a/docs/adr/0024-git-branching-model.md
+++ b/docs/adr/0024-git-branching-model.md
@@ -54,10 +54,12 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
 
 ### CI consequences (applied in this change)
 
-- **`build.yml` `publish-unstable`** now triggers on push to **`dev`** instead
-  of `main` — the rolling snapshot tracks the integration branch, which is where
-  continuous merges now happen. (`main` would otherwise only move at release
-  time, making the "unstable" snapshot stale.)
+- **`build.yml` `publish-unstable` is removed.** With `dev` in place, the tip of
+  `dev` *is* the rolling "latest integrated" state, so a separate `unstable`
+  GitHub pre-release (and its force-pushed `unstable` tag) is redundant. This
+  supersedes the `unstable` pre-release introduced by
+  [ADR-0020](0020-tag-triggered-release-pipeline.md); per-run fat-JAR artifacts
+  remain available on each Actions run.
 - **`sonar.yml`** runs its push analysis on both `main` and `dev` so the
   integration branch is quality-gated.
 - **`docs.yml`** deploys documentation from **`dev`**, so ADRs and design docs
@@ -76,9 +78,9 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
   Keeping it off `main` removes the oddity of a shipped branch carrying an
   `[Unreleased]` heading between releases.
 - **Deliberate releases, continuous integration.** Work still flows
-  continuously (into `dev`, with an `unstable` snapshot), while releasing stays
-  an explicit, low-frequency act (a `dev` → `main` merge plus a tag), consistent
-  with ADR-0020's "releases are deliberate" rationale.
+  continuously into `dev` (whose `HEAD` is the latest integrated code), while
+  releasing stays an explicit, low-frequency act (a `dev` → `main` merge plus a
+  tag), consistent with ADR-0020's "releases are deliberate" rationale.
 - **Low ceremony.** Two long-lived branches and short-lived topic branches is
   the smallest model that separates integration from release; it does not
   require release branches or a full git-flow.
@@ -93,8 +95,8 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
 - The release checklist gains a first step: merge `dev` into `main` before
   tagging (and merge `main` back into `dev` afterwards). The existing
   ADR-0020 / ADR-0023 release steps follow unchanged.
-- The `unstable` GitHub pre-release now reflects `dev`. Its notes ("rebuilt on
-  every push") are updated to reference `dev`.
+- The `unstable` GitHub pre-release and its `unstable` tag are retired; users who
+  want the latest build take the tip of `dev` or a per-run Actions artifact.
 - Published documentation tracks `dev`; a doc fix is visible once merged, not
   only after the next release.
 - Existing open work branched from `main` (e.g. the branch introducing this


### PR DESCRIPTION
Now that we have a `dev` branch, the tip of `dev` is the rolling
latest-integrated build, so the separate `unstable` GitHub pre-release (and its
force-pushed `unstable` tag) is redundant.

- Remove the `publish-unstable` job from `build.yml` (per-run fat-JAR artifacts remain).
- Update ADR-0024 to record this, superseding the `unstable` pre-release from ADR-0020.
- Update CLAUDE.md's CI description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)