### PR TITLE
Fix glob anchoring to support upward paths and improve diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- A glob pattern in a `load` directive may now point outside the declaring
+  file's directory, e.g. `load "../library/*.jd" as lib`, or name an absolute
+  location. Such patterns previously failed with a spurious `No file matches
+  load pattern`, even though the equivalent literal path (`load
+  "../library/foo.jd"`) worked. A pattern whose directory does not exist, or
+  one that uses `..` after a wildcard (`*/../foo.jd`, which can never match),
+  now reports a fatal error that names the actual problem (ADR-0022).
+
 ---
 
 ## [2.3.0] — 2026-08-06

--- a/docs/adr/0022-glob-patterns-in-load.md
+++ b/docs/adr/0022-glob-patterns-in-load.md
@@ -66,7 +66,15 @@ Standard Java NIO glob semantics apply, matched against each candidate's path
 A pattern is split at the last `/` preceding its **first wildcard character**.
 Everything before that cut is a literal path, resolved against the declaring
 file's directory exactly like a literal `load` — so it may contain `..` or be
-absolute. The remainder is the glob, matched relative to the resolved directory,
+absolute.
+
+"The declaring file" always means the file that physically contains the `load`
+line, not the file that started the compilation and not the process working
+directory: `LoadResolver` gives every loaded file a `CompilationContext` of its
+own before recursing, so a nested `load "sibling/*.jd"` inside `b/mid.jd`
+resolves to `b/sibling/`, whatever compiled `b/mid.jd` and wherever the compiler
+was invoked from. A relative path is thus a stable property of the file that
+writes it. The remainder is the glob, matched relative to the resolved directory,
 which is also the only subtree that gets walked:
 
 | Pattern            | Literal prefix | Anchor            | Effective glob |
@@ -158,7 +166,18 @@ glob.
 - Cycle detection and idempotent-load suppression apply per matched file, so a
   glob that (transitively) re-includes a file already in progress is still
   flagged as a cycle, and a file matched twice under the same namespace is
-  loaded once.
+  loaded once. Expansion therefore always terminates, however the patterns are
+  tangled: two directories globbing into each other (`a/` loads `b/*.jd`, `b/`
+  loads `a/*.jd`) stops with a `Circular load detected` FATAL rather than
+  recursing.
+- **A glob must not match its own declaring file.** A pattern with no directory
+  prefix — `*.jd`, `./*.jd`, `**.jd` — is anchored at the declaring file's own
+  directory and so necessarily matches that file, which is a cycle and thus a
+  FATAL. This is deliberate: a self-match is treated as the same error as any
+  other cycle rather than being silently skipped. The practical consequence is
+  that models intended to be glob-loaded live in a directory of their own, so
+  the pattern that pulls them in (`models/*.jd`) cannot reach the file doing the
+  pulling. `examples/invalid/022_load_glob_self.jd` pins the behaviour.
 - Because Java glob is used verbatim, `**/*.jd` matches nested files **only**;
   `**.jd` is the pattern for "every `.jd` at any depth". This is documented in
   the table above and in `examples/022_load_glob_recursive.jd`.

--- a/docs/adr/0022-glob-patterns-in-load.md
+++ b/docs/adr/0022-glob-patterns-in-load.md
@@ -51,13 +51,55 @@ walking beyond a `Files.walk`. True regular expressions on file paths are
 unusual and were rejected.
 
 Standard Java NIO glob semantics apply, matched against each candidate's path
-*relative to the declaring file's directory*:
+*relative to the pattern's anchor directory* (see below):
 
-| Pattern         | Matches                                                    |
-|-----------------|------------------------------------------------------------|
-| `models/*.jd`   | `.jd` files directly in `models/` (one level, no descent)  |
-| `models/**/*.jd`| `.jd` files in **sub**directories of `models/` only        |
-| `models/**.jd`  | every `.jd` under `models/`, at any depth (incl. top level)|
+| Pattern             | Matches                                                    |
+|---------------------|------------------------------------------------------------|
+| `models/*.jd`       | `.jd` files directly in `models/` (one level, no descent)  |
+| `models/**/*.jd`    | `.jd` files in **sub**directories of `models/` only        |
+| `models/**.jd`      | every `.jd` under `models/`, at any depth (incl. top level)|
+| `../library/*.jd`   | `.jd` files directly in a `library/` directory *beside* the declaring file's directory |
+| `/opt/models/*.jd`  | `.jd` files directly in an absolute location               |
+
+### Anchoring: where the walk starts
+
+A pattern is split at the last `/` preceding its **first wildcard character**.
+Everything before that cut is a literal path, resolved against the declaring
+file's directory exactly like a literal `load` — so it may contain `..` or be
+absolute. The remainder is the glob, matched relative to the resolved directory,
+which is also the only subtree that gets walked:
+
+| Pattern            | Literal prefix | Anchor            | Effective glob |
+|--------------------|----------------|-------------------|----------------|
+| `models/*.jd`      | `models`       | `<dir>/models`    | `*.jd`         |
+| `**.jd`            | *(none)*       | `<dir>`           | `**.jd`        |
+| `../library/*.jd`  | `../library`   | `<dir>/../library`| `*.jd`         |
+| `/opt/models/*.jd` | `/opt/models`  | `/opt/models`     | `*.jd`         |
+| `{a,b}/*.jd`       | *(none)*       | `<dir>`           | `{a,b}/*.jd`   |
+
+Anchoring is **meaning-preserving** for patterns that only descend: matching
+`dir/X` against `dir/<glob>` relative to `<dir>` is equivalent to matching `X`
+against `<glob>` relative to `<dir>/dir`, for every glob construct including
+`**`. Because the cut is made before the first wildcard *character* rather than
+at a segment boundary, a wildcard construct is never split — a brace group
+spanning a separator such as `{foo/bar,baz}/*.jd` keeps its original meaning.
+
+Without anchoring, a glob could only ever descend: a directory walk never
+produces a path containing `..`, so `load "../library/*.jd"` matched nothing and
+reported a spurious "no file matches", even though the literal
+`load "../library/foo.jd"` resolved fine. Anchoring makes the two forms agree.
+
+Two situations are rejected up front rather than surfacing as a confusing
+no-match:
+
+- a `..` segment **after** the first wildcard (e.g. `*/../foo.jd`) is
+  unsatisfiable by a downward walk and is a FATAL;
+- an anchor that is not an existing directory is a FATAL naming the directory
+  (`Cannot expand load pattern '…': '…' is not a directory`), which points at
+  the actual mistake — usually a typo in the literal prefix.
+
+Glob *syntax* is validated before either check, so a malformed pattern is always
+reported as such regardless of where it points.
 
 ### Backward compatibility
 
@@ -92,8 +134,15 @@ The change is localized to `LoadResolver`
 
 - `expand(LoadDirective, …)` now computes the base directory, and:
   - for a literal path, calls the extracted per-file helper `expandOne` once;
-  - for a glob, matches via `matchGlob`, FATALs on zero matches, otherwise calls
-    `expandOne` for each matched path and concatenates the results.
+  - for a glob, delegates to `expandGlob`.
+- `expandGlob(…)` splits the pattern with `anchor(base, pattern)` into a
+  `GlobAnchor(root, pattern)` record, compiles the `PathMatcher` (FATAL on a
+  syntax error), rejects a post-wildcard `..` and a non-directory anchor, then
+  matches via `matchGlob(root, matcher)`, FATALs on zero matches, and otherwise
+  calls `expandOne` for each matched path and concatenates the results.
+- `firstMetaChar(String)` is the single definition of what counts as a wildcard
+  (`*`, `?`, `[`, `{`); both `isGlob` and `anchor` are derived from it so the
+  literal/glob split and the anchor cut cannot drift apart.
 - `expandOne(Path, …)` holds the unchanged per-file body from ADR-0017 (cycle
   detection via the `visited` set, duplicate suppression via the `loaded` set,
   sub-file parsing, recursive resolution, namespace prefixing, diagnostic
@@ -116,7 +165,13 @@ glob.
 - A shared namespace over many files can surface name collisions at
   interpretation time; this is intentional and matches existing flat-import
   semantics.
-- Globbing walks the declaring file's directory subtree. For very large trees a
-  single-level `*.jd` still walks the whole subtree and filters; this is
-  acceptable at the current project scale and can be optimized later with a
-  `DirectoryStream` fast path for non-`**` patterns if needed.
+- Globbing walks only the pattern's anchor subtree, not the whole subtree of the
+  declaring file, so a pattern like `models/*.jd` never enumerates sibling
+  directories. A pattern whose anchor is broad (`**.jd` at the top of a large
+  tree) still walks everything below it; this is acceptable at the current
+  project scale and can be optimized later with a `DirectoryStream` fast path
+  for non-`**` patterns if needed.
+- A pattern may now name files outside the project, via `..` or an absolute
+  prefix. This is deliberate — it mirrors what a literal `load` path has always
+  been able to do — and the usual consequence applies: a `.jd` file's set of
+  dependencies is only as portable as the paths it names.

--- a/docs/adr/0022-glob-patterns-in-load.md
+++ b/docs/adr/0022-glob-patterns-in-load.md
@@ -171,11 +171,14 @@ glob.
   loads `a/*.jd`) stops with a `Circular load detected` FATAL rather than
   recursing.
 - **A glob must not match its own declaring file.** A pattern with no directory
-  prefix — `*.jd`, `./*.jd`, `**.jd` — is anchored at the declaring file's own
-  directory and so necessarily matches that file, which is a cycle and thus a
-  FATAL. This is deliberate: a self-match is treated as the same error as any
-  other cycle rather than being silently skipped. The practical consequence is
-  that models intended to be glob-loaded live in a directory of their own, so
+  prefix is anchored at the declaring file's own directory, so it is a cycle —
+  and thus a FATAL — whenever it also matches that file's *name*. A catch-all
+  (`*.jd`, `./*.jd`, `**.jd`) always does, which makes "load everything beside
+  me" unwritable; a narrower prefix-less pattern is fine as long as it does not
+  match the declaring file (`none_*.jd` from a file called `a.jd` is a plain
+  no-match). This is deliberate: a self-match is treated as the same error as
+  any other cycle rather than being silently skipped. The practical consequence
+  is that models intended to be glob-loaded live in a directory of their own, so
   the pattern that pulls them in (`models/*.jd`) cannot reach the file doing the
   pulling. `examples/invalid/022_load_glob_self.jd` pins the behaviour.
 - Because Java glob is used verbatim, `**/*.jd` matches nested files **only**;

--- a/docs/design/steps.md
+++ b/docs/design/steps.md
@@ -177,9 +177,10 @@ sorted for deterministic order; an empty match set is a FATAL. A literal path
 at the last directory before its first wildcard, and that prefix is resolved like
 any literal path — so a pattern may also reach outside the declaring file's
 directory (`load "../library/*.jd" as lib`) or name an absolute location. A
-prefix-less pattern (`*.jd`) is anchored at the declaring file's own directory
-and therefore matches that file, which is a load cycle and a FATAL; keep
-glob-loaded models in a directory of their own. See ADR-0022.
+prefix-less pattern is anchored at the declaring file's own directory, so it is
+a load cycle and a FATAL whenever it also matches that file's name — which a
+catch-all such as `*.jd` always does; keep glob-loaded models in a directory of
+their own. See ADR-0022.
 
 ---
 

--- a/docs/design/steps.md
+++ b/docs/design/steps.md
@@ -176,8 +176,10 @@ sorted for deterministic order; an empty match set is a FATAL. A literal path
 (no glob metacharacters) keeps the single-file behavior. The pattern is anchored
 at the last directory before its first wildcard, and that prefix is resolved like
 any literal path — so a pattern may also reach outside the declaring file's
-directory (`load "../library/*.jd" as lib`) or name an absolute location. See
-ADR-0022.
+directory (`load "../library/*.jd" as lib`) or name an absolute location. A
+prefix-less pattern (`*.jd`) is anchored at the declaring file's own directory
+and therefore matches that file, which is a load cycle and a FATAL; keep
+glob-loaded models in a directory of their own. See ADR-0022.
 
 ---
 

--- a/docs/design/steps.md
+++ b/docs/design/steps.md
@@ -173,7 +173,11 @@ A `load` path may also be a **glob pattern** (e.g. `load "models/*.jd" as lib`),
 in which case one directive expands into every matched file, each resolved by
 the same per-file logic (cycle detection, deduplication, prefixing). Matches are
 sorted for deterministic order; an empty match set is a FATAL. A literal path
-(no glob metacharacters) keeps the single-file behavior. See ADR-0022.
+(no glob metacharacters) keeps the single-file behavior. The pattern is anchored
+at the last directory before its first wildcard, and that prefix is resolved like
+any literal path — so a pattern may also reach outside the declaring file's
+directory (`load "../library/*.jd" as lib`) or name an absolute location. See
+ADR-0022.
 
 ---
 

--- a/examples/023_load_glob_relative.jd
+++ b/examples/023_load_glob_relative.jd
@@ -1,0 +1,13 @@
+// A glob pattern is anchored at its literal prefix, which is resolved exactly
+// like a literal load path. It may therefore climb out of the declaring file's
+// directory with "..": here the pattern walks up out of examples/ and back down
+// into globs/, matching model_alpha.jd and model_beta.jd.
+load "../examples/globs/*.jd" as lib
+
+justification alpha_justification implements lib:alpha {
+    evidence lib:alpha:abs is "A concrete evidence for alpha"
+}
+
+justification beta_justification implements lib:beta {
+    evidence lib:beta:abs is "A concrete evidence for beta"
+}

--- a/examples/invalid/020_load_glob_nomatch.jd
+++ b/examples/invalid/020_load_glob_nomatch.jd
@@ -1,5 +1,8 @@
 // A glob that matches no file is a fatal error (likely a typo or wrong path).
-load "globs/none_*.jd" as lib
+// The anchor directory (examples/globs) exists and simply holds nothing called
+// "none_*.jd"; a pattern whose *directory* is missing is a different error, see
+// 023_load_glob_nodir.jd.
+load "../globs/none_*.jd" as lib
 
 justification j implements lib:alpha {
     evidence lib:alpha:abs is "unreachable"

--- a/examples/invalid/022_load_glob_self.jd
+++ b/examples/invalid/022_load_glob_self.jd
@@ -1,0 +1,11 @@
+// A glob is anchored at its literal prefix, so a pattern with no directory
+// prefix searches the declaring file's own directory — and therefore matches
+// this very file. That is a load cycle, and it is fatal. The pattern below is
+// narrowed so it matches nothing but this file; a bare "*.jd" behaves the same
+// way, which is why models meant to be glob-loaded live in a directory of their
+// own ("globs/*.jd" cannot match the file that loads it).
+load "022_load_glob_self*.jd" as lib
+
+justification j implements lib:alpha {
+    evidence lib:alpha:abs is "unreachable"
+}

--- a/examples/invalid/022_load_glob_self.jd
+++ b/examples/invalid/022_load_glob_self.jd
@@ -1,9 +1,10 @@
 // A glob is anchored at its literal prefix, so a pattern with no directory
-// prefix searches the declaring file's own directory — and therefore matches
-// this very file. That is a load cycle, and it is fatal. The pattern below is
-// narrowed so it matches nothing but this file; a bare "*.jd" behaves the same
-// way, which is why models meant to be glob-loaded live in a directory of their
-// own ("globs/*.jd" cannot match the file that loads it).
+// prefix searches the declaring file's own directory. When it also matches that
+// file's name — as the one below does, being narrowed to match nothing else —
+// the file loads itself, which is a load cycle and is fatal. A bare "*.jd"
+// matches every neighbour including this file and so always behaves this way,
+// which is why models meant to be glob-loaded live in a directory of their own
+// ("globs/*.jd" cannot match the file that loads it).
 load "022_load_glob_self*.jd" as lib
 
 justification j implements lib:alpha {

--- a/examples/invalid/023_load_glob_nodir.jd
+++ b/examples/invalid/023_load_glob_nodir.jd
@@ -1,0 +1,8 @@
+// A glob is anchored at the last directory before its first wildcard. When that
+// directory does not exist the error names it, rather than reporting the vaguer
+// "no file matches" — the mistake is almost always a typo in the prefix.
+load "no_such_dir/*.jd" as lib
+
+justification j implements lib:alpha {
+    evidence lib:alpha:abs is "unreachable"
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -52,7 +53,11 @@ import org.antlr.v4.runtime.tree.ParseTree;
  * Algorithm for each {@code load "path" as ns} directive found in the list:
  * <ol>
  * <li>Resolve {@code path} relative to the directory of the file currently
- * being compiled (taken from the {@link CompilationContext#sourcePath()}).</li>
+ * being compiled (taken from the {@link CompilationContext#sourcePath()}). When
+ * {@code path} is a glob pattern it expands to every matched file instead of
+ * one; its literal prefix is resolved the same way, so a pattern may point
+ * below that directory, above it ({@code ../library/*.jd}) or at an absolute
+ * location — see {@link #anchor}.</li>
  * <li>Detect cycles: if the resolved path is already being compiled in the
  * current call stack, report a FATAL and skip.</li>
  * <li>Parse the referenced file up to and including {@link ActionListProvider}
@@ -92,8 +97,9 @@ public final class LoadResolver
 	 * always throws, so it can never be executed directly.
 	 *
 	 * @param path
-	 *            unquoted path to the file to load, relative to the declaring
-	 *            file.
+	 *            unquoted path to the file to load, or a glob pattern matching
+	 *            several of them; resolved relative to the declaring file
+	 *            unless absolute.
 	 * @param namespace
 	 *            alias under which the loaded file's models are registered, or
 	 *            {@code null} for a flat (no-prefix) import.
@@ -154,14 +160,41 @@ public final class LoadResolver
 			Path resolved = base.resolve(load.path()).normalize();
 			return expandOne(resolved, load, ctx, visited, loaded);
 		}
+		return expandGlob(load, ctx, base, visited, loaded);
+	}
 
-		List<Path> matches;
+	/**
+	 * Expands a glob pattern into the commands of every matched file. The
+	 * pattern is first anchored (see {@link #anchor}), so it may reach outside
+	 * the declaring file's directory via {@code ..} or an absolute prefix.
+	 */
+	private List<Command> expandGlob(LoadDirective load, CompilationContext ctx,
+			Path base, Set<Path> visited, Set<String> loaded) {
+		GlobAnchor anchored = anchor(base, load.path());
+
+		PathMatcher matcher;
 		try {
-			matches = matchGlob(base, load.path());
+			matcher = FileSystems.getDefault()
+					.getPathMatcher("glob:" + anchored.pattern());
 		} catch (PatternSyntaxException e) {
 			ctx.fatal("Invalid glob in load pattern '" + load.path() + "': "
 					+ e.getDescription());
 			return List.of();
+		}
+		if (hasUpwardSegment(anchored.pattern())) {
+			ctx.fatal("'..' may only appear before the first wildcard in load"
+					+ " pattern '" + load.path() + "'");
+			return List.of();
+		}
+		if (!Files.isDirectory(anchored.root())) {
+			ctx.fatal("Cannot expand load pattern '" + load.path() + "': '"
+					+ anchored.root() + "' is not a directory");
+			return List.of();
+		}
+
+		List<Path> matches;
+		try {
+			matches = matchGlob(anchored.root(), matcher);
 		} catch (IOException | UncheckedIOException e) {
 			ctx.fatal("Cannot expand load pattern '" + load.path() + "': "
 					+ e.getMessage());
@@ -227,35 +260,97 @@ public final class LoadResolver
 	}
 
 	/**
+	 * A glob pattern split into the directory the search is anchored at and the
+	 * portion of the pattern matched relative to that directory.
+	 *
+	 * @param root
+	 *            absolute, normalized directory to walk.
+	 * @param pattern
+	 *            glob matched against paths relative to {@code root}.
+	 */
+	private record GlobAnchor(Path root, String pattern) {
+	}
+
+	/**
+	 * Index of the first glob metacharacter in {@code path}, or {@code -1} if
+	 * it holds none. Single source of truth for what counts as "a glob", shared
+	 * by {@link #isGlob} and {@link #anchor}.
+	 */
+	private static int firstMetaChar(String path) {
+		for (int i = 0; i < path.length(); i++) {
+			char c = path.charAt(i);
+			if (c == '*' || c == '?' || c == '[' || c == '{') {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
 	 * Tells whether a load path is a glob pattern (rather than a literal path).
 	 * A literal path keeps the historical single-file behavior, including the
 	 * "Cannot open loaded file" fatal error when it does not exist.
 	 */
 	private static boolean isGlob(String path) {
-		return path.chars()
-				.anyMatch(c -> c == '*' || c == '?' || c == '[' || c == '{');
+		return firstMetaChar(path) >= 0;
 	}
 
 	/**
-	 * Resolves a glob pattern against {@code base}, returning the matching
-	 * regular files as absolute, normalized paths in a deterministic
-	 * (lexicographic) order. Standard glob semantics apply: {@code *} does not
-	 * cross directory boundaries, while {@code **} does.
+	 * Anchors a glob pattern: everything up to the last {@code /} preceding the
+	 * first wildcard is a literal path, resolved against {@code base} exactly
+	 * like a literal load, and the remainder is the pattern to match relative
+	 * to that directory. This is what lets a pattern reach outside the
+	 * declaring file's directory ({@code ../library/*.jd}) or name an absolute
+	 * location ({@code /opt/models/*.jd}).
 	 *
-	 * @throws PatternSyntaxException
-	 *             if {@code pattern} is not a valid glob (e.g. an unbalanced
-	 *             {@code [}); reported as a FATAL by the caller.
+	 * <p>
+	 * The cut is made before the first wildcard <em>character</em>, never
+	 * inside a wildcard construct, so a brace group spanning a separator such
+	 * as {@code {foo/bar,baz}/*.jd} stays intact. Because matching
+	 * {@code dir/X} against {@code dir/<pat>} relative to {@code base} is
+	 * equivalent to matching {@code X} against {@code <pat>} relative to
+	 * {@code base/dir}, anchoring leaves the meaning of every previously
+	 * supported pattern unchanged — it only narrows the subtree that has to be
+	 * walked.
+	 */
+	private static GlobAnchor anchor(Path base, String pattern) {
+		int cut = pattern.lastIndexOf('/', firstMetaChar(pattern));
+		if (cut < 0) {
+			return new GlobAnchor(base, pattern);
+		}
+		// cut == 0 means an absolute pattern such as "/opt/*.jd": the literal
+		// prefix is the root itself, which substring(0, 0) would lose.
+		String prefix = cut == 0 ? "/" : pattern.substring(0, cut);
+		return new GlobAnchor(base.resolve(prefix).normalize(),
+				pattern.substring(cut + 1));
+	}
+
+	/**
+	 * Tells whether a pattern contains a {@code ..} segment. Directory walking
+	 * only ever descends, so a {@code ..} left after anchoring (i.e. one that
+	 * follows a wildcard, as in {@code *}{@code /../foo.jd}) can never match
+	 * anything; the caller reports it as a FATAL rather than as a puzzling
+	 * no-match.
+	 */
+	private static boolean hasUpwardSegment(String pattern) {
+		return Arrays.stream(pattern.split("/", -1)).anyMatch(".."::equals);
+	}
+
+	/**
+	 * Walks {@code root}, returning the regular files matching {@code matcher}
+	 * as absolute, normalized paths in a deterministic (lexicographic) order.
+	 * Standard glob semantics apply: {@code *} does not cross directory
+	 * boundaries, while {@code **} does.
+	 *
 	 * @throws IOException
-	 *             if walking {@code base} fails; reported as a FATAL by the
+	 *             if walking {@code root} fails; reported as a FATAL by the
 	 *             caller so an IO failure is not misclassified as a no-match.
 	 */
-	private static List<Path> matchGlob(Path base, String pattern)
+	private static List<Path> matchGlob(Path root, PathMatcher matcher)
 			throws IOException {
-		PathMatcher matcher = FileSystems.getDefault()
-				.getPathMatcher("glob:" + pattern);
-		try (Stream<Path> walk = Files.walk(base)) {
+		try (Stream<Path> walk = Files.walk(root)) {
 			return walk.filter(Files::isRegularFile)
-					.filter(p -> matcher.matches(base.relativize(p)))
+					.filter(p -> matcher.matches(root.relativize(p)))
 					.map(p -> p.toAbsolutePath().normalize()).sorted().toList();
 		}
 	}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
@@ -71,6 +71,14 @@ import org.antlr.v4.runtime.tree.ParseTree;
  * </ol>
  *
  * <p>
+ * Because step 3 gives every loaded file a {@link CompilationContext} of its
+ * own, step 1 always resolves against the file that <em>contains</em> the
+ * {@code load} — never against the file that started the compilation, and never
+ * against the process working directory. A relative path therefore denotes the
+ * same file wherever the compiler is invoked from, and a file that is loaded
+ * from two different places still resolves its own loads against itself.
+ *
+ * <p>
  * Diagnostics produced while compiling a sub-file are always forwarded to the
  * parent {@link CompilationContext}, so the caller sees a unified error report.
  */

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolver.java
@@ -268,7 +268,7 @@ public final class LoadResolver
 	 * @param pattern
 	 *            glob matched against paths relative to {@code root}.
 	 */
-	private record GlobAnchor(Path root, String pattern) {
+	record GlobAnchor(Path root, String pattern) {
 	}
 
 	/**
@@ -312,8 +312,13 @@ public final class LoadResolver
 	 * {@code base/dir}, anchoring leaves the meaning of every previously
 	 * supported pattern unchanged — it only narrows the subtree that has to be
 	 * walked.
+	 *
+	 * <p>
+	 * Package-private so the anchoring contract can be unit-tested directly:
+	 * anchoring at the filesystem root is otherwise only observable by walking
+	 * the whole filesystem.
 	 */
-	private static GlobAnchor anchor(Path base, String pattern) {
+	static GlobAnchor anchor(Path base, String pattern) {
 		int cut = pattern.lastIndexOf('/', firstMetaChar(pattern));
 		if (cut < 0) {
 			return new GlobAnchor(base, pattern);

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverAnchorTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverAnchorTest.java
@@ -1,0 +1,51 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.mcscert.jpipe.compiler.steps.transformations.LoadResolver.GlobAnchor;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Unit tests for glob anchoring: the split of a pattern into the directory the
+ * search starts from and the portion matched relative to it. Anchoring is
+ * tested directly rather than through a compilation because some of its cases
+ * (an absolute pattern rooted at "/") would otherwise only be observable by
+ * walking the whole filesystem.
+ */
+class LoadResolverAnchorTest {
+
+	private static final Path BASE = Paths.get("/project/src");
+
+	@ParameterizedTest(name = "{0} anchors at {1} with pattern {2}")
+	@CsvSource({
+			// Descending patterns: the anchor moves down, and the effective
+			// pattern loses the prefix, which is what keeps their meaning
+			// identical to matching the whole pattern against BASE.
+			"models/*.jd,          /project/src/models, *.jd",
+			"models/**/*.jd,       /project/src/models, **/*.jd",
+			"dir/[ab].jd,          /project/src/dir,    [ab].jd",
+			// No literal prefix: the anchor stays at the declaring directory.
+			"*.jd,                 /project/src,        *.jd",
+			"**.jd,                /project/src,        **.jd",
+			"a?.jd,                /project/src,        a?.jd",
+			// Upward patterns: the prefix is resolved like any literal path.
+			"../library/*.jd,      /project/library,    *.jd",
+			"../../shared/**.jd,   /shared,             **.jd",
+			// Absolute patterns anchor at their own root, ignoring BASE.
+			"/opt/models/*.jd,     /opt/models,         *.jd",
+			"/*.jd,                /,                   *.jd",
+			// The cut is made before the first wildcard character, so a brace
+			// group is never split even when it spans a separator.
+			"'{a,b}/*.jd',         /project/src,        '{a,b}/*.jd'",
+			"'{foo/bar,baz}/*.jd', /project/src,        '{foo/bar,baz}/*.jd'"})
+	void patternIsSplitIntoAnAnchorAndARelativePattern(String pattern,
+			String expectedRoot, String expectedPattern) {
+		GlobAnchor anchored = LoadResolver.anchor(BASE, pattern);
+
+		assertThat(anchored.root()).isEqualTo(Paths.get(expectedRoot));
+		assertThat(anchored.pattern()).isEqualTo(expectedPattern);
+	}
+}

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
@@ -1,6 +1,7 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.creation.CreateTemplate;
@@ -13,6 +14,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 class LoadResolverGlobTest {
@@ -169,6 +172,28 @@ class LoadResolverGlobTest {
 		assertThat(ctx.hasFatalErrors()).isTrue();
 		assertThat(fatalMessages(ctx))
 				.anyMatch(m -> m.contains("is not a directory"));
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	void anIoFailureWhileWalkingIsAFatalErrorNotANoMatch() throws IOException {
+		writeTemplate("lib/a.jd", "alpha");
+		Path lib = dir.resolve("lib");
+		assumeTrue(lib.toFile().setReadable(false),
+				"filesystem does not honour the permission bit");
+		// A process running as root reads the directory regardless.
+		assumeTrue(!Files.isReadable(lib), "permission bits are not enforced");
+
+		try {
+			CompilationContext ctx = compileFromSubDirectory("../lib/*.jd",
+					null);
+
+			assertThat(ctx.hasFatalErrors()).isTrue();
+			assertThat(fatalMessages(ctx))
+					.anyMatch(m -> m.contains("Cannot expand load pattern"));
+		} finally {
+			lib.toFile().setReadable(true);
+		}
 	}
 
 	@Test

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class LoadResolverGlobTest {
@@ -85,27 +86,25 @@ class LoadResolverGlobTest {
 		assertThat(templateNames()).containsExactly("lib:alpha", "lib:beta");
 	}
 
-	@Test
-	void zeroMatchesIsAFatalError() throws IOException {
+	/**
+	 * A pattern that cannot be expanded is a fatal error naming the reason, and
+	 * never an exception: an unbalanced "[" is a syntax error, a ".." after a
+	 * wildcard can never be satisfied by a downward walk, and a well-formed
+	 * pattern that simply hits nothing is a no-match.
+	 */
+	@ParameterizedTest
+	@CsvSource({"'none_*.jd',  No file matches load pattern",
+			"'[.jd',       Invalid glob in load pattern",
+			"'*/../a.jd',  '''..'' may only appear before the first wildcard'"})
+	void anUnexpandablePatternIsAFatalError(String pattern,
+			String expectedMessage) throws IOException {
 		writeTemplate("a.jd", "alpha");
 
-		CompilationContext ctx = compile("none_*.jd", null);
+		CompilationContext ctx = compile(pattern, null);
 
 		assertThat(ctx.hasFatalErrors()).isTrue();
 		assertThat(fatalMessages(ctx))
-				.anyMatch(m -> m.contains("No file matches load pattern"));
-	}
-
-	@Test
-	void invalidGlobSyntaxIsAFatalErrorAndDoesNotThrow() throws IOException {
-		writeTemplate("a.jd", "alpha");
-
-		// "[.jd" is an unbalanced glob; it must not crash compilation.
-		CompilationContext ctx = compile("[.jd", null);
-
-		assertThat(ctx.hasFatalErrors()).isTrue();
-		assertThat(fatalMessages(ctx))
-				.anyMatch(m -> m.contains("Invalid glob in load pattern"));
+				.anyMatch(m -> m.contains(expectedMessage));
 	}
 
 	@Test
@@ -155,18 +154,6 @@ class LoadResolverGlobTest {
 	}
 
 	@Test
-	void upwardSegmentAfterAWildcardIsAFatalError() throws IOException {
-		writeTemplate("a.jd", "alpha");
-
-		// A directory walk only ever descends, so this can never match.
-		CompilationContext ctx = compile("*/../a.jd", null);
-
-		assertThat(ctx.hasFatalErrors()).isTrue();
-		assertThat(fatalMessages(ctx)).anyMatch(m -> m
-				.contains("'..' may only appear before the first wildcard"));
-	}
-
-	@Test
 	void patternAnchoredAtAMissingDirectoryIsAFatalError() throws IOException {
 		writeTemplate("lib/a.jd", "alpha");
 
@@ -212,10 +199,15 @@ class LoadResolverGlobTest {
 	}
 
 	/**
-	 * A pattern anchored at the declaring file's own directory necessarily
-	 * matches that file, which is a cycle. This is why models meant to be
-	 * glob-loaded live in a directory of their own: "models/*.jd" cannot match
-	 * the file that loads it, whereas "*.jd" always does.
+	 * Anchoring puts the search in the declaring file's own directory, so a
+	 * pattern that also matches that file's <em>name</em> is a cycle. A
+	 * catch-all ("*.jd", "./*.jd", "**.jd") always does; a narrower one only
+	 * when the name happens to match, as "ro*.jd" does against root.jd — and
+	 * "none_*.jd" does not, which is why
+	 * {@link #anUnexpandablePatternIsAFatalError} gets a no-match there rather
+	 * than a cycle. Keeping glob-loaded models in a directory of their own
+	 * sidesteps the question entirely: "models/*.jd" cannot reach the file that
+	 * loads it.
 	 */
 	@ParameterizedTest
 	@ValueSource(strings = {"*.jd", "./*.jd", "**.jd", "ro*.jd"})
@@ -268,8 +260,10 @@ class LoadResolverGlobTest {
 	void mutualGlobLoadsAcrossDirectoriesTerminateWithACycleError()
 			throws IOException {
 		writeTemplate("a/a.jd", "ta");
-		writeSource("b/b.jd", "load \"../a/*.jd\" as aa\n"
-				+ "template tb { conclusion c is \"c\" }\n");
+		writeSource("b/b.jd", """
+				load "../a/*.jd" as aa
+				template tb { conclusion c is "c" }
+				""");
 
 		CompilationContext ctx = compile("../b/*.jd", "bb",
 				dir.resolve("a/a.jd").toString());

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
@@ -103,6 +103,75 @@ class LoadResolverGlobTest {
 	}
 
 	@Test
+	void upwardPatternMatchesFilesOutsideTheSourceDirectory()
+			throws IOException {
+		writeTemplate("lib/a.jd", "alpha");
+		writeTemplate("lib/b.jd", "beta");
+
+		CompilationContext ctx = compileFromSubDirectory("../lib/*.jd", "lib");
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("lib:alpha", "lib:beta");
+	}
+
+	@Test
+	void upwardRecursivePatternMatchesEveryDepth() throws IOException {
+		writeTemplate("lib/a.jd", "alpha");
+		writeTemplate("lib/nested/deep.jd", "deep");
+
+		CompilationContext ctx = compileFromSubDirectory("../lib/**.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("alpha", "deep");
+	}
+
+	@Test
+	void absolutePatternIsAnchoredAtItsOwnRoot() throws IOException {
+		writeTemplate("lib/a.jd", "alpha");
+		writeTemplate("elsewhere/b.jd", "beta");
+
+		CompilationContext ctx = compileFromSubDirectory(
+				dir.resolve("lib") + "/*.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("alpha");
+	}
+
+	@Test
+	void anchoredPatternDoesNotWalkSiblingDirectories() throws IOException {
+		writeTemplate("models/a.jd", "alpha");
+		writeTemplate("other/b.jd", "beta");
+
+		CompilationContext ctx = compile("models/*.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("alpha");
+	}
+
+	@Test
+	void upwardSegmentAfterAWildcardIsAFatalError() throws IOException {
+		writeTemplate("a.jd", "alpha");
+
+		// A directory walk only ever descends, so this can never match.
+		CompilationContext ctx = compile("*/../a.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isTrue();
+		assertThat(fatalMessages(ctx)).anyMatch(m -> m
+				.contains("'..' may only appear before the first wildcard"));
+	}
+
+	@Test
+	void patternAnchoredAtAMissingDirectoryIsAFatalError() throws IOException {
+		writeTemplate("lib/a.jd", "alpha");
+
+		CompilationContext ctx = compileFromSubDirectory("../nope/*.jd", null);
+
+		assertThat(ctx.hasFatalErrors()).isTrue();
+		assertThat(fatalMessages(ctx))
+				.anyMatch(m -> m.contains("is not a directory"));
+	}
+
+	@Test
 	void globMatchingTheSourceFileIsReportedAsACycle() throws IOException {
 		writeTemplate("root.jd", "root");
 
@@ -123,6 +192,16 @@ class LoadResolverGlobTest {
 	private CompilationContext compile(String pattern, String namespace)
 			throws IOException {
 		return compile(pattern, namespace, dir.resolve("main.jd").toString());
+	}
+
+	/**
+	 * Compiles from a source file one level below the temporary directory, so
+	 * that a "../" pattern has somewhere to climb back up to.
+	 */
+	private CompilationContext compileFromSubDirectory(String pattern,
+			String namespace) {
+		return compile(pattern, namespace,
+				dir.resolve("src/main.jd").toString());
 	}
 
 	private CompilationContext compile(String pattern, String namespace,

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/LoadResolverGlobTest.java
@@ -14,9 +14,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class LoadResolverGlobTest {
 
@@ -197,11 +200,79 @@ class LoadResolverGlobTest {
 	}
 
 	@Test
-	void globMatchingTheSourceFileIsReportedAsACycle() throws IOException {
+	void literalLoadOfTheSourceFileIsReportedAsACycle() throws IOException {
 		writeTemplate("root.jd", "root");
 
 		CompilationContext ctx = compile("root.jd", null,
 				dir.resolve("root.jd").toString());
+
+		assertThat(ctx.hasFatalErrors()).isTrue();
+		assertThat(fatalMessages(ctx))
+				.anyMatch(m -> m.contains("Circular load detected"));
+	}
+
+	/**
+	 * A pattern anchored at the declaring file's own directory necessarily
+	 * matches that file, which is a cycle. This is why models meant to be
+	 * glob-loaded live in a directory of their own: "models/*.jd" cannot match
+	 * the file that loads it, whereas "*.jd" always does.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = {"*.jd", "./*.jd", "**.jd", "ro*.jd"})
+	@Timeout(30)
+	void globMatchingTheDeclaringFileIsReportedAsACycle(String pattern)
+			throws IOException {
+		writeTemplate("root.jd", "root");
+
+		CompilationContext ctx = compile(pattern, null,
+				dir.resolve("root.jd").toString());
+
+		assertThat(ctx.hasFatalErrors()).isTrue();
+		assertThat(fatalMessages(ctx))
+				.anyMatch(m -> m.contains("Circular load detected"));
+	}
+
+	/**
+	 * A relative path is resolved against the directory of the file that
+	 * <em>contains</em> the load, not against the file that started the
+	 * compilation. Both {@code a/sibling/} and {@code b/sibling/} exist here,
+	 * so the two readings give different answers: resolving against the
+	 * declaring file (b/mid.jd) yields fromB, resolving against the root file
+	 * (a/main.jd) would yield fromA. Covers the literal and the glob branch
+	 * alike.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = {"sibling/*.jd", "./sibling/*.jd",
+			"sibling/fromB.jd"})
+	void nestedRelativePathIsResolvedAgainstTheFileThatDeclaresIt(
+			String nestedPattern) throws IOException {
+		writeTemplate("a/sibling/fromA.jd", "fromA");
+		writeTemplate("b/sibling/fromB.jd", "fromB");
+		writeSource("b/mid.jd", "load \"" + nestedPattern + "\" as s\n");
+
+		CompilationContext ctx = compile("../b/mid.jd", "m",
+				dir.resolve("a/main.jd").toString());
+
+		assertThat(ctx.hasFatalErrors()).isFalse();
+		assertThat(templateNames()).containsExactly("m:s:fromB");
+	}
+
+	/**
+	 * Two directories globbing into each other: a/a.jd pulls in every model of
+	 * b/, and b/b.jd pulls in every model of a/ — which includes a.jd itself.
+	 * The load stack catches it, so the expansion terminates instead of
+	 * recursing forever.
+	 */
+	@Test
+	@Timeout(30)
+	void mutualGlobLoadsAcrossDirectoriesTerminateWithACycleError()
+			throws IOException {
+		writeTemplate("a/a.jd", "ta");
+		writeSource("b/b.jd", "load \"../a/*.jd\" as aa\n"
+				+ "template tb { conclusion c is \"c\" }\n");
+
+		CompilationContext ctx = compile("../b/*.jd", "bb",
+				dir.resolve("a/a.jd").toString());
 
 		assertThat(ctx.hasFatalErrors()).isTrue();
 		assertThat(fatalMessages(ctx))
@@ -253,9 +324,14 @@ class LoadResolverGlobTest {
 
 	private void writeTemplate(String relativePath, String name)
 			throws IOException {
+		writeSource(relativePath,
+				"template " + name + " { conclusion c is \"c\" }\n");
+	}
+
+	private void writeSource(String relativePath, String content)
+			throws IOException {
 		Path file = dir.resolve(relativePath);
 		Files.createDirectories(file.getParent());
-		Files.writeString(file,
-				"template " + name + " { conclusion c is \"c\" }\n");
+		Files.writeString(file, content);
 	}
 }

--- a/jpipe-compiler/src/test/resources/features/load.feature
+++ b/jpipe-compiler/src/test/resources/features/load.feature
@@ -92,6 +92,15 @@ Feature: Load directive
       And the unit contains a template named "lib:gamma"
       And the unit contains a justification named "gamma_justification"
 
+  Scenario: a glob load can reach outside the declaring file's directory
+    Given the source file "023_load_glob_relative.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+      And the unit contains a template named "lib:alpha"
+      And the unit contains a template named "lib:beta"
+      And the unit contains a justification named "alpha_justification"
+      And the unit contains a justification named "beta_justification"
+
   Scenario: a glob load that matches no file is a fatal error
     Given the source file "invalid/020_load_glob_nomatch.jd"
     When I compile it into a unit

--- a/jpipe-compiler/src/test/resources/features/load.feature
+++ b/jpipe-compiler/src/test/resources/features/load.feature
@@ -107,6 +107,12 @@ Feature: Load directive
     Then the compilation fails with a fatal error
       And a fatal error mentions "No file matches load pattern"
 
+  Scenario: a glob load anchored at a missing directory names that directory
+    Given the source file "invalid/023_load_glob_nodir.jd"
+    When I compile it into a unit
+    Then the compilation fails with a fatal error
+      And a fatal error mentions "is not a directory"
+
   Scenario: a malformed glob pattern is a fatal error, not a crash
     Given the source file "invalid/021_load_glob_invalid.jd"
     When I compile it into a unit

--- a/jpipe-compiler/src/test/resources/features/load.feature
+++ b/jpipe-compiler/src/test/resources/features/load.feature
@@ -113,6 +113,12 @@ Feature: Load directive
     Then the compilation fails with a fatal error
       And a fatal error mentions "is not a directory"
 
+  Scenario: a glob that matches its own declaring file is a fatal cycle
+    Given the source file "invalid/022_load_glob_self.jd"
+    When I compile it into a unit
+    Then the compilation fails with a fatal error
+      And a fatal error mentions "Circular load detected"
+
   Scenario: a malformed glob pattern is a fatal error, not a crash
     Given the source file "invalid/021_load_glob_invalid.jd"
     When I compile it into a unit


### PR DESCRIPTION
This pull request significantly improves how glob patterns in `load` directives are resolved, allowing them to reference files outside the declaring file’s directory, including via relative (`..`) or absolute paths. The changes clarify and enforce the rules for glob anchoring, error reporting, and cycle detection, and update both the implementation and documentation accordingly.

**Glob pattern resolution and anchoring improvements:**

* Glob patterns in `load` directives can now reference files outside the declaring file’s directory (e.g., `load "../library/*.jd"` or an absolute path). The pattern is anchored at the last directory before its first wildcard, and the prefix is resolved like a literal path. Patterns with no directory prefix (e.g., `*.jd`) are anchored at the declaring file’s directory, which can cause self-matching and is treated as a fatal cycle. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R29) [[2]](diffhunk://#diff-500e36170f9da69c6522c151456b658da96835052a45fbed43f53865d5281258L54-R110) [[3]](diffhunk://#diff-b27206f7bb411dac51596bac9d7d9c98856e4e355e66240973f9cddabd6b284fL176-R182) [[4]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1L55-R60) [[5]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1R74-R81)

* The implementation introduces an `anchor` method and `GlobAnchor` record to split glob patterns into a resolved directory and a relative pattern, ensuring consistent and testable anchoring logic. The code validates glob syntax, rejects patterns with `..` after a wildcard, and reports missing anchor directories with clear error messages. [[1]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1R171-R205) [[2]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1R270-R366)

**Error handling and cycle detection:**

* Patterns whose directory does not exist, or that use `..` after a wildcard (which cannot match), now report a fatal error with a precise message. A glob that matches no files is also a fatal error, but with improved specificity. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R29) [[2]](diffhunk://#diff-735785169ed9c5e9c08055ef92d34ee2fc3feb58d61faf240b826e69a56e6f9dL2-R5) [[3]](diffhunk://#diff-0fdb1a8bb4dc9d03c237f9766c8cfdf2b9bf51c986d98a81ccd2fec596f0ea7bR1-R8)

* A glob pattern must not match its own declaring file; such a self-match is a fatal cycle, ensuring that models intended to be glob-loaded reside in their own directory. [[1]](diffhunk://#diff-17b7e01d04a7efa17fb80b3e89f76504089178260bb374b1d3dec03183af0092R1-R11) [[2]](diffhunk://#diff-500e36170f9da69c6522c151456b658da96835052a45fbed43f53865d5281258L112-R196)

**Documentation updates:**

* The ADR and design documentation are updated to describe the new anchoring semantics, error cases, and practical consequences for project organization. Tables and explanations clarify how patterns are split, resolved, and matched. [[1]](diffhunk://#diff-500e36170f9da69c6522c151456b658da96835052a45fbed43f53865d5281258L54-R110) [[2]](diffhunk://#diff-500e36170f9da69c6522c151456b658da96835052a45fbed43f53865d5281258L95-R153) [[3]](diffhunk://#diff-500e36170f9da69c6522c151456b658da96835052a45fbed43f53865d5281258L112-R196) [[4]](diffhunk://#diff-b27206f7bb411dac51596bac9d7d9c98856e4e355e66240973f9cddabd6b284fL176-R182)

**Examples and tests:**

* New and updated example files illustrate the new behavior: loading files via relative globs, handling no-match and missing-directory errors, and demonstrating the self-match cycle. [[1]](diffhunk://#diff-c25d676c641c1b8f6e9727afcfd9c698898e3f9cff414d78866f870533588e2aR1-R13) [[2]](diffhunk://#diff-735785169ed9c5e9c08055ef92d34ee2fc3feb58d61faf240b826e69a56e6f9dL2-R5) [[3]](diffhunk://#diff-17b7e01d04a7efa17fb80b3e89f76504089178260bb374b1d3dec03183af0092R1-R11) [[4]](diffhunk://#diff-0fdb1a8bb4dc9d03c237f9766c8cfdf2b9bf51c986d98a81ccd2fec596f0ea7bR1-R8)

**Codebase refactoring:**

* The `LoadResolver` implementation is refactored for clarity, with the logic for glob detection, anchoring, and matching centralized and documented, and the code now uses a single definition for what counts as a glob. [[1]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1R33) [[2]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1R171-R205) [[3]](diffhunk://#diff-91c35d6704bc9d4d518a49ec74a468c1d1a1f47b7488164e42027aef7396cad1R270-R366)

These changes make glob pattern handling in `load` directives more powerful, predictable, and user-friendly, with improved diagnostics and documentation.