### PR TITLE
fix: enforce template encapsulation on resolved ids + coverage

### DIFF
--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/AddSupport.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/AddSupport.java
@@ -84,11 +84,14 @@ public final class AddSupport extends RegularCommand {
 				.orElseThrow(() -> new NoSuchElementException(
 						"No element with id: " + supporterId));
 
-		if (model.isInheritedNonSupport(supportableId)) {
-			throw new ReferenceIntoTemplateException(supportableId, container);
+		// Check the resolved element ids (findById resolves plain ids to their
+		// qualified form), otherwise a plain id would bypass the restriction.
+		if (model.isInheritedNonSupport(supportable.id())) {
+			throw new ReferenceIntoTemplateException(supportable.id(),
+					container);
 		}
-		if (model.isInheritedNonSupport(supporterId)) {
-			throw new ReferenceIntoTemplateException(supporterId, container);
+		if (model.isInheritedNonSupport(supporter.id())) {
+			throw new ReferenceIntoTemplateException(supporter.id(), container);
 		}
 
 		switch (supportable) {

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
@@ -292,15 +292,16 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 
 	/**
 	 * Returns {@code true} when {@code id} names an ancestor-template element
-	 * that is <em>not</em> an {@link AbstractSupport} placeholder — i.e.
-	 * template-internal structure (a strategy or conclusion) that a model
-	 * implementing the template must not reference. A model may only override
-	 * the template's {@code @support} placeholders, never reach inside its
-	 * structure.
+	 * of any type <em>other than</em> an {@link AbstractSupport} placeholder (a
+	 * strategy, conclusion, sub-conclusion, or evidence inherited from the
+	 * template) — template-internal structure that a model implementing the
+	 * template must not reference. A model may only override the template's
+	 * {@code @support} placeholders, never reach inside its structure.
 	 *
 	 * <p>
 	 * Returns {@code false} for template {@code @support} ids (whether
-	 * overridden or not) and for ids local to this model.
+	 * overridden or not) and for ids local to this model. The {@code id} must
+	 * be the resolved (qualified) element id.
 	 */
 	public boolean isInheritedNonSupport(String id) {
 		Class<? extends JustificationElement> type = ancestorTypes().get(id);

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/AddSupportTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/AddSupportTest.java
@@ -12,8 +12,11 @@ import ca.mcscert.jpipe.commands.creation.CreateStrategy;
 import ca.mcscert.jpipe.commands.creation.CreateSubConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateTemplate;
 import ca.mcscert.jpipe.model.Justification;
+import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
 import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
 import ca.mcscert.jpipe.model.elements.JustificationElement;
 import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
@@ -132,6 +135,72 @@ class AddSupportTest {
 			var cmd = new AddSupport("j1", "e1", "s1");
 			assertThatThrownBy(() -> cmd.execute(unit))
 					.isInstanceOf(IllegalArgumentException.class);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Template encapsulation — an implementor may only override @support
+	// placeholders, never reference the parent template's own structure.
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class TemplateEncapsulation {
+
+		@Test
+		void rejectsInheritedStrategyReferencedByQualifiedId() {
+			Unit unit = unitWithImplementation();
+			var cmd = new AddSupport("j", "t:s", "local");
+
+			assertThatThrownBy(() -> cmd.execute(unit))
+					.isInstanceOf(ReferenceIntoTemplateException.class)
+					.hasMessageContaining("t:s");
+		}
+
+		@Test
+		void rejectsInheritedStrategyReferencedByPlainId() {
+			// findById resolves the plain id "s" to the qualified "t:s"; the
+			// restriction must apply to the resolved id, not the raw one.
+			Unit unit = unitWithImplementation();
+			var cmd = new AddSupport("j", "s", "local");
+
+			assertThatThrownBy(() -> cmd.execute(unit))
+					.isInstanceOf(ReferenceIntoTemplateException.class)
+					.hasMessageContaining("t:s");
+		}
+
+		@Test
+		void rejectsInheritedElementUsedAsSupporter() {
+			Unit unit = unitWithImplementation();
+			var cmd = new AddSupport("j", "local", "t:s");
+
+			assertThatThrownBy(() -> cmd.execute(unit))
+					.isInstanceOf(ReferenceIntoTemplateException.class)
+					.hasMessageContaining("t:s");
+		}
+
+		/**
+		 * A unit with template {@code t} (conclusion c, strategy s, @support
+		 * abs) and a justification {@code j} that inlines it and adds a local
+		 * evidence.
+		 */
+		private static Unit unitWithImplementation() {
+			Unit unit = new Unit("src");
+			Template t = new Template("t");
+			Conclusion tc = new Conclusion("c", "conclusion");
+			t.setConclusion(tc);
+			Strategy ts = new Strategy("s", "strategy");
+			t.addElement(ts);
+			AbstractSupport abs = new AbstractSupport("abs", "abstract");
+			t.addElement(abs);
+			ts.addSupport(abs);
+			tc.addSupport(ts);
+			unit.add(t);
+
+			Justification j = new Justification("j");
+			j.inline(t, "t");
+			j.addElement(new Evidence("local", "local evidence"));
+			unit.add(j);
+			return unit;
 		}
 	}
 

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/AddSupportTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/commands/linking/AddSupportTest.java
@@ -23,6 +23,8 @@ import ca.mcscert.jpipe.model.elements.SubConclusion;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class AddSupportTest {
 
@@ -146,32 +148,19 @@ class AddSupportTest {
 	@Nested
 	class TemplateEncapsulation {
 
-		@Test
-		void rejectsInheritedStrategyReferencedByQualifiedId() {
+		/**
+		 * Every reference to the parent template's own strategy {@code t:s} is
+		 * rejected, whether it appears as the supportable or the supporter, and
+		 * whether it is written qualified ({@code t:s}) or as a plain id
+		 * ({@code s}) — {@code findById} resolves the plain id, so the
+		 * restriction must apply to the resolved id.
+		 */
+		@ParameterizedTest
+		@CsvSource({"t:s, local", "s, local", "local, t:s"})
+		void rejectsReferenceToTemplateInternalStructure(String supportable,
+				String supporter) {
 			Unit unit = unitWithImplementation();
-			var cmd = new AddSupport("j", "t:s", "local");
-
-			assertThatThrownBy(() -> cmd.execute(unit))
-					.isInstanceOf(ReferenceIntoTemplateException.class)
-					.hasMessageContaining("t:s");
-		}
-
-		@Test
-		void rejectsInheritedStrategyReferencedByPlainId() {
-			// findById resolves the plain id "s" to the qualified "t:s"; the
-			// restriction must apply to the resolved id, not the raw one.
-			Unit unit = unitWithImplementation();
-			var cmd = new AddSupport("j", "s", "local");
-
-			assertThatThrownBy(() -> cmd.execute(unit))
-					.isInstanceOf(ReferenceIntoTemplateException.class)
-					.hasMessageContaining("t:s");
-		}
-
-		@Test
-		void rejectsInheritedElementUsedAsSupporter() {
-			Unit unit = unitWithImplementation();
-			var cmd = new AddSupport("j", "local", "t:s");
+			var cmd = new AddSupport("j", supportable, supporter);
 
 			assertThatThrownBy(() -> cmd.execute(unit))
 					.isInstanceOf(ReferenceIntoTemplateException.class)

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/JustificationModelTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/JustificationModelTest.java
@@ -392,8 +392,10 @@ class JustificationModelTest {
 		void isInheritedNonSupportAllowsSupportsAndLocals() {
 			Template child = new Template("child");
 			child.inline(template(), "t");
+			child.addElement(new Strategy("local", "a local strategy"));
 
 			assertThat(child.isInheritedNonSupport("t:abs")).isFalse();
+			assertThat(child.isInheritedNonSupport("local")).isFalse();
 			assertThat(child.isInheritedNonSupport("nonexistent")).isFalse();
 		}
 

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/JustificationModelTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/JustificationModelTest.java
@@ -378,6 +378,35 @@ class JustificationModelTest {
 		}
 
 		@Test
+		@DisplayName("isInheritedNonSupport: true for inherited strategy and conclusion")
+		void isInheritedNonSupportFlagsTemplateStructure() {
+			Template child = new Template("child");
+			child.inline(template(), "t");
+
+			assertThat(child.isInheritedNonSupport("t:s")).isTrue();
+			assertThat(child.isInheritedNonSupport("t:c")).isTrue();
+		}
+
+		@Test
+		@DisplayName("isInheritedNonSupport: false for @support, local, and unknown ids")
+		void isInheritedNonSupportAllowsSupportsAndLocals() {
+			Template child = new Template("child");
+			child.inline(template(), "t");
+
+			assertThat(child.isInheritedNonSupport("t:abs")).isFalse();
+			assertThat(child.isInheritedNonSupport("nonexistent")).isFalse();
+		}
+
+		@Test
+		@DisplayName("isInheritedNonSupport: false when the model has no parent")
+		void isInheritedNonSupportFalseWithoutParent() {
+			Justification j = new Justification("j");
+			j.addElement(new Strategy("s", "strategy"));
+
+			assertThat(j.isInheritedNonSupport("s")).isFalse();
+		}
+
+		@Test
 		@DisplayName("after inline into Justification: CommonElement copies are inherited")
 		void inlinedCommonElementsAreInheritedInJustification() {
 			// Template with no AbstractSupport — safe to inline into


### PR DESCRIPTION
Addresses the two Copilot review comments on #137 and the SonarCloud new-code coverage gate.

- **Plain-id bypass (correctness):** `AddSupport` now checks the *resolved* element ids. Because `findById` resolves a plain id (`gates`) to its qualified form (`quality:gates`), the previous raw-id check could be bypassed by referencing a template-internal element by plain id. Now `tested supports gates` is rejected just like `quality:tested supports quality:gates`.
- **Javadoc:** `JustificationModel.isInheritedNonSupport` documented as flagging any inherited non-`@support` element (strategy, conclusion, sub-conclusion, or evidence), not just "a strategy or conclusion".
- **Coverage:** the encapsulation logic lives in `jpipe-model` but was only exercised by a Cucumber scenario in `jpipe-compiler`. Added `jpipe-model` unit tests (`AddSupportTest.TemplateEncapsulation`, `JustificationModelTest` `isInheritedNonSupport`) covering both throw branches, the plain-id case, and the true/false/absent-parent paths.

Once merged into `dev`, this flows into #137 (dev → main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)