### PR TITLE
Prepare release for version 2.3.1 with updates and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+---
+
+## [2.3.1] — 2026-08-07
+
 ### Fixed
 - A glob pattern in a `load` directive may now point outside the declaring
   file's directory, e.g. `load "../library/*.jd" as lib`, or name an absolute
@@ -287,7 +291,8 @@ server.
 ### Added
 - Initial commit: first version of the compiler.
 
-[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.1...HEAD
+[2.3.1]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.0.4...v2.1.0

--- a/jpipe-cli/pom.xml
+++ b/jpipe-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-cli</artifactId>

--- a/jpipe-compiler/pom.xml
+++ b/jpipe-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-compiler</artifactId>

--- a/jpipe-lang/pom.xml
+++ b/jpipe-lang/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-lang</artifactId>

--- a/jpipe-model/pom.xml
+++ b/jpipe-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-model</artifactId>

--- a/jpipe-operators/pom.xml
+++ b/jpipe-operators/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-operators</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jpipe</groupId>
     <artifactId>jpipe</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>jPipe</name>


### PR DESCRIPTION
This pull request prepares the project for the `2.3.1` release by updating version numbers across all Maven modules and documenting the new release in the changelog. It also updates changelog links to reflect the new version.

Release documentation:

* Added a new `2.3.1` section to `CHANGELOG.md` for the 2026-08-07 release, including a summary of fixed issues.
* Updated changelog comparison links to include `2.3.1` and point `Unreleased` to the new base.

Version updates:

* Changed the parent version from `2.4.0-SNAPSHOT` to `2.3.1-SNAPSHOT` in all Maven module `pom.xml` files: `pom.xml`, `jpipe-cli/pom.xml`, `jpipe-compiler/pom.xml`, `jpipe-lang/pom.xml`, `jpipe-model/pom.xml`, and `jpipe-operators/pom.xml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9) [[2]](diffhunk://#diff-70e0ecf70d842804a690af37666f356433d1c9bcb4b80df625ee541367cd7d3dL10-R10) [[3]](diffhunk://#diff-81d214f9fc36e7be6b9226666c876c7ec2598a1e6ca35ce4e80471c4afd23c13L10-R10) [[4]](diffhunk://#diff-5e5cdbe53b76280e9e2b6c2a698bb79aa9c638435f40806d0fece9afa498245aL10-R10) [[5]](diffhunk://#diff-015105e7cbd6b2fd3067d498701ee77f3f966a539bb6f003e18e6babc9436167L10-R10) [[6]](diffhunk://#diff-63b8bd16eca0534955980432e7c4676afd7bd5d88fd47cc5aeeda2ceaed88396L10-R10)