### PR TITLE
chore: prepare the 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,16 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+---
+
+## [2.3.0] — 2026-08-06
+
 ### Added
 - jPipe can now be installed on Windows with [Scoop](https://scoop.sh):
   `scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert`
-  followed by `scoop install jpipe`. Releases publish an additional
+  followed by `scoop install mcscert/jpipe`. Releases publish an additional
   `jpipe-<version>.zip` asset, and the release pipeline keeps the bucket
-  manifest up to date automatically (ADR-0025).
+  manifest up to date automatically (#142, ADR-0025).
 
 ---
 
@@ -274,7 +278,8 @@ server.
 ### Added
 - Initial commit: first version of the compiler.
 
-[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.4...v2.1.0
 [2.0.4]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.3...v2.0.4

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sudo apt update && sudo apt install jpipe
 ```powershell
 # Windows
 scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert
-scoop install jpipe
+scoop install mcscert/jpipe
 ```
 
 #### Code style


### PR DESCRIPTION
Release-prep for **v2.3.0**. Changelog finalization plus one consistency fix; no code changes.

## Changes

**`CHANGELOG.md`**
- `## [Unreleased]` → `## [2.3.0] — 2026-08-06`, with a fresh empty `[Unreleased]` opened above it.
- Link definitions: `[Unreleased]` now compares `v2.3.0...HEAD`; added `[2.3.0]` → `v2.2.0...v2.3.0`.
- The Scoop entry now reads `scoop install mcscert/jpipe` and carries the `(#142, ADR-0025)` reference.

**`README.md`**
- The "Verifying the release" Windows block uses the same bucket-qualified form.

## Why the qualified install command

The bare `scoop install jpipe` only resolves when no other installed bucket ships a `jpipe` manifest — otherwise Scoop reports an ambiguous app name and refuses. The bucket's own README already documented the qualified form, so the three sources now agree.

## Scope check

I reviewed the full `v2.2.0..dev` range. Scoop support (#142) is the only user-facing change in this release; everything else is the `2.3.0-SNAPSHOT` bump, the `.gitattributes` linguist chore, and ADR/doc work, none of which warrants a changelog entry.

`pom.xml` deliberately stays at `2.3.0-SNAPSHOT` — the release pipeline runs `mvn versions:set` internally to stamp the exact version into the fat JAR manifest.

## After this merges

Merge `dev` → `main`, tag `v2.3.0`, push the tag. That release run publishes the first `jpipe-<version>.zip` and pushes real values into the Scoop bucket, at which point `scoop install mcscert/jpipe` starts working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)