### PR TITLE
fix: rename local var shadowing Strategy.id (SonarCloud S1117)

### DIFF
--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
@@ -33,9 +33,9 @@ public final class Strategy implements CommonElement {
 	 * nothing is added.
 	 */
 	public void addSupport(SupportLeaf supporter) {
-		String id = ((JustificationElement) supporter).id();
-		boolean present = supporters.stream()
-				.anyMatch(s -> ((JustificationElement) s).id().equals(id));
+		String supporterId = ((JustificationElement) supporter).id();
+		boolean present = supporters.stream().anyMatch(
+				s -> ((JustificationElement) s).id().equals(supporterId));
 		if (!present) {
 			this.supporters.add(supporter);
 		}


### PR DESCRIPTION
Resolves the SonarCloud `java:S1117` issue on #137: the local `id` in `Strategy.addSupport` shadowed the `id` field. Renamed it to `supporterId`. No behavior change; `StrategyTest` still green.

Flows into #137 (dev → main) once merged into `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)