### PR TITLE
docs: correct how Scoop resolves an explicit @version

### DIFF
--- a/docs/adr/0020-tag-triggered-release-pipeline.md
+++ b/docs/adr/0020-tag-triggered-release-pipeline.md
@@ -43,8 +43,8 @@ A workflow (`.github/workflows/release.yml`) is triggered when a tag matching
    SHA256, and `openjdk` dependency version) and writes a versioned
    `jpipe@$VERSION.rb` alongside it.
 6. **Updates** `bucket/jpipe.json` in `jpipe-mcscert/scoop-mcscert` (version,
-   URL, hash) with one commit per release, which is what Scoop's
-   `scoop install jpipe@X.Y.Z` history lookup walks.
+   URL, hash). The manifest's `autoupdate` block is left untouched, and is what
+   lets Scoop reconstruct an older `scoop install mcscert/jpipe@X.Y.Z`.
 7. **Builds and uploads** a signed Debian source package to `ppa:mcscert/ppa`
    on Launchpad, once per targeted Ubuntu series (see
    [ADR-0023](0023-ubuntu-release-target-policy.md)).

--- a/docs/adr/0025-mainstream-platform-distribution.md
+++ b/docs/adr/0025-mainstream-platform-distribution.md
@@ -60,9 +60,11 @@ Every channel must satisfy the following contract:
    Pre-releases are for verifying the pipeline, not for distribution.
 6. **Superseded versions stay installable.** Each channel keeps older releases
    reachable through its own native mechanism — versioned formulas
-   (`jpipe@X.Y.Z.rb`) for Homebrew, manifest git history
-   (`scoop install jpipe@X.Y.Z`) for Scoop, and Launchpad's published version
-   history for the PPA. The project does not maintain a separate archive.
+   (`jpipe@X.Y.Z.rb`) for Homebrew, an `autoupdate` block that lets Scoop
+   reconstruct a manifest for an explicit `@version`, and Launchpad's published
+   version history for the PPA. The project does not maintain a separate
+   archive. A channel reaches only as far back as the first release that
+   published its asset.
 
 Adding a channel means adding a release asset, a `release.yml` job, and a
 credential — and meeting all six points. A channel is dropped when its platform
@@ -90,9 +92,14 @@ updated automatically.
   longer matches. Making the pipeline the only writer makes that unrepresentable.
 - **Point 6 lets users pin without the project hoarding.** Each package manager
   already solves version pinning; adopting the native mechanism per channel is
-  cheaper and more idiomatic than a project-run artifact archive. It is also why
-  the Scoop bucket needs no pinned per-version manifests: one commit per release
-  against `bucket/jpipe.json` is exactly what Scoop's `@version` lookup walks.
+  cheaper and more idiomatic than a project-run artifact archive. For Scoop this
+  means an `autoupdate` block rather than pinned per-version manifests: Scoop
+  does **not** search bucket history for an older manifest — `generate_user_manifest`
+  synthesises one by substituting the requested version into the `autoupdate`
+  URL and hashing the downloaded archive. A single templatable release URL
+  therefore covers every version, and the bucket stays one file per app. The
+  block carries no `checkver`, so nothing polls or self-updates and point 4
+  still holds: the release pipeline remains the only writer.
 - **One channel per OS, not the most popular one.** Chocolatey and WinGet are
   larger Windows ecosystems than Scoop, but both are curated: publishing means
   submitting a package for review, which violates point 4. Scoop's bucket model


### PR DESCRIPTION
Corrects a factual error in ADR-0020 and ADR-0025, both introduced in #142.

## The error

Both ADRs claimed Scoop finds an older manifest by walking the bucket's git history:

> …with one commit per release, which is what Scoop's `scoop install jpipe@X.Y.Z` history lookup walks.

ADR-0025 went further and used that as the *reason* the bucket needs no pinned per-version manifests. It is wrong. `generate_user_manifest` ([`lib/manifest.ps1:175-197`](https://github.com/ScoopInstaller/Scoop/blob/master/lib/manifest.ps1)) never touches git — it reconstructs the manifest from the `autoupdate` block, substituting the requested version into the URL and hashing the downloaded archive, and aborts with *"does not have autoupdate capability"* when that block is absent.

Surfaced by real Windows testing: `scoop install mcscert/jpipe@2.2.0` failed with exactly that message.

## What changed

- **ADR-0025 point 6** — Scoop's native mechanism is an `autoupdate` block, not manifest history. Adds that a channel reaches only as far back as the first release publishing its asset.
- **ADR-0025 rationale** — rewritten. The *decision* survives (the bucket still needs no pinned manifests) but for a different reason: one templatable release URL covers every version. Also records that the block carries no `checkver`, so point 4 (the pipeline is the only writer) still holds.
- **ADR-0020 step 6** — describes `autoupdate` as the mechanism and notes the pipeline leaves it untouched.

The bucket manifest gains the corresponding `autoupdate` block in jpipe-mcscert/scoop-mcscert#4.

## Notes

**No CHANGELOG entry.** The change here is documentation only; the capability itself ships in the bucket repository, independent of any jPipe release. I checked the released 2.3.0 entry — it claims only that the pipeline keeps the manifest current, never version pinning, so no released section is inaccurate.

Docs only; no code, no behaviour change in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)