### PR TITLE
chore(release): prepare 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+---
+
+## [2.2.0] — 2026-07-18
+
 ### Added
 - A model implementing a template may now only override the template's
   `@support` placeholders; referencing a template-internal element (a strategy
@@ -27,6 +31,11 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 - PPA packages are now published for Ubuntu `noble` (24.04 LTS), `resolute`
   (26.04 LTS), and `stonking` per the new Ubuntu release target policy
   (ADR-0023); `jammy` (22.04 LTS) and `questing` (25.10) are no longer targeted.
+
+### Removed
+- The rolling `unstable` GitHub pre-release and its force-pushed `unstable` tag
+  are retired (ADR-0024); use the tip of `dev` or a per-run CI build artifact for
+  the latest integrated build.
 
 ### Fixed
 - DOT export now quotes template cluster ids, so a namespaced template name
@@ -258,7 +267,8 @@ server.
 ### Added
 - Initial commit: first version of the compiler.
 
-[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.4...v2.1.0
 [2.0.4]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.2...v2.0.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 - **Never commit or push code without explicit user consent.** Always show the diff and ask before running any `git commit` or `git push` command.
 - **Never commit directly to `main`.** `main` is release-only (see [Git Workflow](#git-workflow)). All feature and fix work branches off `dev` and merges back into `dev`.
+- **Never merge a pull request or push a git tag.** Merging (including the release `dev`→`main` merge) and tagging (`vX.Y.Z`) are **human-only** actions. Claude prepares the branch/PR and hands off; it does not run `gh pr merge`, merge branches into `dev`/`main`, or push tags.
 
 ---
 
@@ -24,7 +25,9 @@ The repository uses a two-tier branching model (ADR-0024):
   what adds the change to `[Unreleased]`.
 - **Releasing** — merge `dev` → `main`, rename `[Unreleased]` to the version,
   push a `vX.Y.Z` tag on `main` (this triggers `release.yml`, ADR-0020), then
-  merge `main` back into `dev`.
+  merge `main` back into `dev`. **The `dev`→`main` merge and the tag push are
+  human-only actions** (see Critical Rules); Claude only prepares the
+  release-prep branch/PR (changelog finalization, version bump).
 - **Hotfixes** — branch from `main`, merge into `main`, release via a patch tag,
   then merge back into `dev`.
 
@@ -239,10 +242,11 @@ Rules:
   the implementation. Reference the PR or issue number when there is one
   (e.g. `(#136)`). Match the tone and style of existing entries.
 - **Releasing (maintainer action):** Cutting a release is a `dev` → `main`
-  merge (see [Git Workflow](#git-workflow)). As part of it, rename
-  `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, add the git-compare link at
-  the bottom, and open a fresh empty `## [Unreleased]` section above it. The
-  `vX.Y.Z` tag is pushed on `main`.
+  merge (see [Git Workflow](#git-workflow)). Claude prepares a release-prep
+  branch that renames `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, adds the
+  git-compare link at the bottom, and opens a fresh empty `## [Unreleased]`
+  section above it. **The maintainer (human) performs the `dev`→`main` merge and
+  pushes the `vX.Y.Z` tag on `main`** — Claude does not merge or tag.
 
 Do not edit already-released sections except to correct an error.
 


### PR DESCRIPTION
Release-prep for **2.2.0** (to be merged into `dev`, then folded into #137 for the `dev`→`main` release).

- **CHANGELOG.md** — promote `[Unreleased]` → `## [2.2.0] — 2026-07-18`, open a fresh empty `[Unreleased]`, add compare links. Includes a `Removed` note for the retired `unstable` pre-release (ADR-0024).
- **CLAUDE.md** — record that merging PRs and pushing tags are human-only actions.
- **pom.xml** — unchanged (already `2.2.0-SNAPSHOT`); `release.yml` validates the `v2.2.0` tag against the SNAPSHOT-stripped base.

`mvn verify` is green. Docs-only, no source/pom changes.

**Hand-off (human only):** merge this into `dev` → merge #137 (`dev`→`main`) → `git tag v2.2.0` on `main` and push (triggers `release.yml`) → merge `main` back into `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)