### PR TITLE
Remove tree reporter to ensure failing scenarios fail the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
-        <junit-tree-reporter.version>1.5.1</junit-tree-reporter.version>
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <log4j-transform.version>0.1.0</log4j-transform.version>
         <spotless-plugin.version>3.8.0</spotless-plugin.version>
@@ -214,26 +213,21 @@
                     </configuration>
                 </plugin>
 
+                <!--
+                  Stock reporting only. A custom statelessTestsetInfoReporter
+                  does not just restyle the output: it supplies the listener
+                  that accumulates run statistics, so a defective one can drop
+                  results from the pass/fail decision. The tree reporter
+                  (me.fabriciorby:maven-surefire-junit5-tree-reporter) did
+                  exactly that at 1.5.1 — Cucumber scenarios, which run under a
+                  @Suite-nested engine, were written to their XML report but
+                  omitted from the aggregate, so failing E2E tests still gave
+                  BUILD SUCCESS. Prettier output is not worth that risk.
+                -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>me.fabriciorby</groupId>
-                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-                            <version>${junit-tree-reporter.version}</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <consoleOutputReporter>
-                            <disable>true</disable>
-                        </consoleOutputReporter>
-                        <statelessTestsetInfoReporter
-                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
-                            <theme>UNICODE</theme>
-                        </statelessTestsetInfoReporter>
-                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
This pull request removes the custom JUnit tree reporter from the Maven Surefire plugin configuration due to reliability concerns and reverts to using the default reporting. A detailed comment is added to explain the reasoning behind this change.

Testing and reporting configuration:

* Removed the `maven-surefire-junit5-tree-reporter` dependency and its configuration from the `maven-surefire-plugin` section in `pom.xml`, reverting to stock reporting to ensure all test results are correctly aggregated and build failures are not missed.
* Deleted the `junit-tree-reporter.version` property from `pom.xml` as it is no longer needed.
* Added a comment to clarify that the custom reporter could cause false positives by omitting failing tests from the build result, justifying the return to default reporting.