### PR TITLE
feat(packaging): add Scoop as a Windows release channel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.jd linguist-language=HCL
+
+# Windows launcher templates ship with CRLF endings, whatever the build host is.
+*.ps1 text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*.jd linguist-language=HCL
+*.jd linguist-language=TypeScript linguist-detectable=false
 
 # Windows launcher templates ship with CRLF endings, whatever the build host is.
 *.ps1 text eol=crlf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       sha256: ${{ steps.sha256.outputs.sha256 }}
+      sha256_zip: ${{ steps.sha256_zip.outputs.sha256 }}
 
     steps:
       - uses: actions/checkout@v6
@@ -84,6 +85,22 @@ jobs:
           SHA=$(sha256sum "${{ steps.tarball.outputs.path }}" | awk '{print $1}')
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
 
+      - name: Assemble Scoop zip
+        id: zip
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          mkdir -p dist/scoop
+          cp "${{ steps.locate.outputs.path }}" dist/scoop/jpipe.jar
+          cp bin/jpipe.ps1 dist/scoop/jpipe.ps1
+          (cd dist/scoop && zip -qr "../jpipe-$VERSION.zip" .)
+          echo "path=dist/jpipe-$VERSION.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Compute SHA256 (zip)
+        id: sha256_zip
+        run: |
+          SHA=$(sha256sum "${{ steps.zip.outputs.path }}" | awk '{print $1}')
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -96,6 +113,7 @@ jobs:
             --generate-notes \
             $PRERELEASE_FLAG \
             "${{ steps.tarball.outputs.path }}" \
+            "${{ steps.zip.outputs.path }}" \
             "${{ steps.locate.outputs.path }}"
 
   update-homebrew:
@@ -135,6 +153,43 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "jpipe.rb" "jpipe@${VERSION}.rb"
+          git commit -m "chore: bump jpipe to v${VERSION}"
+          git push
+
+  update-scoop:
+    name: Update Scoop manifest
+    runs-on: ubuntu-latest
+    needs: build-and-release
+    if: ${{ !contains(needs.build-and-release.outputs.version, '-') }}
+
+    steps:
+      - name: Checkout Scoop bucket
+        uses: actions/checkout@v6
+        with:
+          repository: jpipe-mcscert/scoop-mcscert
+          token: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          path: scoop-bucket
+
+      - name: Update Scoop manifest
+        run: |
+          VERSION="${{ needs.build-and-release.outputs.version }}"
+          SHA256="${{ needs.build-and-release.outputs.sha256_zip }}"
+          URL="https://github.com/jpipe-mcscert/jpipe-compiler/releases/download/v${VERSION}/jpipe-${VERSION}.zip"
+
+          # Only version/url/hash are templated; everything else (depends,
+          # bin, post_install) is owned by the manifest in the bucket repo.
+          jq --indent 4 --arg v "$VERSION" --arg u "$URL" --arg h "$SHA256" \
+             '.version = $v | .url = $u | .hash = $h' \
+             scoop-bucket/bucket/jpipe.json > jpipe.json
+          mv jpipe.json scoop-bucket/bucket/jpipe.json
+
+      - name: Commit and push
+        run: |
+          VERSION="${{ needs.build-and-release.outputs.version }}"
+          cd scoop-bucket
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/jpipe.json
           git commit -m "chore: bump jpipe to v${VERSION}"
           git push
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- jPipe can now be installed on Windows with [Scoop](https://scoop.sh):
+  `scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert`
+  followed by `scoop install jpipe`. Releases publish an additional
+  `jpipe-<version>.zip` asset, and the release pipeline keeps the bucket
+  manifest up to date automatically (ADR-0025).
+
 ---
 
 ## [2.2.0] — 2026-07-18

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The jPipe environment supports the definition of justification to support softwa
 - `jpipe-compiler`: compiler pipeline (parsing, model building, validation, export)
 - `jpipe-cli`: command-line interface and fat JAR entry point
 - `docs`: technical documentation and architecture decision records
-- `homebrew`: launcher script template for the Homebrew formula
+- `bin`: launcher script templates (POSIX `sh` and PowerShell) used by the packaging channels
 - `debian`: Debian source packaging metadata for the Ubuntu PPA
 
 ### Developer Setup
@@ -60,8 +60,8 @@ The fat JAR is produced in `jpipe-cli/target/`.
 #### Releasing a new version
 
 Releases are triggered by pushing a `v*.*.*` tag to `main`. The pipeline
-creates a GitHub Release, updates the Homebrew formula, and uploads a Debian
-source package to the Ubuntu PPA.
+creates a GitHub Release, updates the Homebrew formula and the Scoop manifest,
+and uploads a Debian source package to the Ubuntu PPA.
 
 **Prerequisites:** The following secrets must be configured in the GitHub
 repository settings:
@@ -69,6 +69,7 @@ repository settings:
 | Secret | Purpose |
 |--------|---------|
 | `HOMEBREW_TAP_TOKEN` | PAT with write access to `jpipe-mcscert/homebrew-mcscert` |
+| `SCOOP_BUCKET_TOKEN` | PAT with write access to `jpipe-mcscert/scoop-mcscert` |
 | `GPG_PRIVATE_KEY` | ASCII-armored GPG key registered on Launchpad |
 | `GPG_KEY_ID` | Fingerprint of the signing key |
 | `GPG_PASSPHRASE` | Passphrase for the signing key |
@@ -96,11 +97,14 @@ git push origin main
    (e.g. tag `v2.1.0` is accepted when `pom.xml` declares `2.1.0-SNAPSHOT`).
 2. `mvn versions:set` is run inside the pipeline to stamp the exact release version
    into the fat JAR manifest (`Implementation-Version: X.Y.Z`).
-3. A GitHub Release is created with the fat JAR and a Homebrew tarball.
-   Tags containing `-` (e.g. `-rc1`) are automatically marked as pre-releases.
+3. A GitHub Release is created with the fat JAR, a Homebrew tarball, and a
+   Scoop zip. Tags containing `-` (e.g. `-rc1`) are automatically marked as
+   pre-releases.
 4. `jpipe.rb` in the Homebrew tap is updated with the new URL and SHA256
    (stable releases only — skipped for pre-releases).
-5. A signed Debian source package is uploaded to `ppa:mcscert/ppa`
+5. `bucket/jpipe.json` in the Scoop bucket is updated with the new version, URL
+   and hash (stable releases only — skipped for pre-releases).
+6. A signed Debian source package is uploaded to `ppa:mcscert/ppa`
    (stable releases only — skipped for pre-releases).
 
 **Verifying the release** (~30 min after the pipeline completes):
@@ -113,6 +117,12 @@ brew install jpipe
 # Ubuntu
 sudo add-apt-repository ppa:mcscert/ppa
 sudo apt update && sudo apt install jpipe
+```
+
+```powershell
+# Windows
+scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert
+scoop install jpipe
 ```
 
 #### Code style

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ The fat JAR is produced in `jpipe-cli/target/`.
 
 #### Releasing a new version
 
-Releases are triggered by pushing a `v*.*.*` tag to `main`. The pipeline
+Releases are triggered by pushing a `v*.*.*` tag that points at a commit on
+`main` — the pipeline refuses a tag that is not an ancestor of `main`. Day-to-day
+work is merged into `dev`; cutting a release means merging `dev` into `main`
+first (see [ADR-0024](docs/adr/0024-git-branching-model.md)). The pipeline then
 creates a GitHub Release, updates the Homebrew formula and the Scoop manifest,
 and uploads a Debian source package to the Ubuntu PPA.
 
@@ -81,14 +84,17 @@ repository settings:
 #    pom.xml should be X.Y.Z-SNAPSHOT; the pipeline strips -SNAPSHOT automatically.
 mvn verify   # confirm the build is green locally
 
-# 2. Tag and push — the pipeline fires automatically.
-git tag vX.Y.Z          # or vX.Y.Z-rcN for a pre-release
-git push origin main --tags
+# 2. Merge dev into main (normally via a release PR). main is release-only:
+#    every commit on it is a published version.
 
-# 3. After the pipeline completes, bump to the next development version.
+# 3. Tag the resulting commit on main and push the tag — the pipeline fires.
+git switch main && git pull --ff-only
+git tag vX.Y.Z          # or vX.Y.Z-rcN for a pre-release
+git push origin vX.Y.Z
+
+# 4. Merge main back into dev, then bump to the next development version on a
+#    topic branch merged into dev.
 mvn -B versions:set -DnewVersion=X.Y+1.0-SNAPSHOT -DgenerateBackupPoms=false
-git commit -am "chore: bump to X.Y+1.0-SNAPSHOT"
-git push origin main
 ```
 
 **What happens automatically:**

--- a/bin/jpipe.ps1
+++ b/bin/jpipe.ps1
@@ -1,0 +1,28 @@
+#!/usr/bin/env pwsh
+# jPipe launcher template (Windows / PowerShell).
+#
+# @@JAVA@@ and @@PREFIX@@ are substituted at package-install time by the
+# packaging channel (see ADR-0021 and ADR-0025). Left unsubstituted, the script
+# falls back to PATH and its own directory so it can be run straight from the
+# repository during development.
+
+$ErrorActionPreference = 'Stop'
+
+$java = '@@JAVA@@'
+if ($java -like '@@*@@') { $java = 'java' }
+
+$prefix = '@@PREFIX@@'
+if ($prefix -like '@@*@@') { $prefix = $PSScriptRoot }
+
+if (-not (Get-Command $java -ErrorAction SilentlyContinue)) {
+    Write-Host '[jpipe] Java not found'
+    exit 1
+}
+
+if (-not (Get-Command 'dot' -ErrorAction SilentlyContinue)) {
+    Write-Host '[jpipe] Graphviz not found'
+    exit 1
+}
+
+& $java -jar (Join-Path $prefix 'jpipe.jar') @args
+exit $LASTEXITCODE

--- a/docs/adr/0020-tag-triggered-release-pipeline.md
+++ b/docs/adr/0020-tag-triggered-release-pipeline.md
@@ -6,42 +6,52 @@
 ## Context
 
 As jPipe matures, stable releases must be distributed to end-users through
-standard package managers. Two primary channels were identified:
-
-- **Homebrew** (macOS) — via the `jpipe-mcscert/homebrew-mcscert` tap
-- **Ubuntu PPA** (Linux) — via `ppa:mcscert/ppa` on Launchpad
-
-Before this ADR, no automated release process existed. The `unstable`
-pre-release job in `build.yml` provided a rolling snapshot for CI consumers,
-but it produced no versioned artifacts and did not update any package manager
-formula.
+standard package managers. Before this ADR, no automated release process
+existed: the build produced a fat JAR, but no versioned artifacts and no
+package-manager update.
 
 Additionally, the version shown by `jpipe doctor` was hardcoded as a string
 literal (`"jPipe 2.0.0"`) in the `@Command` annotation of `Main.java`. This
 was a separate, manually maintained value that could silently diverge from
 the project version in `pom.xml`.
 
+Which platforms jPipe targets, and what a packaging channel must provide, is a
+separate concern owned by
+[ADR-0025](0025-mainstream-platform-distribution.md). This ADR owns the
+*mechanics*: how a release is triggered, validated, built, and handed to each
+channel.
+
 ## Decision
 
-A new workflow (`.github/workflows/release.yml`) is triggered when a tag
-matching `v*.*.*` is pushed to the repository. The workflow:
+A workflow (`.github/workflows/release.yml`) is triggered when a tag matching
+`v*.*.*` is pushed. The workflow:
 
-1. **Validates** that the tag version matches the base version declared in
+1. **Verifies** that the tag points at a commit on `main`, which is release-only
+   under [ADR-0024](0024-git-branching-model.md).
+2. **Validates** that the tag version matches the base version declared in
    `pom.xml` (stripping any `-SNAPSHOT` suffix). The build fails fast if they
    diverge.
-2. **Sets** the final release version via `mvn versions:set` so the fat JAR
+3. **Sets** the final release version via `mvn versions:set` so the fat JAR
    manifest carries the correct `Implementation-Version`.
-3. **Publishes a GitHub Release** with the fat JAR and a Homebrew-compatible
-   tarball (`jpipe-$VERSION.tar.gz` containing `jpipe.jar` + the `homebrew/jpipe`
-   launcher script).
-4. **Updates** the `jpipe.rb` formula in `jpipe-mcscert/homebrew-mcscert`
-   (URL, SHA256, and `openjdk` dependency version).
-5. **Builds and uploads** a signed Debian source package to `ppa:mcscert/ppa`
-   on Launchpad.
+4. **Publishes a GitHub Release** with three assets:
+   - `jpipe-cli-$VERSION.jar` — the fat JAR;
+   - `jpipe-$VERSION.tar.gz` — the Homebrew payload (`jpipe.jar` plus the
+     `bin/jpipe` launcher, in a versioned directory);
+   - `jpipe-$VERSION.zip` — the Scoop payload (`jpipe.jar` plus the
+     `bin/jpipe.ps1` launcher, flat at the archive root).
+5. **Updates** the `jpipe.rb` formula in `jpipe-mcscert/homebrew-mcscert` (URL,
+   SHA256, and `openjdk` dependency version) and writes a versioned
+   `jpipe@$VERSION.rb` alongside it.
+6. **Updates** `bucket/jpipe.json` in `jpipe-mcscert/scoop-mcscert` (version,
+   URL, hash) with one commit per release, which is what Scoop's
+   `scoop install jpipe@X.Y.Z` history lookup walks.
+7. **Builds and uploads** a signed Debian source package to `ppa:mcscert/ppa`
+   on Launchpad, once per targeted Ubuntu series (see
+   [ADR-0023](0023-ubuntu-release-target-policy.md)).
 
-The launcher script previously located at `templates/homebrew/jpipe` is moved
-to `homebrew/jpipe` at the repository root, symmetric with the `debian/`
-directory that Debian tooling requires at the root.
+Steps 5–7 run in parallel, each in its own job depending on the build. The
+launcher templates they install live in `bin/` at the repository root,
+symmetric with the `debian/` directory that Debian tooling requires there.
 
 `pom.xml` becomes the **single source of truth** for the version. The fat JAR
 manifest is populated with `Implementation-Version: ${project.version}` by
@@ -51,29 +61,29 @@ no manifest is present (IDE runs, unit tests).
 
 ## Rationale
 
-- **Tag-based trigger keeps releases deliberate.** Every merge to `main` does
-  not produce a stable release; a developer must explicitly create and push a
-  version tag. The existing `unstable` pre-release on every `main` push
-  continues to serve CI consumers.
+- **Tag-based trigger keeps releases deliberate.** Merging to `dev` integrates a
+  change; it does not ship one. A developer must explicitly merge `dev` into
+  `main` and push a version tag for a release to happen.
 - **Single source of truth eliminates drift.** The previous hardcoded string
   in `Main.java` was a maintenance hazard. Embedding the version from
   `pom.xml` via the manifest removes the need to update two places.
 - **Fail-fast validation.** The workflow aborts immediately if the tag and
-  `pom.xml` version disagree, preventing a release with a mismatched version
-  from reaching package managers.
-- **Homebrew and PPA are the supported install paths.** These two channels
-  cover macOS and Ubuntu users respectively, matching the project's primary
-  audience.
+  `pom.xml` version disagree, or if the tag is not on `main`, preventing a
+  release with a mismatched version from reaching package managers.
+- **One build feeds every channel.** All assets derive from a single
+  `mvn verify`, so every platform ships identical bytecode. Channel jobs
+  consume release assets rather than rebuilding — a requirement of ADR-0025.
 
 ## Consequences
 
 ### Required secrets
 
-Four GitHub Actions secrets must be configured in the repository:
+Five GitHub Actions secrets must be configured in the repository:
 
 | Secret | Purpose |
 |--------|---------|
 | `HOMEBREW_TAP_TOKEN` | PAT with `contents: write` on `jpipe-mcscert/homebrew-mcscert` |
+| `SCOOP_BUCKET_TOKEN` | PAT with `contents: write` on `jpipe-mcscert/scoop-mcscert` |
 | `GPG_PRIVATE_KEY` | ASCII-armored GPG private key registered on Launchpad |
 | `GPG_KEY_ID` | Fingerprint of the signing key |
 | `GPG_PASSPHRASE` | Passphrase for the signing key |
@@ -90,12 +100,13 @@ Manual steps required:
 1. Verify the base version in `pom.xml` matches the intended tag
    (e.g. `2.1.0-SNAPSHOT` to release `v2.1.0`).
 2. Run `mvn verify` locally to confirm the build is green.
-3. Push the tag — the pipeline fires automatically.
-4. After the pipeline completes, bump `pom.xml` to the next development version
-   (`mvn -B versions:set -DnewVersion=X.Y+1.0-SNAPSHOT`) and push to `main`.
+3. Merge `dev` into `main` and push the tag — the pipeline fires automatically.
+4. Merge `main` back into `dev`, then bump `pom.xml` to the next development
+   version (`mvn -B versions:set -DnewVersion=X.Y+1.0-SNAPSHOT`) on a topic
+   branch merged into `dev`.
 
 Tags containing `-` (e.g. `v2.1.0-rc1`) are automatically marked as pre-releases;
-the Homebrew and PPA jobs are skipped for pre-releases.
+all three channel jobs are skipped for them.
 
 See the "Releasing a new version" section in `README.md` for the full
 step-by-step procedure.
@@ -104,7 +115,7 @@ step-by-step procedure.
 
 - `jpipe doctor` now reports the version embedded in the JAR manifest. When
   running from source (no fat JAR), it reports `jPipe dev`.
-- The `templates/` directory is removed; `homebrew/` at the repository root
-  replaces it.
+- The `templates/` directory is removed; `bin/` at the repository root holds the
+  launcher templates for every packaging channel.
 - The `debian/` directory at the repository root is required by
   `dpkg-buildpackage` and must not be moved.

--- a/docs/adr/0025-mainstream-platform-distribution.md
+++ b/docs/adr/0025-mainstream-platform-distribution.md
@@ -1,0 +1,120 @@
+# ADR-0025: Mainstream Platform Distribution Policy
+
+**Date:** 2026-08-06
+**Status:** Accepted
+
+## Context
+
+jPipe reaches its end users through operating-system package managers, not
+through a download page. The set of channels grew ad hoc:
+[ADR-0020](0020-tag-triggered-release-pipeline.md) introduced Homebrew and the
+Ubuntu PPA together as an implementation detail of the release pipeline, and
+this ADR adds Scoop for Windows.
+
+Nothing in the record states *which* platforms are in scope, what a channel has
+to provide before it can be added, or on what grounds one would be dropped. Two
+narrower rules exist — [ADR-0021](0021-pin-runtime-binary-to-declared-dependency.md)
+fixed how the Java runtime is resolved, and
+[ADR-0023](0023-ubuntu-release-target-policy.md) fixed which Ubuntu series the
+PPA matrix targets — but both were written as one-channel patches. The general
+policy lived only in the shape of `.github/workflows/release.yml`.
+
+Adding a third channel makes that gap expensive. Without a stated contract, each
+new package manager invites its own launcher script, its own build, and its own
+notion of where the package index lives; three divergent channels are more than
+one maintainer can keep correct.
+
+## Decision
+
+jPipe supports **one package manager per mainstream desktop operating system**:
+
+| OS | Channel | Index | Release asset | Secret |
+|----|---------|-------|---------------|--------|
+| macOS | Homebrew | `jpipe-mcscert/homebrew-mcscert` (tap) | `jpipe-X.Y.Z.tar.gz` | `HOMEBREW_TAP_TOKEN` |
+| Ubuntu | APT / Launchpad PPA | `ppa:mcscert/ppa` | Debian source package (built from the fat JAR) | `GPG_*` |
+| Windows | Scoop | `jpipe-mcscert/scoop-mcscert` (bucket) | `jpipe-X.Y.Z.zip` | `SCOOP_BUCKET_TOKEN` |
+
+Every channel must satisfy the following contract:
+
+1. **One launcher source.** The channel installs a launcher template from `bin/`
+   — `bin/jpipe` for POSIX shells, `bin/jpipe.ps1` for PowerShell — using the
+   `@@JAVA@@` / `@@PREFIX@@` placeholder convention. A channel does not carry
+   its own launcher implementation.
+2. **Dependencies are declared, and the runtime is resolved from them.** The
+   channel declares Java 25 and Graphviz as package-manager dependencies, and
+   substitutes `@@JAVA@@` with the exact binary owned by the declared
+   dependency, resolved through the package manager's own registry at install
+   time — never with a bare `java`. This generalises ADR-0021 from the two
+   original channels to any channel.
+3. **Channels consume, they do not build.** The channel installs a versioned
+   asset published on the GitHub Release created by the tag-triggered pipeline.
+   No channel compiles from source, so every platform ships bit-identical
+   bytecode from a single `mvn verify`.
+4. **The index is ours and machine-updated.** The formula, manifest, or PPA
+   lives in a repository or service the project controls, and is updated by a
+   push from `release.yml`. Package indices are never edited by hand, and
+   jPipe is not published to third-party-curated indices that would take the
+   update out of the pipeline's hands.
+5. **Stable releases only.** Tags containing `-` (e.g. `v2.3.0-rc1`) publish a
+   GitHub Release marked as a pre-release, but every channel job is skipped.
+   Pre-releases are for verifying the pipeline, not for distribution.
+6. **Superseded versions stay installable.** Each channel keeps older releases
+   reachable through its own native mechanism — versioned formulas
+   (`jpipe@X.Y.Z.rb`) for Homebrew, manifest git history
+   (`scoop install jpipe@X.Y.Z`) for Scoop, and Launchpad's published version
+   history for the PPA. The project does not maintain a separate archive.
+
+Adding a channel means adding a release asset, a `release.yml` job, and a
+credential — and meeting all six points. A channel is dropped when its platform
+is no longer mainstream for jPipe's audience, or when its index can no longer be
+updated automatically.
+
+## Rationale
+
+- **The contract is what makes three channels affordable.** A single launcher
+  source, a single build, and a single trigger mean a release is one tag push
+  regardless of how many platforms are served. Channel-specific launchers or
+  builds would multiply the surface that can break between releases, and each
+  would break on a platform the maintainer does not run day to day.
+- **Point 2 generalises a rule that was learned the hard way.** ADR-0021 was
+  written after the launcher was found to invoke whichever JVM happened to be
+  the system default, defeating the declared dependency. Stating the rule as a
+  channel-admission criterion prevents rediscovering it once per package
+  manager — Scoop's `post_install` substitution exists because of this clause.
+- **Point 3 removes a whole class of divergence.** If Scoop rebuilt from source
+  it would need a JDK on Windows, a Maven cache, and a green Windows build —
+  none of which CI has. Consuming the release asset means the Windows package
+  contains the JAR that macOS and Ubuntu users already run.
+- **Point 4 keeps release state out of human hands.** The failure mode for
+  hand-edited package indices is a formula pointing at a URL whose checksum no
+  longer matches. Making the pipeline the only writer makes that unrepresentable.
+- **Point 6 lets users pin without the project hoarding.** Each package manager
+  already solves version pinning; adopting the native mechanism per channel is
+  cheaper and more idiomatic than a project-run artifact archive. It is also why
+  the Scoop bucket needs no pinned per-version manifests: one commit per release
+  against `bucket/jpipe.json` is exactly what Scoop's `@version` lookup walks.
+- **One channel per OS, not the most popular one.** Chocolatey and WinGet are
+  larger Windows ecosystems than Scoop, but both are curated: publishing means
+  submitting a package for review, which violates point 4. Scoop's bucket model
+  lets the project own the index outright, matching how the Homebrew tap and the
+  PPA already work.
+
+## Consequences
+
+- Five GitHub Actions secrets are now required for a complete release:
+  `HOMEBREW_TAP_TOKEN`, `SCOOP_BUCKET_TOKEN`, `GPG_PRIVATE_KEY`, `GPG_KEY_ID`,
+  and `GPG_PASSPHRASE`. A missing credential fails one channel job, not the
+  release itself.
+- `bin/` is a channel-neutral launcher directory, not a Homebrew-specific one.
+  It holds `jpipe` (POSIX `sh`) and `jpipe.ps1` (PowerShell); both keep a
+  working fallback when their placeholders are unsubstituted, so they can be run
+  directly from a source checkout.
+- Windows is the only channel CI cannot smoke-test: the release workflow runs
+  entirely on `ubuntu-latest` and no Windows runner exists. Verifying a Scoop
+  release requires a Windows machine and remains a manual release-checklist step.
+- `jpipe-mcscert/scoop-mcscert` must contain `bucket/jpipe.json` before the
+  first stable tag after this ADR; `update-scoop` updates an existing manifest
+  and does not create one.
+- ADR-0023 is unaffected and remains the sub-policy governing *which* Ubuntu
+  series the PPA matrix targets. This ADR governs the set of channels; ADR-0020
+  owns the pipeline mechanics that implement them.

--- a/docs/adr/0025-mainstream-platform-distribution.md
+++ b/docs/adr/0025-mainstream-platform-distribution.md
@@ -106,9 +106,13 @@ updated automatically.
   and `GPG_PASSPHRASE`. A missing credential fails one channel job, not the
   release itself.
 - `bin/` is a channel-neutral launcher directory, not a Homebrew-specific one.
-  It holds `jpipe` (POSIX `sh`) and `jpipe.ps1` (PowerShell); both keep a
-  working fallback when their placeholders are unsubstituted, so they can be run
-  directly from a source checkout.
+  It holds `jpipe` (POSIX `sh`) and `jpipe.ps1` (PowerShell). The two differ in
+  how far they get without substitution: `jpipe.ps1` falls back to `PATH` and
+  its own directory, so it runs unchanged from a source checkout, whereas
+  `jpipe` invokes `@@JAVA@@` directly and only keeps its pre-flight `which java`
+  check intact (ADR-0021) — it requires substitution to run. Aligning the POSIX
+  launcher would mean rewriting the line that `debian/postinst` rewrites by
+  exact string match, so it is deliberately left alone here.
 - Windows is the only channel CI cannot smoke-test: the release workflow runs
   entirely on `ubuntu-latest` and no Windows runner exists. Verifying a Scoop
   release requires a Windows machine and remains a manual release-checklist step.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - adr/0022-glob-patterns-in-load.md
       - adr/0023-ubuntu-release-target-policy.md
       - adr/0024-git-branching-model.md
+      - adr/0025-mainstream-platform-distribution.md
 plugins:
   - search
 


### PR DESCRIPTION
Adds Windows distribution via [Scoop](https://scoop.sh), the third mainstream packaging channel alongside Homebrew and the Ubuntu PPA.

jPipe had no Windows install path: `bin/jpipe` is a POSIX `sh` script, and the release published only a tarball and the fat JAR — neither of which Scoop can consume natively.

## Changes

- **`bin/jpipe.ps1`** — PowerShell launcher on the same `@@JAVA@@` / `@@PREFIX@@` placeholder contract as `bin/jpipe`, with a PATH fallback so it still runs unsubstituted from a source checkout (ADR-0021).
- **`release.yml`** — assembles and hashes a flat `jpipe-<version>.zip` (`jpipe.jar` + `jpipe.ps1`), attaches it to the GitHub Release, and adds an `update-scoop` job that bumps `version`/`url`/`hash` in `bucket/jpipe.json` of `jpipe-mcscert/scoop-mcscert`. Mirrors `update-homebrew`, including the stable-releases-only guard.
- **ADR-0025** — records the mainstream platform distribution policy covering all three channels and the six-point contract a channel must meet. This was never written down; the channel set lived only in the shape of the workflow.
- **ADR-0020** — rewritten to describe the pipeline as it stands today: three channels, five secrets, `bin/` rather than the long-renamed `homebrew/`, and the `dev`/`main` model from ADR-0024.
- README, CHANGELOG, mkdocs nav.

## Design notes

**Versioning without pinned manifests.** One commit per release against `bucket/jpipe.json` is exactly what Scoop's `scoop install jpipe@X.Y.Z` git-history lookup walks, so past versions stay installable with no per-version manifest files — the native equivalent of Homebrew's `jpipe@X.Y.Z.rb`.

**Flat zip, not a versioned directory.** Drops the `extract_dir` field, so CI templates exactly three fields.

**ADR-0021 compliance.** `temurin25-jre` is declared as a dependency and `post_install` substitutes the absolute `java.exe` path from `scoop prefix`, rather than relying on a bare `java` from PATH.

## Verification

- Zip assembly reproduced locally from the exact CI shell — archive contains exactly `jpipe.jar` + `jpipe.ps1` at the root.
- The `jq` manifest bump was dry-run against the real seeded manifest: it changes only `version`/`url`/`hash`, and is byte-stable on re-run.
- Both dependency names checked against the live buckets: `temurin25-jre` exists in `ScoopInstaller/Java` (with `env_add_path: "bin"`, confirming the `post_install` path), `graphviz` in `ScoopInstaller/Main`.
- Not verified: `pwsh` and `mkdocs` were unavailable locally, so the launcher was never executed and the docs site was not built. Windows end-to-end needs a real machine — CI has no Windows runner.

No Java source changes; `mvn verify` is unaffected.

## Prerequisites (both already done)

- `SCOOP_BUCKET_TOKEN` secret — set.
- `bucket/jpipe.json` seeded in the bucket repo — merged as jpipe-mcscert/scoop-mcscert#1.

`scoop install jpipe` starts working on the first **stable** tag after this merges; an `-rc` tag skips `update-scoop` by the same guard that skips Homebrew and the PPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)