### PR TITLE
Simplify branching model and enhance release scripting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,24 @@
 name: Build
 
 on:
+  # Topic branches are built through `pull_request`, which builds the merge
+  # result rather than the branch tip. Listing them here as well would run
+  # every build twice, and a bare `push:` would also rebuild release tags that
+  # release.yml already verifies.
   push:
+    branches:
+      - main
+      - dev
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts, but only for pull requests --
+# builds of main and dev always run to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,9 +44,12 @@ jobs:
 
       - name: Prepare docs index from README
         run: |
+          # The README is read from the repository root on GitHub and from
+          # docs/ on the site, so docs-relative paths have to be re-anchored.
           sed \
             -e 's|./docs/logo.svg|logo.svg|g' \
             -e 's|./docs/sponsors/|sponsors/|g' \
+            -e 's|](docs/|](|g' \
             -e 's|^  - |    - |g' \
             README.md > docs/index.md
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,8 +47,8 @@ jobs:
           # The README is read from the repository root on GitHub and from
           # docs/ on the site, so docs-relative paths have to be re-anchored.
           sed \
-            -e 's|./docs/logo.svg|logo.svg|g' \
-            -e 's|./docs/sponsors/|sponsors/|g' \
+            -e 's|\./docs/logo\.svg|logo.svg|g' \
+            -e 's|\./docs/sponsors/|sponsors/|g' \
             -e 's|](docs/|](|g' \
             -e 's|^  - |    - |g' \
             README.md > docs/index.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with this repository.
 ## Critical Rules
 
 - **Never commit or push code without explicit user consent.** Always show the diff and ask before running any `git commit` or `git push` command.
-- **Never commit directly to `main`.** `main` is release-only (see [Git Workflow](#git-workflow)). All feature and fix work branches off `dev` and merges back into `dev`.
+- **Never commit directly to `main` or `dev`.** `main` is release-only (see [Git Workflow](#git-workflow)); `dev` accepts direct pushes from human authors, but Claude works on a topic branch unless explicitly told otherwise.
 - **Never merge a pull request or push a git tag.** Merging (including the release `dev`→`main` merge) and tagging (`vX.Y.Z`) are **human-only** actions. Claude prepares the branch/PR and hands off; it does not run `gh pr merge`, merge branches into `dev`/`main`, or push tags.
 
 ---
@@ -21,13 +21,19 @@ The repository uses a two-tier branching model (ADR-0024):
   It holds "everything merged since the last release," and the `CHANGELOG.md`
   `## [Unreleased]` section lives on `dev`.
 - **Topic branches** — `feat/…`, `fix/…`, `chore/…`, `docs/…`. Branch **from
-  `dev`**, merge back **into `dev`** (normally via PR). Merging into `dev` is
-  what adds the change to `[Unreleased]`.
-- **Releasing** — merge `dev` → `main`, rename `[Unreleased]` to the version,
-  push a `vX.Y.Z` tag on `main` (this triggers `release.yml`, ADR-0020), then
-  merge `main` back into `dev`. **The `dev`→`main` merge and the tag push are
-  human-only actions** (see Critical Rules); Claude only prepares the
-  release-prep branch/PR (changelog finalization, version bump).
+  `dev`**, merge back **into `dev`**. Merging into `dev` is what adds the change
+  to `[Unreleased]`.
+- **A PR into `dev` is not required.** Human authors may push low-risk changes
+  (version bumps, changelog close-out, CI configuration, small fixes carried by
+  their tests) straight to `dev` once `mvn verify` is green (ADR-0024, amendment
+  of 2026-08-07). Only `main` requires a PR. **This relaxation is for human
+  authors.** Claude still branches, commits, pushes the topic branch and stops;
+  it pushes to `dev` directly only when explicitly asked, and never commits
+  without showing the diff first (see Critical Rules).
+- **Releasing** — the full runbook is [`docs/releasing.md`](docs/releasing.md),
+  driven by `scripts/release.sh`. **The `dev`→`main` merge and the tag push are
+  human-only actions** (see Critical Rules); Claude only prepares the release
+  commit (changelog close-out, version bump).
 - **Hotfixes** — branch from `main`, merge into `main`, release via a patch tag,
   then merge back into `dev`.
 
@@ -241,12 +247,12 @@ Rules:
 - **How:** Write one concise, user-facing sentence describing the *effect*, not
   the implementation. Reference the PR or issue number when there is one
   (e.g. `(#136)`). Match the tone and style of existing entries.
-- **Releasing (maintainer action):** Cutting a release is a `dev` → `main`
-  merge (see [Git Workflow](#git-workflow)). Claude prepares a release-prep
-  branch that renames `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, adds the
-  git-compare link at the bottom, and opens a fresh empty `## [Unreleased]`
-  section above it. **The maintainer (human) performs the `dev`→`main` merge and
-  pushes the `vX.Y.Z` tag on `main`** — Claude does not merge or tag.
+- **Releasing (maintainer action):** `scripts/release.sh prepare X.Y.Z` performs
+  the close-out — it renames `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, adds
+  the git-compare link at the bottom, and opens a fresh empty `## [Unreleased]`
+  above it. Do this by hand only if the script cannot. **The maintainer (human)
+  performs the `dev`→`main` merge and pushes the `vX.Y.Z` tag** — Claude does not
+  merge or tag. Full runbook: [`docs/releasing.md`](docs/releasing.md).
 
 Do not edit already-released sections except to correct an error.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The jPipe environment supports the definition of justification to support softwa
 - `jpipe-cli`: command-line interface and fat JAR entry point
 - `docs`: technical documentation and architecture decision records
 - `bin`: launcher script templates (POSIX `sh` and PowerShell) used by the packaging channels
+- `scripts`: maintainer tooling (`release.sh`)
 - `debian`: Debian source packaging metadata for the Ubuntu PPA
 
 ### Developer Setup
@@ -57,79 +58,37 @@ mvn package
 
 The fat JAR is produced in `jpipe-cli/target/`.
 
+#### Branching
+
+Work is integrated on `dev`; `main` is release-only, and every commit on it is a
+published version ([ADR-0024](docs/adr/0024-git-branching-model.md)). Branch from
+`dev` and open a pull request for anything with reviewable content. Low-risk
+changes — version bumps, changelog close-out, CI configuration, a small fix
+carried by its tests — may be pushed straight to `dev` once `mvn verify` is green
+locally. Only `main` requires a pull request.
+
 #### Releasing a new version
 
-Releases are triggered by pushing a `v*.*.*` tag that points at a commit on
-`main` — the pipeline refuses a tag that is not an ancestor of `main`. Day-to-day
-work is merged into `dev`; cutting a release means merging `dev` into `main`
-first (see [ADR-0024](docs/adr/0024-git-branching-model.md)). The pipeline then
-creates a GitHub Release, updates the Homebrew formula and the Scoop manifest,
-and uploads a Debian source package to the Ubuntu PPA.
-
-**Prerequisites:** The following secrets must be configured in the GitHub
-repository settings:
-
-| Secret | Purpose |
-|--------|---------|
-| `HOMEBREW_TAP_TOKEN` | PAT with write access to `jpipe-mcscert/homebrew-mcscert` |
-| `SCOOP_BUCKET_TOKEN` | PAT with write access to `jpipe-mcscert/scoop-mcscert` |
-| `GPG_PRIVATE_KEY` | ASCII-armored GPG key registered on Launchpad |
-| `GPG_KEY_ID` | Fingerprint of the signing key |
-| `GPG_PASSPHRASE` | Passphrase for the signing key |
-
-**Steps:**
+A release is prepared on `dev`, merged into `main` through a pull request, and
+started by pushing a `vX.Y.Z` tag on `main`. The tag triggers the pipeline, which
+publishes the GitHub Release and updates Homebrew, Scoop and the Ubuntu PPA.
 
 ```bash
-# 1. Verify the base version in pom.xml matches what you plan to tag.
-#    pom.xml should be X.Y.Z-SNAPSHOT; the pipeline strips -SNAPSHOT automatically.
-mvn verify   # confirm the build is green locally
+scripts/release.sh prepare X.Y.Z       # on dev: set the version, close the changelog
+                                       # then push, and open the dev → main PR
+scripts/release.sh preflight X.Y.Z     # on main, after the merge: re-run the
+                                       # pipeline's checks before the tag exists
+git tag vX.Y.Z && git push origin vX.Y.Z
 
-# 2. Merge dev into main (normally via a release PR). main is release-only:
-#    every commit on it is a published version.
-
-# 3. Tag the resulting commit on main and push the tag — the pipeline fires.
-git switch main && git pull --ff-only
-git tag vX.Y.Z          # or vX.Y.Z-rcN for a pre-release
-git push origin vX.Y.Z
-
-# 4. Merge main back into dev, then bump to the next development version on a
-#    topic branch merged into dev.
-mvn -B versions:set -DnewVersion=X.Y+1.0-SNAPSHOT -DgenerateBackupPoms=false
+git switch dev && git merge origin/main            # after the release
+scripts/release.sh post-release X.Y.Z+1-SNAPSHOT
 ```
 
-**What happens automatically:**
-
-1. The pipeline validates that the tag version matches the base version in `pom.xml`
-   (e.g. tag `v2.1.0` is accepted when `pom.xml` declares `2.1.0-SNAPSHOT`).
-2. `mvn versions:set` is run inside the pipeline to stamp the exact release version
-   into the fat JAR manifest (`Implementation-Version: X.Y.Z`).
-3. A GitHub Release is created with the fat JAR, a Homebrew tarball, and a
-   Scoop zip. Tags containing `-` (e.g. `-rc1`) are automatically marked as
-   pre-releases.
-4. `jpipe.rb` in the Homebrew tap is updated with the new URL and SHA256
-   (stable releases only — skipped for pre-releases).
-5. `bucket/jpipe.json` in the Scoop bucket is updated with the new version, URL
-   and hash (stable releases only — skipped for pre-releases).
-6. A signed Debian source package is uploaded to `ppa:mcscert/ppa`
-   (stable releases only — skipped for pre-releases).
-
-**Verifying the release** (~30 min after the pipeline completes):
-
-```bash
-# macOS
-brew tap jpipe-mcscert/mcscert
-brew install jpipe
-
-# Ubuntu
-sudo add-apt-repository ppa:mcscert/ppa
-sudo apt update && sudo apt install jpipe
-```
-
-```powershell
-# Windows
-scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert
-scoop install mcscert/jpipe
-```
+**Read [`docs/releasing.md`](docs/releasing.md) before cutting a release** — it is
+the full checklist, including the dependency review, the Ubuntu series review and
+the Windows smoke test that the ADRs require. The pipeline's mechanics and the
+repository secrets it needs are documented in
+[ADR-0020](docs/adr/0020-tag-triggered-release-pipeline.md).
 
 #### Code style
 
@@ -149,9 +108,33 @@ mvn package -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade.DefaultS
 
 ## Usage
 
+### Installation
+
+Released versions are published to one package manager per platform
+([ADR-0025](docs/adr/0025-mainstream-platform-distribution.md)):
+
+```bash
+# macOS
+brew tap jpipe-mcscert/mcscert && brew install jpipe
+
+# Ubuntu
+sudo add-apt-repository ppa:mcscert/ppa
+sudo apt update && sudo apt install jpipe
+```
+
+```powershell
+# Windows
+scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert
+scoop install mcscert/jpipe
+```
+
+Each channel installs a `jpipe` launcher on your `PATH`; run `jpipe doctor` to
+check the installed version and its runtime dependencies. The fat JAR is also
+attached to every [GitHub Release](https://github.com/jpipe-mcscert/jpipe-compiler/releases).
+
 ### Running the compiler
 
-After building, the fat JAR is at `jpipe-cli/target/jpipe-cli-*.jar`. The
+After building from source, the fat JAR is at `jpipe-cli/target/jpipe-cli-*.jar`. The
 `process` subcommand is the default, so these two invocations are equivalent:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ scripts/release.sh preflight X.Y.Z     # on main, after the merge: re-run the
 git tag vX.Y.Z && git push origin vX.Y.Z
 
 git switch dev && git merge origin/main            # after the release
-scripts/release.sh post-release X.Y.Z+1-SNAPSHOT
+scripts/release.sh post-release <next>-SNAPSHOT    # e.g. 2.4.1-SNAPSHOT
 ```
 
 **Read [`docs/releasing.md`](docs/releasing.md) before cutting a release** — it is

--- a/docs/adr/0020-tag-triggered-release-pipeline.md
+++ b/docs/adr/0020-tag-triggered-release-pipeline.md
@@ -95,21 +95,21 @@ need to remove the `-SNAPSHOT` suffix before tagging. The validation step strips
 `-SNAPSHOT` from the pom version before comparing, so a pom at `2.1.0-SNAPSHOT`
 is correct when releasing `v2.1.0`.
 
-Manual steps required:
-
-1. Verify the base version in `pom.xml` matches the intended tag
-   (e.g. `2.1.0-SNAPSHOT` to release `v2.1.0`).
-2. Run `mvn verify` locally to confirm the build is green.
-3. Merge `dev` into `main` and push the tag — the pipeline fires automatically.
-4. Merge `main` back into `dev`, then bump `pom.xml` to the next development
-   version (`mvn -B versions:set -DnewVersion=X.Y+1.0-SNAPSHOT`) on a topic
-   branch merged into `dev`.
+That validation is also the pipeline's sharpest edge: it runs *after* the tag has
+been pushed, so a pom that disagrees with the tag fails the release rather than
+preventing it. The release version is therefore set during preparation, on `dev`,
+by `scripts/release.sh prepare X.Y.Z` — and `scripts/release.sh preflight X.Y.Z`
+reproduces this check, and the "tag is on `main`" check above, locally before the
+tag exists.
 
 Tags containing `-` (e.g. `v2.1.0-rc1`) are automatically marked as pre-releases;
 all three channel jobs are skipped for them.
 
-See the "Releasing a new version" section in `README.md` for the full
-step-by-step procedure.
+The step-by-step procedure — including the dependency review
+([ADR-0007](0007-dependency-freshness-policy.md)), the Ubuntu series review
+([ADR-0023](0023-ubuntu-release-target-policy.md)) and the manual Windows check
+([ADR-0025](0025-mainstream-platform-distribution.md)) — lives in
+[`docs/releasing.md`](../releasing.md).
 
 ### Downstream effects
 

--- a/docs/adr/0024-git-branching-model.md
+++ b/docs/adr/0024-git-branching-model.md
@@ -89,8 +89,9 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
 ## Consequences
 
 - A `dev` branch is created from the current `main` and becomes the default
-  branch for development; branch protection should require PRs into `dev` and
-  forbid direct pushes to `main`.
+  branch for development; branch protection should forbid direct pushes to
+  `main`. (Amended 2026-08-07: protection on `dev` must *not* require a pull
+  request — see the amendment below.)
 - Contributors branch from `dev`, not `main`. The default branch on the remote
   should be set to `dev` so clones and PRs target it by default.
 - The release checklist gains a first step: merge `dev` into `main` before
@@ -102,3 +103,43 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
   only after the next release.
 - Existing open work branched from `main` (e.g. the branch introducing this
   ADR) is retargeted onto `dev`.
+
+## Amendment (2026-08-07): pull requests are not required for `dev`
+
+The original decision said feature branches merge into `dev` "normally via pull
+request" and that branch protection "should require PRs into `dev`". In practice
+that made routine bookkeeping disproportionately expensive: bumping the version
+to the next `-SNAPSHOT` after a release is a one-line change with nothing to
+review, yet it cost a branch, a pull request, and a merge.
+
+### Amended decision
+
+- **A pull request remains the default** for any change with reviewable content —
+  new behaviour, bug fixes of substance, grammar or model changes, anything a
+  second reader would improve.
+- **Direct pushes to `dev` are permitted** when the author judges the change
+  low-risk and `mvn verify` is green locally. Blessed examples:
+    - release bookkeeping — version bumps, changelog close-out, compare links;
+    - CI and build configuration;
+    - small fixes carried by their own tests.
+- **`main` is unchanged.** It stays release-only, is entered exclusively through
+  a `dev` → `main` pull request, and the `vX.Y.Z` tag is pushed by a human.
+- **Branch protection** on `dev` should forbid force-pushes and require the
+  status checks to pass; it must **not** require a pull request. `main` keeps its
+  pull-request requirement.
+
+### Rationale
+
+The pull request was never what made a change to `dev` safe. `build.yml` has no
+branch filter, so it runs on every push; `sonar.yml` analyses pushes on
+`branches: [main, dev]`. A direct commit is therefore built, tested and
+quality-gated exactly like a pull-requested one. What the pull request adds is
+*review* — valuable for reviewable content, and pure overhead for a version bump.
+
+One caveat worth weighing rather than legislating: `docs.yml` deploys the
+documentation site on every push to `dev`, so a docs change pushed directly is
+published immediately, with no staging step.
+
+This amendment narrows only *how* a change enters `dev`. The two-tier model, the
+role of each branch, and the release procedure are unaffected. The full release
+runbook lives in [`docs/releasing.md`](../releasing.md).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,182 @@
+# Releasing a new version
+
+This is the release checklist. Work through the phases in order; each one ends
+with a single command or a single decision.
+
+**The shape of a release.** Day-to-day work accumulates on `dev`. A release closes
+out the `CHANGELOG.md` `[Unreleased]` section, merges `dev` into `main` through a
+pull request, and pushes a `vX.Y.Z` tag on `main`. The tag — nothing else —
+triggers `release.yml`, which publishes the GitHub Release and updates Homebrew,
+Scoop and the Ubuntu PPA. See [ADR-0024](adr/0024-git-branching-model.md) for the
+branch model and [ADR-0020](adr/0020-tag-triggered-release-pipeline.md) for the
+pipeline mechanics and the list of required repository secrets.
+
+`scripts/release.sh` does the mechanical parts. It never merges, never tags, and
+never pushes — those stay in your hands.
+
+---
+
+## Phase 0 — Decide
+
+Three judgement calls, none of which a script can make for you.
+
+**Pick the version number.** Read the `[Unreleased]` section and apply semantic
+versioning ([ADR-0001](adr/0001-semver-versioning.md)): a breaking change to a
+public API — `jpipe-operators` above all — is a MAJOR bump, new behaviour is
+MINOR, fixes alone are PATCH. What `pom.xml` currently says is *not* an input to
+this decision; Phase 1 sets the pom to whatever you choose here.
+
+**Review dependencies** ([ADR-0007](adr/0007-dependency-freshness-policy.md)) —
+a required step, not optional housekeeping:
+
+```bash
+mvn versions:display-dependency-updates
+mvn versions:display-plugin-updates
+```
+
+**Review the Ubuntu series matrix**
+([ADR-0023](adr/0023-ubuntu-release-target-policy.md)). Compare the `distro:` list
+in `.github/workflows/release.yml` against the policy: every LTS released in or
+after 2024 that is still in standard support, plus the next LTS once its series
+opens on Launchpad, plus every interim release inside its nine-month window. Add
+a series when it enters support; drop one in the release that follows its EOL.
+
+---
+
+## Phase 1 — Prepare, on `dev`
+
+```bash
+git switch dev && git pull --ff-only
+scripts/release.sh prepare X.Y.Z
+```
+
+This sets every pom to `X.Y.Z-SNAPSHOT`, renames `## [Unreleased]` to
+`## [X.Y.Z] — <today>`, opens a fresh empty `[Unreleased]` above it, adds the
+`[X.Y.Z]` compare link at the bottom of the changelog, runs `mvn verify`, and
+commits. Add `--dry-run` to see the diff without writing anything.
+
+Setting the pom here is what makes the version safe. The pipeline compares the
+tag against the pom version and fails **after the tag has been pushed**, so the
+pom must say `X.Y.Z-SNAPSHOT` before you tag `vX.Y.Z` — whatever `dev` happened
+to be bumped to earlier is irrelevant once `prepare` has run.
+
+Then push. A release chore does not need a pull request
+([ADR-0024, amended](adr/0024-git-branching-model.md#amendment-2026-08-07-pull-requests-are-not-required-for-dev)):
+
+```bash
+git push
+```
+
+---
+
+## Phase 2 — Release pull request
+
+```bash
+scripts/release.sh preflight X.Y.Z
+```
+
+Preflight re-runs every check `release.yml` performs, while the tag still does
+not exist: clean tree, branch in sync, pom version against the tag base, tag not
+already taken, changelog closed out, `mvn verify` green. It also reports whether
+`HEAD` is on `main` yet — expect a warning here, since the merge has not
+happened.
+
+Open a pull request from `dev` to `main` titled `Release vX.Y.Z`, and merge it
+once the checks are green. This is the one merge in the process that must go
+through a pull request: `main` is release-only, and every commit on it is a
+published version.
+
+---
+
+## Phase 3 — Tag, on `main`
+
+```bash
+git switch main && git pull --ff-only
+scripts/release.sh preflight X.Y.Z    # now expect "HEAD is on main"
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Pushing the tag is what starts the release. `release.yml` verifies the tag is an
+ancestor of `main`, re-checks it against `pom.xml`, stamps the version into the
+fat JAR manifest, builds once, and publishes the GitHub Release with three
+assets. The Homebrew, Scoop and PPA jobs then run in parallel off that release.
+
+A tag containing a hyphen (`v2.4.0-rc1`) is published as a GitHub pre-release and
+**every** channel job is skipped
+([ADR-0025](adr/0025-mainstream-platform-distribution.md)). A release candidate is
+cut from an already-prepared version — do not run `prepare` for it.
+
+Watch the run: <https://github.com/jpipe-mcscert/jpipe-compiler/actions>
+
+---
+
+## Phase 4 — Verify
+
+Package indices take up to about thirty minutes to settle.
+
+```bash
+# macOS
+brew tap jpipe-mcscert/mcscert
+brew install jpipe && jpipe doctor
+
+# Ubuntu
+sudo add-apt-repository ppa:mcscert/ppa
+sudo apt update && sudo apt install jpipe && jpipe doctor
+```
+
+```powershell
+# Windows
+scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert
+scoop install mcscert/jpipe
+jpipe doctor
+```
+
+`jpipe doctor` should report the version you just tagged. **The Windows check is
+manual and required** — it is the one channel CI cannot smoke-test
+([ADR-0025](adr/0025-mainstream-platform-distribution.md)).
+
+---
+
+## Phase 5 — Merge back and reopen development
+
+```bash
+git switch dev && git pull --ff-only
+git merge origin/main
+scripts/release.sh post-release X.Y.Z+1-SNAPSHOT
+git push
+```
+
+Merging `main` back into `dev` keeps the release commit shared between the two
+branches; `post-release` refuses to run until you have. The next patch version is
+the low-surprise default — since Phase 1 sets the release version explicitly, an
+over-bump here is harmless, but it is what confused the 2.3.1 release.
+
+---
+
+## Troubleshooting
+
+**The tag is pushed and the pipeline failed on the version check.** The tag is
+not on the release yet, so it is safe to withdraw:
+
+```bash
+git push --delete origin vX.Y.Z
+git tag -d vX.Y.Z
+```
+
+Fix the pom on `dev` (`scripts/release.sh prepare X.Y.Z`), merge to `main` again,
+and re-tag. Running `preflight` in Phase 3 is what prevents this.
+
+**The release published but a channel job failed.** By design, a missing
+credential or a broken index fails one channel, not the release — the GitHub
+Release and its assets are already live. Fix the cause and re-run the failed job
+from the Actions run page; the channel jobs consume release assets rather than
+rebuilding, so re-running is safe and produces identical bytecode.
+
+**`prepare` says `[Unreleased]` is empty.** Nothing has been merged into `dev`
+since the last release, or the entries were never written. The changelog is the
+release notes — write them before releasing, not after.
+
+**`post-release` says main is not merged back.** Run `git merge origin/main` on
+`dev` first. Skipping this leaves the release commit on `main` only, and the next
+release's `dev` → `main` merge becomes a conflict.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -143,14 +143,17 @@ manual and required** — it is the one channel CI cannot smoke-test
 ```bash
 git switch dev && git pull --ff-only
 git merge origin/main
-scripts/release.sh post-release X.Y.Z+1-SNAPSHOT
+scripts/release.sh post-release <next>-SNAPSHOT   # e.g. 2.4.1-SNAPSHOT
 git push
 ```
 
-Merging `main` back into `dev` keeps the release commit shared between the two
-branches; `post-release` refuses to run until you have. The next patch version is
-the low-surprise default — since Phase 1 sets the release version explicitly, an
+Pass the next version literally — `<next>` is a placeholder, and the script
+rejects anything that is not a valid Maven version. The next **patch** is the
+low-surprise default: since Phase 1 sets the release version explicitly, an
 over-bump here is harmless, but it is what confused the 2.3.1 release.
+
+Merging `main` back into `dev` keeps the release commit shared between the two
+branches; `post-release` refuses to run until you have.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ extra_css:
 nav:
   - Home: index.md
   - API Reference: api-reference.md
+  - Releasing: releasing.md
   - Design:
       - design/language.md
       - design/model.md

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <jacoco-plugin.version>0.8.15</jacoco-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <sonar-plugin.version>5.7.0.6970</sonar-plugin.version>
+        <versions-plugin.version>2.21.0</versions-plugin.version>
 
         <!-- SonarCloud -->
         <sonar.projectKey>jpipe-mcscert_jpipe-compiler</sonar.projectKey>
@@ -318,6 +319,14 @@
                             <phase>verify</phase>
                         </execution>
                     </executions>
+                </plugin>
+
+                <!-- Used by scripts/release.sh and by release.yml; pinned so a
+                     release never depends on whatever version resolves today. -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${versions-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,6 +18,7 @@ REPO_URL_FALLBACK="https://github.com/jpipe-mcscert/jpipe-compiler"
 
 DRY_RUN=0
 FAILURES=0
+ON_MAIN=0
 
 # ----------------------------------------------------------------------------
 # output helpers
@@ -118,13 +119,16 @@ check_branch_is() {
 }
 
 check_in_sync() {
-  local branch upstream
+  local branch upstream remote
   branch=$(current_branch)
   if ! upstream=$(git rev-parse --abbrev-ref "@{upstream}" 2>/dev/null); then
     warn "$branch has no upstream — cannot check whether it is current"
     return
   fi
-  git fetch --quiet origin
+  # Refresh the remote the branch actually tracks, which is not necessarily
+  # origin — otherwise a stale ref reads as "in sync".
+  remote=${upstream%%/*}
+  git fetch --quiet "$remote"
   if [ "$(git rev-parse HEAD)" = "$(git rev-parse "$upstream")" ]; then
     pass "$branch is in sync with $upstream"
   elif git merge-base --is-ancestor "$upstream" HEAD; then
@@ -138,6 +142,7 @@ check_in_sync() {
 check_on_main() {
   git fetch --quiet origin main
   if git merge-base --is-ancestor HEAD origin/main; then
+    ON_MAIN=1
     pass "HEAD is on main — release.yml's branch check will pass"
   else
     warn "HEAD is not on main yet — merge the dev → main release PR before tagging"
@@ -241,9 +246,14 @@ cmd_preflight() {
     printf '\n%s%d check(s) failed.%s Fix them before tagging.\n' "$C_RED" "$FAILURES" "$C_OFF"
     exit 1
   fi
-  printf '\n%sReady.%s Next: merge the dev → main PR, then tag on main:\n' "$C_GREEN" "$C_OFF"
-  printf '  git switch main && git pull --ff-only\n'
-  printf '  git tag v%s && git push origin v%s\n' "$version" "$version"
+  if [ "$ON_MAIN" -eq 1 ]; then
+    printf '\n%sReady to tag.%s This is the last check before the release fires:\n' "$C_GREEN" "$C_OFF"
+    printf '  git tag v%s && git push origin v%s\n' "$version" "$version"
+  else
+    printf '\n%sReady.%s Next: merge the dev → main PR, then re-run this on main:\n' "$C_GREEN" "$C_OFF"
+    printf '  git switch main && git pull --ff-only\n'
+    printf '  scripts/release.sh preflight %s\n' "$version"
+  fi
 }
 
 rewrite_changelog() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+#
+# release.sh — drive a jPipe release from the command line.
+#
+# Three verbs, matching the phases in docs/releasing.md:
+#
+#   preflight X.Y.Z          re-run release.yml's checks locally, before the tag exists
+#   prepare   X.Y.Z          set the pom version and close out the changelog, on dev
+#   post-release X.Y.Z-SNAPSHOT   bump to the next development version, on dev
+#
+# The script never merges a branch, never creates or pushes a tag, and never
+# pushes anything. Those stay human actions (see CLAUDE.md).
+
+set -euo pipefail
+
+MVN=${MVN:-mvn}
+REPO_URL_FALLBACK="https://github.com/jpipe-mcscert/jpipe-compiler"
+
+DRY_RUN=0
+FAILURES=0
+
+# ----------------------------------------------------------------------------
+# output helpers
+# ----------------------------------------------------------------------------
+
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'
+  C_BOLD=$'\033[1m'; C_OFF=$'\033[0m'
+else
+  C_RED=''; C_GREEN=''; C_YELLOW=''; C_BOLD=''; C_OFF=''
+fi
+
+pass() { printf '  %sok%s   %s\n' "$C_GREEN" "$C_OFF" "$1"; }
+warn() { printf '  %swarn%s %s\n' "$C_YELLOW" "$C_OFF" "$1"; }
+fail() { printf '  %sFAIL%s %s\n' "$C_RED" "$C_OFF" "$1"; FAILURES=$((FAILURES + 1)); }
+head2() { printf '\n%s%s%s\n' "$C_BOLD" "$1" "$C_OFF"; }
+die() { printf '%serror:%s %s\n' "$C_RED" "$C_OFF" "$1" >&2; exit 1; }
+note() { printf '       %s\n' "$1"; }
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release.sh <verb> [options]
+
+Verbs:
+  preflight X.Y.Z            Check that everything release.yml validates would pass,
+                             before the tag exists. Read-only. Runs `mvn verify`.
+  prepare X.Y.Z              On dev: set the pom to X.Y.Z-SNAPSHOT, close out the
+                             CHANGELOG [Unreleased] section, verify, and commit.
+  post-release X.Y.Z-SNAPSHOT
+                             On dev, after main has been merged back: set the next
+                             development version and commit.
+
+Options:
+  --dry-run                  Show what would change without writing anything
+                             (prepare and post-release only).
+  --skip-verify              Skip `mvn verify` (preflight and prepare).
+  -h, --help                 This message.
+
+The full runbook is in docs/releasing.md.
+EOF
+}
+
+# ----------------------------------------------------------------------------
+# small utilities
+# ----------------------------------------------------------------------------
+
+# A release version: X.Y.Z, optionally with a pre-release suffix (2.4.0-rc1).
+valid_version() {
+  printf '%s' "$1" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+}
+
+pom_version() {
+  "$MVN" -B -q help:evaluate -Dexpression=project.version -DforceStdout 2>/dev/null | tail -1
+}
+
+current_branch() {
+  git rev-parse --abbrev-ref HEAD
+}
+
+# Content of the CHANGELOG [Unreleased] section, blank lines stripped.
+unreleased_body() {
+  awk '
+    /^## \[Unreleased\]/ { inside = 1; next }
+    inside && /^---[[:space:]]*$/ { exit }
+    inside && NF { print }
+  ' CHANGELOG.md
+}
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  %s[dry-run]%s %s\n' "$C_YELLOW" "$C_OFF" "$*"
+  else
+    "$@"
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# individual checks
+# ----------------------------------------------------------------------------
+
+check_clean_tree() {
+  if [ -n "$(git status --porcelain)" ]; then
+    fail "working tree is dirty — commit or stash first"
+    git status --short | sed 's/^/       /'
+  else
+    pass "working tree is clean"
+  fi
+}
+
+check_branch_is() {
+  local expected=$1 actual
+  actual=$(current_branch)
+  if [ "$actual" = "$expected" ]; then
+    pass "on branch $expected"
+  else
+    fail "on branch $actual, expected $expected"
+  fi
+}
+
+check_in_sync() {
+  local branch upstream
+  branch=$(current_branch)
+  if ! upstream=$(git rev-parse --abbrev-ref "@{upstream}" 2>/dev/null); then
+    warn "$branch has no upstream — cannot check whether it is current"
+    return
+  fi
+  git fetch --quiet origin
+  if [ "$(git rev-parse HEAD)" = "$(git rev-parse "$upstream")" ]; then
+    pass "$branch is in sync with $upstream"
+  elif git merge-base --is-ancestor "$upstream" HEAD; then
+    warn "$branch is ahead of $upstream — remember to push"
+  else
+    fail "$branch is behind or diverged from $upstream — pull first"
+  fi
+}
+
+# release.yml:22-28 — the tag must point at a commit on main.
+check_on_main() {
+  git fetch --quiet origin main
+  if git merge-base --is-ancestor HEAD origin/main; then
+    pass "HEAD is on main — release.yml's branch check will pass"
+  else
+    warn "HEAD is not on main yet — merge the dev → main release PR before tagging"
+    note "release.yml refuses a tag that is not an ancestor of main"
+  fi
+}
+
+# release.yml:50-58 — the tag base must equal the pom version with -SNAPSHOT stripped.
+check_version_matches_pom() {
+  local version=$1 pom base
+  pom=$(pom_version)
+  pom=${pom%-SNAPSHOT}
+  base=${version%%-*}
+  if [ "$base" = "$pom" ]; then
+    pass "pom version ($pom) matches tag base ($base)"
+  else
+    fail "pom version is $pom but tag v$version has base $base"
+    note "release.yml performs this exact comparison, and fails after the tag is pushed"
+    note "fix with: scripts/release.sh prepare $base"
+  fi
+}
+
+check_tag_absent() {
+  local version=$1
+  if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+    fail "tag v$version already exists locally"
+  elif [ -n "$(git ls-remote --tags origin "refs/tags/v$version" 2>/dev/null)" ]; then
+    fail "tag v$version already exists on origin"
+  else
+    pass "tag v$version does not exist yet"
+  fi
+}
+
+check_changelog_closed() {
+  local version=$1
+  if grep -q "^## \[$version\] — " CHANGELOG.md; then
+    pass "CHANGELOG has a [$version] section"
+  else
+    fail "CHANGELOG has no '## [$version] — <date>' section"
+    note "run: scripts/release.sh prepare $version"
+  fi
+
+  if grep -q "^\[$version\]: " CHANGELOG.md; then
+    pass "CHANGELOG has a [$version] compare link"
+  else
+    fail "CHANGELOG has no '[$version]:' compare link at the bottom"
+  fi
+
+  if [ -z "$(unreleased_body)" ]; then
+    pass "CHANGELOG [Unreleased] is empty"
+  else
+    fail "CHANGELOG [Unreleased] still has entries — they would ship unlisted"
+  fi
+}
+
+check_build() {
+  local log
+  if [ "${SKIP_VERIFY:-0}" -eq 1 ]; then
+    warn "skipping mvn verify (--skip-verify)"
+    return
+  fi
+  log=$(mktemp -t jpipe-release-verify)
+  printf '  ..   running mvn verify (this takes a while)\n'
+  if "$MVN" -B verify >"$log" 2>&1; then
+    pass "mvn verify is green"
+    rm -f "$log"
+  else
+    fail "mvn verify failed — full log in $log"
+    tail -20 "$log" | sed 's/^/       /'
+  fi
+}
+
+print_manual_checklist() {
+  head2 "Manual checks — these are required, not optional housekeeping"
+  cat <<'EOF'
+  [ ] Dependency review: `mvn versions:display-dependency-updates` (ADR-0007)
+  [ ] Ubuntu series matrix in .github/workflows/release.yml still matches the
+      policy in ADR-0023 — add a series entering support, drop one past EOL
+  [ ] Windows/Scoop smoke test — CI cannot run it (ADR-0025)
+  [ ] The version number matches what [Unreleased] actually contains (ADR-0001)
+EOF
+}
+
+# ----------------------------------------------------------------------------
+# verbs
+# ----------------------------------------------------------------------------
+
+cmd_preflight() {
+  local version=$1
+  head2 "Preflight for v$version"
+  check_clean_tree
+  check_in_sync
+  check_on_main
+  check_version_matches_pom "$version"
+  check_tag_absent "$version"
+  check_changelog_closed "${version%%-*}"
+  check_build
+  print_manual_checklist
+
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n%s%d check(s) failed.%s Fix them before tagging.\n' "$C_RED" "$FAILURES" "$C_OFF"
+    exit 1
+  fi
+  printf '\n%sReady.%s Next: merge the dev → main PR, then tag on main:\n' "$C_GREEN" "$C_OFF"
+  printf '  git switch main && git pull --ff-only\n'
+  printf '  git tag v%s && git push origin v%s\n' "$version" "$version"
+}
+
+rewrite_changelog() {
+  local version=$1 today=$2 tmp link base prev
+  today=${today:-$(date +%Y-%m-%d)}
+
+  link=$(grep -m1 '^\[Unreleased\]: ' CHANGELOG.md || true)
+  if [ -n "$link" ]; then
+    base=${link#*: }
+    base=${base%/compare/*}
+    prev=${link##*/compare/}
+    prev=${prev%%...*}
+  else
+    base=$REPO_URL_FALLBACK
+    prev=""
+  fi
+
+  tmp=$(mktemp)
+  awk -v ver="$version" -v today="$today" '
+    !swapped && /^## \[Unreleased\]$/ {
+      print "## [Unreleased]"
+      print ""
+      print "---"
+      print ""
+      print "## [" ver "] — " today
+      swapped = 1
+      next
+    }
+    { print }
+  ' CHANGELOG.md >"$tmp"
+
+  if [ -n "$prev" ]; then
+    awk -v ver="$version" -v base="$base" -v prev="$prev" '
+      /^\[Unreleased\]: / {
+        print "[Unreleased]: " base "/compare/v" ver "...HEAD"
+        print "[" ver "]: " base "/compare/" prev "...v" ver
+        next
+      }
+      { print }
+    ' "$tmp" >"$tmp.2" && mv "$tmp.2" "$tmp"
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  %s[dry-run]%s CHANGELOG.md would change:\n' "$C_YELLOW" "$C_OFF"
+    diff -u CHANGELOG.md "$tmp" | sed 's/^/       /' || true
+    rm -f "$tmp"
+  else
+    mv "$tmp" CHANGELOG.md
+    pass "CHANGELOG closed out as [$version] — $today"
+  fi
+}
+
+cmd_prepare() {
+  local version=$1 today
+  today=$(date +%Y-%m-%d)
+
+  case $version in
+    *-*) die "prepare takes a plain X.Y.Z; a pre-release tag (v$version) is cut from an already-prepared version" ;;
+  esac
+
+  head2 "Preparing the $version release"
+  check_clean_tree
+  check_branch_is dev
+  check_in_sync
+  check_tag_absent "$version"
+
+  if [ -z "$(unreleased_body)" ]; then
+    fail "CHANGELOG [Unreleased] is empty — there is nothing to release"
+  else
+    pass "CHANGELOG [Unreleased] has entries"
+  fi
+
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n%s%d check(s) failed.%s Nothing was changed.\n' "$C_RED" "$FAILURES" "$C_OFF"
+    exit 1
+  fi
+
+  head2 "Applying"
+  # The root pom is also the parent of every module, so a plain versions:set
+  # rewrites all six poms; -DprocessAllModules is not needed here.
+  run "$MVN" -B -q versions:set "-DnewVersion=$version-SNAPSHOT" -DgenerateBackupPoms=false
+  [ "$DRY_RUN" -eq 1 ] || pass "pom version set to $version-SNAPSHOT"
+  rewrite_changelog "$version" "$today"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n%sDry run — nothing was written.%s\n' "$C_YELLOW" "$C_OFF"
+    return
+  fi
+
+  check_build
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n%sBuild failed.%s The working tree holds the prepared changes; fix and commit yourself.\n' \
+      "$C_RED" "$C_OFF"
+    exit 1
+  fi
+
+  git add CHANGELOG.md pom.xml ./*/pom.xml
+  git commit -q -m "chore: prepare the $version release"
+  pass "committed: chore: prepare the $version release"
+
+  print_manual_checklist
+  printf '\n%sPrepared.%s Next:\n' "$C_GREEN" "$C_OFF"
+  printf '  git push                                  # straight to dev, no PR needed\n'
+  printf '  scripts/release.sh preflight %s\n' "$version"
+  printf '  then open the dev → main release PR\n'
+}
+
+cmd_post_release() {
+  local next=$1
+  case $next in
+    *-SNAPSHOT) : ;;
+    *) die "post-release takes the next development version, e.g. 2.4.1-SNAPSHOT" ;;
+  esac
+  valid_version "$next" || die "not a valid version: $next"
+
+  head2 "Bumping to $next"
+  check_clean_tree
+  check_branch_is dev
+  check_in_sync
+
+  git fetch --quiet origin main
+  if git merge-base --is-ancestor origin/main HEAD; then
+    pass "main has been merged back into dev"
+  else
+    fail "main is not merged back into dev yet"
+    note "run: git merge origin/main"
+  fi
+
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n%s%d check(s) failed.%s Nothing was changed.\n' "$C_RED" "$FAILURES" "$C_OFF"
+    exit 1
+  fi
+
+  head2 "Applying"
+  run "$MVN" -B -q versions:set "-DnewVersion=$next" -DgenerateBackupPoms=false
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n%sDry run — nothing was written.%s\n' "$C_YELLOW" "$C_OFF"
+    return
+  fi
+  pass "pom version set to $next"
+
+  git add pom.xml ./*/pom.xml
+  git commit -q -m "chore: bump to $next"
+  pass "committed: chore: bump to $next"
+  printf '\n%sDone.%s Push straight to dev — no PR needed for a version bump.\n' "$C_GREEN" "$C_OFF"
+}
+
+# ----------------------------------------------------------------------------
+# entry point
+# ----------------------------------------------------------------------------
+
+main() {
+  local verb="" version="" arg
+  SKIP_VERIFY=0
+
+  for arg in "$@"; do
+    case $arg in
+      --dry-run) DRY_RUN=1 ;;
+      --skip-verify) SKIP_VERIFY=1 ;;
+      -h|--help) usage; exit 0 ;;
+      -*) die "unknown option: $arg" ;;
+      *)
+        if [ -z "$verb" ]; then verb=$arg
+        elif [ -z "$version" ]; then version=$arg
+        else die "unexpected argument: $arg"
+        fi
+        ;;
+    esac
+  done
+
+  [ -n "$verb" ] || { usage; exit 1; }
+
+  cd "$(git rev-parse --show-toplevel)" ||
+    die "not inside a git repository"
+  command -v "$MVN" >/dev/null || die "maven not found on PATH"
+
+  version=${version#v}
+  case $verb in
+    preflight|prepare)
+      [ -n "$version" ] || die "$verb needs a version, e.g. scripts/release.sh $verb 2.4.0"
+      valid_version "$version" || die "not a valid version: $version"
+      ;;
+    post-release)
+      [ -n "$version" ] || die "post-release needs the next version, e.g. 2.4.1-SNAPSHOT"
+      ;;
+  esac
+
+  case $verb in
+    preflight) cmd_preflight "$version" ;;
+    prepare) cmd_prepare "$version" ;;
+    post-release) cmd_post_release "$version" ;;
+    *) die "unknown verb: $verb (expected preflight, prepare or post-release)" ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
This pull request updates the documentation and workflow to clarify and streamline the release process, branching model, and related tooling. The changes formalize the use of direct pushes to `dev` for low-risk changes, introduce a detailed release checklist in `docs/releasing.md`, and update references and instructions throughout the repository to match the amended workflow.

**Branching model and release process updates:**

* The branching policy is amended to allow direct pushes to `dev` for low-risk, well-tested changes (like version bumps, changelog updates, and CI config), while still requiring pull requests for all changes to `main` and for reviewable changes to `dev`. Branch protection on `dev` should not require a PR, only passing checks. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L8-R8) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L24-R36) [[3]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295L92-R94) [[4]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295R106-R145)
* The release process is now fully documented in a new `docs/releasing.md`, which provides a step-by-step checklist for preparing, verifying, tagging, and finalizing a release, including dependency and platform checks. The release script `scripts/release.sh` is referenced as the main tool for mechanical release steps. [[1]](diffhunk://#diff-c5175610592ce29ea8498f5df5c11c82d2f2ba273d60d5c13820b25731d72e49R1-R182) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R118) [[4]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R22)

**Documentation and workflow improvements:**

* The `README.md` is updated to reflect the new branching and release process, referencing the new release checklist and clarifying the roles of `dev` and `main`. The installation and usage instructions are also clarified. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R137)
* The ADRs and workflow documentation are updated to match the amended process, including the removal of the PR requirement for `dev`, and clearer separation of responsibilities for humans versus automation. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L244-R255) [[2]](diffhunk://#diff-4c558b33df7ebd1f454cc09262ebb1e1bdc3ef3f217760b29baeeea6048f2a12L98-R112) [[3]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295L92-R94) [[4]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295R106-R145)

**CI/CD and build system adjustments:**

* The docs build workflow is improved to better handle relative links in the README when generating the documentation index.

These changes collectively modernize and clarify the project's contribution and release process, making it easier for maintainers and contributors to follow best practices while reducing unnecessary overhead.

---

**Branching and release workflow:**
- Amended the branching policy to allow direct pushes to `dev` for low-risk changes, while maintaining pull request requirements for `main` and reviewable changes. Branch protection on `dev` should not require a PR, only passing status checks. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L8-R8) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L24-R36) [[3]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295L92-R94) [[4]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295R106-R145)
- Added a detailed release checklist in `docs/releasing.md`, outlining each phase of the release process and referencing the `scripts/release.sh` tooling. [[1]](diffhunk://#diff-c5175610592ce29ea8498f5df5c11c82d2f2ba273d60d5c13820b25731d72e49R1-R182) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R118) [[4]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R22)

**Documentation updates:**
- Updated `README.md` to reflect the new branching model, release process, and installation/usage instructions, with references to the new release checklist and ADRs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R137)
- Revised ADRs and workflow documentation to align with the amended process, clarifying roles and automation boundaries. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L244-R255) [[2]](diffhunk://#diff-4c558b33df7ebd1f454cc09262ebb1e1bdc3ef3f217760b29baeeea6048f2a12L98-R112) [[3]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295L92-R94) [[4]](diffhunk://#diff-1986228d15476990eff7f00f2d02b5ff1ac95fa056ee70e92d0c8eeb5ec5d295R106-R145)

**Build and CI improvements:**
- Improved the docs build workflow to correctly handle relative links from the README when generating the documentation site index.