### PR TITLE
Bump version to 2.4.0-SNAPSHOT

### DIFF
--- a/jpipe-cli/pom.xml
+++ b/jpipe-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-cli</artifactId>

--- a/jpipe-compiler/pom.xml
+++ b/jpipe-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-compiler</artifactId>

--- a/jpipe-lang/pom.xml
+++ b/jpipe-lang/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-lang</artifactId>

--- a/jpipe-model/pom.xml
+++ b/jpipe-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-model</artifactId>

--- a/jpipe-operators/pom.xml
+++ b/jpipe-operators/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-operators</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jpipe</groupId>
     <artifactId>jpipe</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>jPipe</name>


### PR DESCRIPTION
This pull request updates the project version across all modules from `2.3.0-SNAPSHOT` to `2.4.0-SNAPSHOT`. This ensures consistency in versioning for the entire codebase.

Version updates:

* Updated the parent project version in `pom.xml` to `2.4.0-SNAPSHOT`
* Updated the parent version references in the following module POM files to `2.4.0-SNAPSHOT`:
  * `jpipe-cli/pom.xml`
  * `jpipe-compiler/pom.xml`
  * `jpipe-lang/pom.xml`
  * `jpipe-model/pom.xml`
  * `jpipe-operators/pom.xml`