### PR TITLE
Release v2.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,24 @@
 name: Build
 
 on:
+  # Topic branches are built through `pull_request`, which builds the merge
+  # result rather than the branch tip. Listing them here as well would run
+  # every build twice, and a bare `push:` would also rebuild release tags that
+  # release.yml already verifies.
   push:
+    branches:
+      - main
+      - dev
   pull_request:
 
 permissions:
   contents: read
+
+# A new push supersedes the run it interrupts, but only for pull requests --
+# builds of main and dev always run to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,12 @@ permissions:
 
 # A new push supersedes the run it interrupts, but only for pull requests --
 # builds of main and dev always run to completion.
+#
+# Keyed on the pull request *number* rather than the branch name: two pull
+# requests can carry the same head_ref (`patch-1` from two different forks),
+# and sharing a group would let one cancel the other's build.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,9 +44,12 @@ jobs:
 
       - name: Prepare docs index from README
         run: |
+          # The README is read from the repository root on GitHub and from
+          # docs/ on the site, so docs-relative paths have to be re-anchored.
           sed \
             -e 's|./docs/logo.svg|logo.svg|g' \
             -e 's|./docs/sponsors/|sponsors/|g' \
+            -e 's|](docs/|](|g' \
             -e 's|^  - |    - |g' \
             README.md > docs/index.md
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,8 +47,8 @@ jobs:
           # The README is read from the repository root on GitHub and from
           # docs/ on the site, so docs-relative paths have to be re-anchored.
           sed \
-            -e 's|./docs/logo.svg|logo.svg|g' \
-            -e 's|./docs/sponsors/|sponsors/|g' \
+            -e 's|\./docs/logo\.svg|logo.svg|g' \
+            -e 's|\./docs/sponsors/|sponsors/|g' \
             -e 's|](docs/|](|g' \
             -e 's|^  - |    - |g' \
             README.md > docs/index.md

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Copy Javadoc into docs
         run: cp -r target/reports/apidocs docs/api
 
+      - name: Copy the diagnostic report JSON Schema into docs
+        # The schema is a packaged compiler resource; it is staged here so the
+        # site serves it at the $id URL declared inside the file. Copied rather
+        # than duplicated in git, so there is only ever one source of truth.
+        run: |
+          mkdir -p docs/schema
+          cp jpipe-compiler/src/main/resources/schema/*.json docs/schema/
+
       - name: Prepare docs index from README
         run: |
           # The README is read from the repository root on GitHub and from

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ jpipe-lang/src/main/java
 .java-version
 site/
 
+# Staged into docs/ by the docs workflow at build time; the source of truth is
+# jpipe-compiler/src/main/resources/schema/. Ignored so a stale copy can never
+# be committed alongside it.
+docs/schema/
+
 # Local agent instructions
 CLAUDE.md
 GEMINI.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,36 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- `jpipe diagnostic` accepts `-f/--format text|json`. The JSON report carries
+  the same content as the human-readable one — diagnostics, statistics, model
+  summary, symbol table, and executed actions — in a form tools can consume,
+  making IDE integration possible without scraping the text output. The
+  document declares a `schemaVersion` so consumers can detect its shape.
+- Diagnostics now carry a machine-readable `code` (e.g. `unknown-model`,
+  `no-duplicate-ids`) as a distinct field, exposed in the JSON report. Codes
+  cover both compiler errors and consistency/completeness rules.
+- A **published JSON Schema** documents the report as a stable contract for
+  consumers. It ships on the classpath at
+  `/schema/diagnostic-report-v1.schema.json`, is served from the documentation
+  site, and is described in [the schema
+  reference](https://ace-design.github.io/jpipe/design/diagnostic-schema/).
+  Documents declare `schemaVersion` so consumers can branch on the shape.
+
+### Changed
+- The logo is suppressed automatically when `diagnostic -f json` writes to
+  standard output, so the document is parseable without passing `--headless`.
+  Text output and output to a file are unaffected.
+- **For API consumers:** `Diagnostic.message()` no longer contains the
+  `[code]` prefix — the code moved to `Diagnostic.code()`. The rendered text
+  report is unchanged, but code reading `message()` programmatically should
+  read `code()` instead. `DiagnosticCodes` constants lost their brackets
+  accordingly (`"[unknown-model]"` → `"unknown-model"`).
+
+### Fixed
+- `diagnostic -f json` (and any future machine-readable output) no longer has
+  its first bytes corrupted by the ASCII banner on standard output.
+
 ---
 
 ## [2.3.1] — 2026-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+---
+
+## [2.4.0] — 2026-08-10
+
 ### Added
 - `jpipe diagnostic` accepts `-f/--format text|json`. The JSON report carries
   the same content as the human-readable one — diagnostics, statistics, model
@@ -321,7 +325,8 @@ server.
 ### Added
 - Initial commit: first version of the compiler.
 
-[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.1...HEAD
+[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.1.0...v2.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with this repository.
 ## Critical Rules
 
 - **Never commit or push code without explicit user consent.** Always show the diff and ask before running any `git commit` or `git push` command.
-- **Never commit directly to `main`.** `main` is release-only (see [Git Workflow](#git-workflow)). All feature and fix work branches off `dev` and merges back into `dev`.
+- **Never commit directly to `main` or `dev`.** `main` is release-only (see [Git Workflow](#git-workflow)); `dev` accepts direct pushes from human authors, but Claude works on a topic branch unless explicitly told otherwise.
 - **Never merge a pull request or push a git tag.** Merging (including the release `dev`→`main` merge) and tagging (`vX.Y.Z`) are **human-only** actions. Claude prepares the branch/PR and hands off; it does not run `gh pr merge`, merge branches into `dev`/`main`, or push tags.
 
 ---
@@ -21,13 +21,19 @@ The repository uses a two-tier branching model (ADR-0024):
   It holds "everything merged since the last release," and the `CHANGELOG.md`
   `## [Unreleased]` section lives on `dev`.
 - **Topic branches** — `feat/…`, `fix/…`, `chore/…`, `docs/…`. Branch **from
-  `dev`**, merge back **into `dev`** (normally via PR). Merging into `dev` is
-  what adds the change to `[Unreleased]`.
-- **Releasing** — merge `dev` → `main`, rename `[Unreleased]` to the version,
-  push a `vX.Y.Z` tag on `main` (this triggers `release.yml`, ADR-0020), then
-  merge `main` back into `dev`. **The `dev`→`main` merge and the tag push are
-  human-only actions** (see Critical Rules); Claude only prepares the
-  release-prep branch/PR (changelog finalization, version bump).
+  `dev`**, merge back **into `dev`**. Merging into `dev` is what adds the change
+  to `[Unreleased]`.
+- **A PR into `dev` is not required.** Human authors may push low-risk changes
+  (version bumps, changelog close-out, CI configuration, small fixes carried by
+  their tests) straight to `dev` once `mvn verify` is green (ADR-0024, amendment
+  of 2026-08-07). Only `main` requires a PR. **This relaxation is for human
+  authors.** Claude still branches, commits, pushes the topic branch and stops;
+  it pushes to `dev` directly only when explicitly asked, and never commits
+  without showing the diff first (see Critical Rules).
+- **Releasing** — the full runbook is [`docs/releasing.md`](docs/releasing.md),
+  driven by `scripts/release.sh`. **The `dev`→`main` merge and the tag push are
+  human-only actions** (see Critical Rules); Claude only prepares the release
+  commit (changelog close-out, version bump).
 - **Hotfixes** — branch from `main`, merge into `main`, release via a patch tag,
   then merge back into `dev`.
 
@@ -241,12 +247,12 @@ Rules:
 - **How:** Write one concise, user-facing sentence describing the *effect*, not
   the implementation. Reference the PR or issue number when there is one
   (e.g. `(#136)`). Match the tone and style of existing entries.
-- **Releasing (maintainer action):** Cutting a release is a `dev` → `main`
-  merge (see [Git Workflow](#git-workflow)). Claude prepares a release-prep
-  branch that renames `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, adds the
-  git-compare link at the bottom, and opens a fresh empty `## [Unreleased]`
-  section above it. **The maintainer (human) performs the `dev`→`main` merge and
-  pushes the `vX.Y.Z` tag on `main`** — Claude does not merge or tag.
+- **Releasing (maintainer action):** `scripts/release.sh prepare X.Y.Z` performs
+  the close-out — it renames `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, adds
+  the git-compare link at the bottom, and opens a fresh empty `## [Unreleased]`
+  above it. Do this by hand only if the script cannot. **The maintainer (human)
+  performs the `dev`→`main` merge and pushes the `vX.Y.Z` tag** — Claude does not
+  merge or tag. Full runbook: [`docs/releasing.md`](docs/releasing.md).
 
 Do not edit already-released sections except to correct an error.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The jPipe environment supports the definition of justification to support softwa
 - `jpipe-cli`: command-line interface and fat JAR entry point
 - `docs`: technical documentation and architecture decision records
 - `bin`: launcher script templates (POSIX `sh` and PowerShell) used by the packaging channels
+- `scripts`: maintainer tooling (`release.sh`)
 - `debian`: Debian source packaging metadata for the Ubuntu PPA
 
 ### Developer Setup
@@ -57,79 +58,37 @@ mvn package
 
 The fat JAR is produced in `jpipe-cli/target/`.
 
+#### Branching
+
+Work is integrated on `dev`; `main` is release-only, and every commit on it is a
+published version ([ADR-0024](docs/adr/0024-git-branching-model.md)). Branch from
+`dev` and open a pull request for anything with reviewable content. Low-risk
+changes — version bumps, changelog close-out, CI configuration, a small fix
+carried by its tests — may be pushed straight to `dev` once `mvn verify` is green
+locally. Only `main` requires a pull request.
+
 #### Releasing a new version
 
-Releases are triggered by pushing a `v*.*.*` tag that points at a commit on
-`main` — the pipeline refuses a tag that is not an ancestor of `main`. Day-to-day
-work is merged into `dev`; cutting a release means merging `dev` into `main`
-first (see [ADR-0024](docs/adr/0024-git-branching-model.md)). The pipeline then
-creates a GitHub Release, updates the Homebrew formula and the Scoop manifest,
-and uploads a Debian source package to the Ubuntu PPA.
-
-**Prerequisites:** The following secrets must be configured in the GitHub
-repository settings:
-
-| Secret | Purpose |
-|--------|---------|
-| `HOMEBREW_TAP_TOKEN` | PAT with write access to `jpipe-mcscert/homebrew-mcscert` |
-| `SCOOP_BUCKET_TOKEN` | PAT with write access to `jpipe-mcscert/scoop-mcscert` |
-| `GPG_PRIVATE_KEY` | ASCII-armored GPG key registered on Launchpad |
-| `GPG_KEY_ID` | Fingerprint of the signing key |
-| `GPG_PASSPHRASE` | Passphrase for the signing key |
-
-**Steps:**
+A release is prepared on `dev`, merged into `main` through a pull request, and
+started by pushing a `vX.Y.Z` tag on `main`. The tag triggers the pipeline, which
+publishes the GitHub Release and updates Homebrew, Scoop and the Ubuntu PPA.
 
 ```bash
-# 1. Verify the base version in pom.xml matches what you plan to tag.
-#    pom.xml should be X.Y.Z-SNAPSHOT; the pipeline strips -SNAPSHOT automatically.
-mvn verify   # confirm the build is green locally
+scripts/release.sh prepare X.Y.Z       # on dev: set the version, close the changelog
+                                       # then push, and open the dev → main PR
+scripts/release.sh preflight X.Y.Z     # on main, after the merge: re-run the
+                                       # pipeline's checks before the tag exists
+git tag vX.Y.Z && git push origin vX.Y.Z
 
-# 2. Merge dev into main (normally via a release PR). main is release-only:
-#    every commit on it is a published version.
-
-# 3. Tag the resulting commit on main and push the tag — the pipeline fires.
-git switch main && git pull --ff-only
-git tag vX.Y.Z          # or vX.Y.Z-rcN for a pre-release
-git push origin vX.Y.Z
-
-# 4. Merge main back into dev, then bump to the next development version on a
-#    topic branch merged into dev.
-mvn -B versions:set -DnewVersion=X.Y+1.0-SNAPSHOT -DgenerateBackupPoms=false
+git switch dev && git merge origin/main            # after the release
+scripts/release.sh post-release X.Y.Z+1-SNAPSHOT
 ```
 
-**What happens automatically:**
-
-1. The pipeline validates that the tag version matches the base version in `pom.xml`
-   (e.g. tag `v2.1.0` is accepted when `pom.xml` declares `2.1.0-SNAPSHOT`).
-2. `mvn versions:set` is run inside the pipeline to stamp the exact release version
-   into the fat JAR manifest (`Implementation-Version: X.Y.Z`).
-3. A GitHub Release is created with the fat JAR, a Homebrew tarball, and a
-   Scoop zip. Tags containing `-` (e.g. `-rc1`) are automatically marked as
-   pre-releases.
-4. `jpipe.rb` in the Homebrew tap is updated with the new URL and SHA256
-   (stable releases only — skipped for pre-releases).
-5. `bucket/jpipe.json` in the Scoop bucket is updated with the new version, URL
-   and hash (stable releases only — skipped for pre-releases).
-6. A signed Debian source package is uploaded to `ppa:mcscert/ppa`
-   (stable releases only — skipped for pre-releases).
-
-**Verifying the release** (~30 min after the pipeline completes):
-
-```bash
-# macOS
-brew tap jpipe-mcscert/mcscert
-brew install jpipe
-
-# Ubuntu
-sudo add-apt-repository ppa:mcscert/ppa
-sudo apt update && sudo apt install jpipe
-```
-
-```powershell
-# Windows
-scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert
-scoop install mcscert/jpipe
-```
+**Read [`docs/releasing.md`](docs/releasing.md) before cutting a release** — it is
+the full checklist, including the dependency review, the Ubuntu series review and
+the Windows smoke test that the ADRs require. The pipeline's mechanics and the
+repository secrets it needs are documented in
+[ADR-0020](docs/adr/0020-tag-triggered-release-pipeline.md).
 
 #### Code style
 
@@ -149,9 +108,33 @@ mvn package -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade.DefaultS
 
 ## Usage
 
+### Installation
+
+Released versions are published to one package manager per platform
+([ADR-0025](docs/adr/0025-mainstream-platform-distribution.md)):
+
+```bash
+# macOS
+brew tap jpipe-mcscert/mcscert && brew install jpipe
+
+# Ubuntu
+sudo add-apt-repository ppa:mcscert/ppa
+sudo apt update && sudo apt install jpipe
+```
+
+```powershell
+# Windows
+scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert
+scoop install mcscert/jpipe
+```
+
+Each channel installs a `jpipe` launcher on your `PATH`; run `jpipe doctor` to
+check the installed version and its runtime dependencies. The fat JAR is also
+attached to every [GitHub Release](https://github.com/jpipe-mcscert/jpipe-compiler/releases).
+
 ### Running the compiler
 
-After building, the fat JAR is at `jpipe-cli/target/jpipe-cli-*.jar`. The
+After building from source, the fat JAR is at `jpipe-cli/target/jpipe-cli-*.jar`. The
 `process` subcommand is the default, so these two invocations are equivalent:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ scripts/release.sh preflight X.Y.Z     # on main, after the merge: re-run the
 git tag vX.Y.Z && git push origin vX.Y.Z
 
 git switch dev && git merge origin/main            # after the release
-scripts/release.sh post-release X.Y.Z+1-SNAPSHOT
+scripts/release.sh post-release <next>-SNAPSHOT    # e.g. 2.4.1-SNAPSHOT
 ```
 
 **Read [`docs/releasing.md`](docs/releasing.md) before cutting a release** — it is

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ the `dot` binary is on your `PATH` before using image formats.
 # Parse and validate without exporting — prints diagnostics, statistics, and the symbol table
 java -jar jpipe-cli/target/jpipe-cli-*.jar diagnostic -i my.jd
 
+# Same report as JSON, for IDEs and other tooling
+java -jar jpipe-cli/target/jpipe-cli-*.jar diagnostic -i my.jd -f json
+
 # Check runtime dependencies (Graphviz)
 java -jar jpipe-cli/target/jpipe-cli-*.jar doctor
 ```

--- a/docs/adr/0016-error-management.md
+++ b/docs/adr/0016-error-management.md
@@ -109,3 +109,48 @@ outside the compiler's control.
   there).
 - All CLI commands must check the boolean return of `compile()` and map `true` to
   `EXIT_JPIPE_ERROR`.
+
+## Amendment (2026-08-09): diagnostic codes are data, not a message prefix
+
+The original decision modelled a `Diagnostic` as a level, a source location, and
+a human-readable message. Codes existed — `DiagnosticCodes` listed ten of them —
+but only as bracketed *prefixes concatenated into the message*
+(`"[unknown-model] unknown model 'foo'"`), and validation rules were flattened
+the same way at the checker boundary, discarding the `Violation.rule()` field
+that already carried the identifier structurally.
+
+That was adequate while the only consumer was a human reading a terminal. It
+stopped being adequate once the diagnostic report gained a machine-readable
+rendering (`jpipe diagnostic -f json`): a consumer wanting to categorise, filter
+or map diagnostics onto IDE severities had to re-parse the prefix back out of a
+string the compiler had just assembled.
+
+### Amended decision
+
+- **`Diagnostic` carries a `code` component**: a stable, bare kebab-case
+  identifier, or `null` when the diagnostic has none. `hasCode()` reports its
+  presence.
+- **`DiagnosticCodes` constants lose their brackets** (`"[unknown-model]"` →
+  `"unknown-model"`), which also makes them directly comparable with
+  `Violation.rule()`, already bare kebab-case.
+- **Presentation belongs to the renderer.** The human-readable report and the
+  `ChainCompiler` stderr fallback re-add the `"[code] "` prefix, so their output
+  is byte-for-byte what it was; the JSON report emits `code` as its own field.
+- **Codes remain optional.** Several diagnostics are summary lines with no
+  meaningful code (`"model construction failed — see errors above"`), and no
+  code is invented for them. `FATAL` diagnostics carry no code today; giving
+  them one is a later, additive change.
+
+This is a refinement of the diagnostic *payload*. The two-level severity model,
+the fast-fail semantics of `fire()`, the `HaltAndCatchFire` placement, and the
+exit-code table are all unchanged.
+
+### Consequences
+
+- `Diagnostic.message()` no longer contains the code. Code reading it
+  programmatically must read `code()` instead — the one consumer-visible break,
+  recorded in the changelog.
+- The canonical `Diagnostic` constructor gained a component; the factory methods
+  absorb this for all in-tree callers.
+- Tests and tooling that matched `"[" + rule + "]"` inside a message now match
+  `code()` directly, which is both cheaper and stricter.

--- a/docs/adr/0016-error-management.md
+++ b/docs/adr/0016-error-management.md
@@ -1,6 +1,7 @@
-# ADR-0016: Error Management — Diagnostic Levels, Pipeline Interruption, and Exit Codes
+# ADR-0016: Error Management — Diagnostic Levels, Codes, Pipeline Interruption, and Exit Codes
 
 **Date:** 2026-04-01
+**Last revised:** 2026-08-09
 **Status:** Accepted
 
 ## Context
@@ -14,6 +15,10 @@ categories of problem can arise during compilation:
 2. **Semantic errors** — the model is structurally sound but violates domain rules
    (consistency, completeness). The model can still be exported; the errors are
    informational for the user.
+
+Diagnostics have two audiences: a person reading a terminal, and tooling that
+consumes the compiler's output (IDE integrations, CI dashboards). A diagnostic
+shaped only for the first forces the second to parse prose.
 
 Prior to this ADR:
 - `HaltAndCatchFire` checkpoints were placed after *both* parsing and semantic
@@ -40,6 +45,32 @@ and the user must see it", but allows the pipeline to continue and produce outpu
 `FATAL` means "continuing is meaningless or dangerous". It is promoted from `ERROR`
 only by `HaltAndCatchFire`, and only in contexts where downstream steps cannot
 function correctly on the resulting intermediate value.
+
+### Diagnostics carry a machine-readable code
+
+A `Diagnostic` is a level, an optional code, a source location, and a
+human-readable message. The code is a stable, bare kebab-case identifier —
+`unknown-model`, `no-duplicate-ids` — or `null` when the diagnostic has none;
+`hasCode()` reports its presence.
+
+Compiler codes are centralised in `DiagnosticCodes`. Validation rules reach the
+same field through `Violation.rule()` (ADR-0015), which is already bare
+kebab-case, so the two families are directly comparable and no translation layer
+sits between a validator and a diagnostic.
+
+The code is **data, not text**: it never appears inside `message()`, and each
+renderer chooses its own presentation.
+
+| Renderer | Presentation |
+|----------|--------------|
+| Human-readable diagnostic report | `[unknown-model] unknown model 'foo'` |
+| `ChainCompiler` stderr fallback | `[unknown-model] unknown model 'foo'` |
+| JSON diagnostic report | a separate `code` member |
+
+Codes are optional by design. Summary diagnostics such as `"model construction
+failed — see errors above"` name no specific rule, and none is invented for
+them. `FATAL` diagnostics carry no code: a fatal aborts the pipeline before any
+report is rendered, so nothing consumes one.
 
 ### HaltAndCatchFire is placed exclusively after parsing
 
@@ -97,6 +128,11 @@ outside the compiler's control.
 - **boolean return over exception.** Throwing a post-completion exception to signal
   "succeeded with errors" would cause the CLI to print a redundant error message on
   top of already-printed diagnostics. A boolean return keeps the separation clean.
+- **Codes as a field, not a message prefix.** Encoding the code inside the message
+  would make every consumer re-parse a string the compiler had just assembled, and
+  would discard at the checker boundary the identifier the validators already carry.
+  One representation, chosen by each renderer at display time, keeps the human and
+  machine readings of a diagnostic from drifting apart.
 
 ## Consequences
 
@@ -109,48 +145,9 @@ outside the compiler's control.
   there).
 - All CLI commands must check the boolean return of `compile()` and map `true` to
   `EXIT_JPIPE_ERROR`.
-
-## Amendment (2026-08-09): diagnostic codes are data, not a message prefix
-
-The original decision modelled a `Diagnostic` as a level, a source location, and
-a human-readable message. Codes existed — `DiagnosticCodes` listed ten of them —
-but only as bracketed *prefixes concatenated into the message*
-(`"[unknown-model] unknown model 'foo'"`), and validation rules were flattened
-the same way at the checker boundary, discarding the `Violation.rule()` field
-that already carried the identifier structurally.
-
-That was adequate while the only consumer was a human reading a terminal. It
-stopped being adequate once the diagnostic report gained a machine-readable
-rendering (`jpipe diagnostic -f json`): a consumer wanting to categorise, filter
-or map diagnostics onto IDE severities had to re-parse the prefix back out of a
-string the compiler had just assembled.
-
-### Amended decision
-
-- **`Diagnostic` carries a `code` component**: a stable, bare kebab-case
-  identifier, or `null` when the diagnostic has none. `hasCode()` reports its
-  presence.
-- **`DiagnosticCodes` constants lose their brackets** (`"[unknown-model]"` →
-  `"unknown-model"`), which also makes them directly comparable with
-  `Violation.rule()`, already bare kebab-case.
-- **Presentation belongs to the renderer.** The human-readable report and the
-  `ChainCompiler` stderr fallback re-add the `"[code] "` prefix, so their output
-  is byte-for-byte what it was; the JSON report emits `code` as its own field.
-- **Codes remain optional.** Several diagnostics are summary lines with no
-  meaningful code (`"model construction failed — see errors above"`), and no
-  code is invented for them. `FATAL` diagnostics carry no code today; giving
-  them one is a later, additive change.
-
-This is a refinement of the diagnostic *payload*. The two-level severity model,
-the fast-fail semantics of `fire()`, the `HaltAndCatchFire` placement, and the
-exit-code table are all unchanged.
-
-### Consequences
-
-- `Diagnostic.message()` no longer contains the code. Code reading it
-  programmatically must read `code()` instead — the one consumer-visible break,
-  recorded in the changelog.
-- The canonical `Diagnostic` constructor gained a component; the factory methods
-  absorb this for all in-tree callers.
-- Tests and tooling that matched `"[" + rule + "]"` inside a message now match
-  `code()` directly, which is both cheaper and stricter.
+- `Diagnostic.message()` never contains the code; consumers read `code()`. Tests and
+  tooling match on the code directly rather than searching the message text.
+- Introducing a diagnostic code means adding a constant to `DiagnosticCodes`, or
+  naming a rule in a validator — not editing a message string. A renderer that wants
+  to display it decides how.
+- Any renderer of diagnostics must handle a `null` code, since the field is optional.

--- a/docs/adr/0020-tag-triggered-release-pipeline.md
+++ b/docs/adr/0020-tag-triggered-release-pipeline.md
@@ -95,21 +95,21 @@ need to remove the `-SNAPSHOT` suffix before tagging. The validation step strips
 `-SNAPSHOT` from the pom version before comparing, so a pom at `2.1.0-SNAPSHOT`
 is correct when releasing `v2.1.0`.
 
-Manual steps required:
-
-1. Verify the base version in `pom.xml` matches the intended tag
-   (e.g. `2.1.0-SNAPSHOT` to release `v2.1.0`).
-2. Run `mvn verify` locally to confirm the build is green.
-3. Merge `dev` into `main` and push the tag — the pipeline fires automatically.
-4. Merge `main` back into `dev`, then bump `pom.xml` to the next development
-   version (`mvn -B versions:set -DnewVersion=X.Y+1.0-SNAPSHOT`) on a topic
-   branch merged into `dev`.
+That validation is also the pipeline's sharpest edge: it runs *after* the tag has
+been pushed, so a pom that disagrees with the tag fails the release rather than
+preventing it. The release version is therefore set during preparation, on `dev`,
+by `scripts/release.sh prepare X.Y.Z` — and `scripts/release.sh preflight X.Y.Z`
+reproduces this check, and the "tag is on `main`" check above, locally before the
+tag exists.
 
 Tags containing `-` (e.g. `v2.1.0-rc1`) are automatically marked as pre-releases;
 all three channel jobs are skipped for them.
 
-See the "Releasing a new version" section in `README.md` for the full
-step-by-step procedure.
+The step-by-step procedure — including the dependency review
+([ADR-0007](0007-dependency-freshness-policy.md)), the Ubuntu series review
+([ADR-0023](0023-ubuntu-release-target-policy.md)) and the manual Windows check
+([ADR-0025](0025-mainstream-platform-distribution.md)) — lives in
+[`docs/releasing.md`](../releasing.md).
 
 ### Downstream effects
 

--- a/docs/adr/0024-git-branching-model.md
+++ b/docs/adr/0024-git-branching-model.md
@@ -89,8 +89,9 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
 ## Consequences
 
 - A `dev` branch is created from the current `main` and becomes the default
-  branch for development; branch protection should require PRs into `dev` and
-  forbid direct pushes to `main`.
+  branch for development; branch protection should forbid direct pushes to
+  `main`. (Amended 2026-08-07: protection on `dev` must *not* require a pull
+  request — see the amendment below.)
 - Contributors branch from `dev`, not `main`. The default branch on the remote
   should be set to `dev` so clones and PRs target it by default.
 - The release checklist gains a first step: merge `dev` into `main` before
@@ -102,3 +103,43 @@ and the tag-triggered pipeline (ADR-0020) are unchanged; this ADR only changes
   only after the next release.
 - Existing open work branched from `main` (e.g. the branch introducing this
   ADR) is retargeted onto `dev`.
+
+## Amendment (2026-08-07): pull requests are not required for `dev`
+
+The original decision said feature branches merge into `dev` "normally via pull
+request" and that branch protection "should require PRs into `dev`". In practice
+that made routine bookkeeping disproportionately expensive: bumping the version
+to the next `-SNAPSHOT` after a release is a one-line change with nothing to
+review, yet it cost a branch, a pull request, and a merge.
+
+### Amended decision
+
+- **A pull request remains the default** for any change with reviewable content —
+  new behaviour, bug fixes of substance, grammar or model changes, anything a
+  second reader would improve.
+- **Direct pushes to `dev` are permitted** when the author judges the change
+  low-risk and `mvn verify` is green locally. Blessed examples:
+    - release bookkeeping — version bumps, changelog close-out, compare links;
+    - CI and build configuration;
+    - small fixes carried by their own tests.
+- **`main` is unchanged.** It stays release-only, is entered exclusively through
+  a `dev` → `main` pull request, and the `vX.Y.Z` tag is pushed by a human.
+- **Branch protection** on `dev` should forbid force-pushes and require the
+  status checks to pass; it must **not** require a pull request. `main` keeps its
+  pull-request requirement.
+
+### Rationale
+
+The pull request was never what made a change to `dev` safe. `build.yml` has no
+branch filter, so it runs on every push; `sonar.yml` analyses pushes on
+`branches: [main, dev]`. A direct commit is therefore built, tested and
+quality-gated exactly like a pull-requested one. What the pull request adds is
+*review* — valuable for reviewable content, and pure overhead for a version bump.
+
+One caveat worth weighing rather than legislating: `docs.yml` deploys the
+documentation site on every push to `dev`, so a docs change pushed directly is
+published immediately, with no staging step.
+
+This amendment narrows only *how* a change enters `dev`. The two-tier model, the
+role of each branch, and the release procedure are unaffected. The full release
+runbook lives in [`docs/releasing.md`](../releasing.md).

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -167,8 +167,9 @@ compilations. Delegates to
 ```
 
 Optional keys are omitted rather than emitted as `null`. Arrays preserve order;
-object key order is not significant. `schemaVersion` is bumped only on a
-breaking change — additions stay additive.
+object key order is not significant. `schemaVersion` is incremented whenever the
+set of members changes, additions included — the schema is strict, so no change
+is invisible to a consumer validating against it.
 
 The document is described by a published **[JSON Schema](diagnostic-schema.md)**
 that acts as the contract with consumers; it ships on the classpath at

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -103,25 +103,86 @@ success, `1` if any ERROR or FATAL diagnostic was reported.
 
 ### `diagnostic`
 
-Parses and validates a `.jd` source file and prints a human-readable report
-without exporting any model. Useful for checking a file for errors or
-inspecting the symbol table.
+Parses and validates a `.jd` source file and reports on it without exporting
+any model. Useful for checking a file for errors, inspecting the symbol table,
+or feeding an IDE.
 
 ```
-jpipe diagnostic -i <file> [-o <output>]
+jpipe diagnostic -i <file> [-o <output>] [-f <format>]
 ```
 
-The report produced by `DiagnosticReport` has four sections:
+| Option | Values | Default |
+|--------|--------|---------|
+| `-f`, `--format` | `TEXT`, `JSON` (case-insensitive) | `TEXT` |
 
-1. **Diagnostics** — all ERROR and FATAL messages, with source locations.
+The report has five sections:
+
+1. **Diagnostics** — all ERROR and FATAL messages, with source locations and
+   their diagnostic code.
 2. **Action Statistics** — total command count, macro count, and deferral
    count from the `ExecutionEngine`.
 3. **Model Summary** — for each model: kind (justification/template), parent
    template (if any), element counts, and which justifications implement it.
 4. **Symbol Table** — all element ids with their source locations, plus alias
    mappings from composition operators.
+5. **Executed Actions** — the ordered model-construction command trace.
 
-Delegates to `CompilerFactory.buildDiagnosticCompiler(out)`.
+Sections whose data is absent (no statistics recorded, no actions executed)
+are omitted rather than printed empty.
+
+Both formats are produced from the same `DiagnosticSnapshot`, collected once by
+`CollectDiagnostics` and then rendered by either `DiagnosticReport` (text) or
+`JsonDiagnosticReport` (JSON), so the two can never describe different
+compilations. Delegates to
+`CompilerFactory.buildDiagnosticCompiler(format, out)`.
+
+#### JSON report
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "source": "examples/foo.jd",
+  "status": "ok",                    // "ok" | "errors"
+  "diagnostics": [
+    { "severity": "error",           // "error" | "fatal"
+      "code": "unknown-model",       // omitted when the diagnostic has no code
+      "source": "foo.jd",
+      "line": 12, "column": 4,       // both omitted when the location is unknown
+      "message": "unknown model 'bar'" }
+  ],
+  "stats": { "commands": { "total": 42, "macros": 3 }, "deferrals": 1 },
+  "models": [
+    { "name": "m", "kind": "justification",
+      "implements": "t",             // omitted when the model implements nothing
+      "location": { "source": "foo.jd", "line": 3, "column": 0 },
+      "elements": { "conclusion": 1, "subConclusion": 2, "strategy": 1,
+                    "evidence": 3, "abstractSupport": 0 },
+      "usedBy":  [ { "name": "j", "location": { … } } ],  // templates only
+      "symbols": [ { "id": "e1", "kind": "evidence",
+                     "synthesized": false, "location": { … } } ],
+      "aliases": [ { "from": "a", "to": "b" } ] }
+  ],
+  "actions": [ { "index": 1, "depth": 0, "macro": false, "description": "…" } ]
+}
+```
+
+Optional keys are omitted rather than emitted as `null`. Arrays preserve order;
+object key order is not significant. `schemaVersion` is bumped only on a
+breaking change — additions stay additive.
+
+The document is described by a published **[JSON Schema](diagnostic-schema.md)**
+that acts as the contract with consumers; it ships on the classpath at
+`/schema/diagnostic-report-v1.schema.json` and every report the test suite
+produces is validated against it.
+
+The ASCII logo is suppressed automatically when the JSON report goes to
+standard output, so `jpipe diagnostic -f json | jq .` works without
+`--headless`. Writing to a file with `-o` keeps the banner on stdout.
+
+**Limitation.** A *fatal* error (a syntax error, an unresolvable `load`) aborts
+the pipeline before any report is produced, in either format: nothing is
+written to the output stream, the message goes to standard error, and the exit
+code is 1. Tools must handle that case separately.
 
 ### `doctor`
 

--- a/docs/design/diagnostic-schema.md
+++ b/docs/design/diagnostic-schema.md
@@ -62,12 +62,31 @@ check-jsonschema \
 Every document carries `schemaVersion`, so a consumer can branch on it before
 reading anything else.
 
-- **Additive changes** — a new optional member — keep `schemaVersion` at `1`.
-  Because the schema is strict, the schema file is updated in the same change;
-  consumers pinned to an older copy should ignore members they do not know.
-- **Breaking changes** — removing or retyping a member, or changing what an
-  existing one means — publish a new file (`…-v2.schema.json`) and bump
-  `schemaVersion`. The previous schema stays reachable at its own `$id`.
+**Any change to the set of members publishes a new schema file
+(`…-v2.schema.json`) and increments `schemaVersion`. Adding an optional member
+counts.** Earlier schemas stay reachable at their own `$id`, so a consumer
+pinned to one keeps validating the documents it was written for.
+
+That rule follows from strictness rather than caution. Because the schema sets
+`additionalProperties: false`, a document carrying a member the schema does not
+list *fails validation* — so there is no such thing as an addition that is
+invisible to a consumer. Telling consumers to "ignore members you don't know"
+would not help: their validator rejects the document before their code sees it.
+
+The alternative would be to let the schema permit unknown properties, which
+buys silent additions at the cost of the guarantee that makes the schema useful
+as a test oracle — a typo'd or duplicated key would then validate cleanly. The
+strict reading is the deliberate choice; the versioning rule above is its
+consequence.
+
+For consumers, the practical form is:
+
+```jsonc
+if (report.schemaVersion !== 1) {
+  // a shape this code was not written against — refuse it or handle it
+  // explicitly, rather than reading fields that may have changed meaning
+}
+```
 
 ## Where it is enforced
 

--- a/docs/design/diagnostic-schema.md
+++ b/docs/design/diagnostic-schema.md
@@ -1,0 +1,96 @@
+# Diagnostic report JSON Schema
+
+`jpipe diagnostic -f json` emits a document described by a published
+[JSON Schema](https://json-schema.org/) (draft 2020-12). The schema is the
+contract between the compiler and its consumers: an IDE extension, a CI
+dashboard, or any tool that reads the report can validate against it and code
+against its guarantees rather than against whatever the compiler happened to
+print.
+
+| | |
+|---|---|
+| **Download** | <https://ace-design.github.io/jpipe/schema/diagnostic-report-v1.schema.json> |
+| **`$id`** | `https://ace-design.github.io/jpipe/schema/diagnostic-report-v1.schema.json` |
+| **Source of truth** | `jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json` |
+| **Current version** | `schemaVersion: 1` |
+
+## Getting the schema
+
+There is exactly one copy of the file — a packaged compiler resource. It is
+reachable three ways:
+
+- **From the classpath**, the cheapest option for a JVM consumer: it ships in
+  `jpipe-compiler` and in the fat JAR at
+  `/schema/diagnostic-report-v1.schema.json`.
+
+  ```java
+  try (InputStream in = getClass()
+          .getResourceAsStream("/schema/diagnostic-report-v1.schema.json")) {
+      // …
+  }
+  ```
+
+- **From the documentation site**, at the `$id` URL above. The docs build stages
+  the packaged resource into the site; it is not a second copy kept in the
+  repository, so it cannot drift.
+
+- **From the repository**, at the source-of-truth path in the table above.
+
+## Validating
+
+The schema is strict: `additionalProperties` is `false` throughout, so an
+unexpected key is a violation. Beyond structure it pins several invariants
+worth relying on:
+
+- a diagnostic `code` is bare kebab-case, never bracketed — `unknown-model`,
+  not `[unknown-model]`;
+- `line` and `column` always appear together, or not at all;
+- a symbol carries a `location` **iff** it is not `synthesized`;
+- a `justification` never has entries in `usedBy`;
+- `elements.conclusion` is `0` or `1` — a model owns at most one conclusion.
+
+```bash
+# with any draft 2020-12 validator, e.g. check-jsonschema
+jpipe diagnostic -i my.jd -f json > report.json
+check-jsonschema \
+  --schemafile jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json \
+  report.json
+```
+
+## Versioning policy
+
+Every document carries `schemaVersion`, so a consumer can branch on it before
+reading anything else.
+
+- **Additive changes** — a new optional member — keep `schemaVersion` at `1`.
+  Because the schema is strict, the schema file is updated in the same change;
+  consumers pinned to an older copy should ignore members they do not know.
+- **Breaking changes** — removing or retyping a member, or changing what an
+  existing one means — publish a new file (`…-v2.schema.json`) and bump
+  `schemaVersion`. The previous schema stays reachable at its own `$id`.
+
+## Where it is enforced
+
+The schema is **not** validated at runtime. The document is built by
+straight-line code from a typed `DiagnosticSnapshot`, so no input a user
+supplies can make it structurally invalid — only a change to the compiler can,
+and that is a build-time concern. Validating on every invocation would spend
+work checking our own output, and would leave nothing sensible to do on
+failure: aborting a compilation that just succeeded is worse than emitting the
+report.
+
+Instead `JsonDiagnosticReportSchemaTest` validates against the schema every
+report produced from the unit fixtures **and from every file in `examples/`**,
+so code and schema cannot drift apart without CI noticing. The same test also
+asserts that the schema rejects malformed documents, so it cannot quietly decay
+into one that accepts anything.
+
+## Note on fatal errors
+
+A *fatal* error — a syntax error, an unresolvable `load` — aborts the pipeline
+before any report is rendered. **Nothing is written to the output stream**, the
+message goes to standard error, and the exit code is 1. Consumers must handle
+that case outside the schema. `severity: "fatal"` is reserved in the schema but
+does not currently appear in any document.
+
+See [`cli.md`](cli.md#diagnostic) for the command itself.

--- a/docs/design/steps.md
+++ b/docs/design/steps.md
@@ -278,16 +278,38 @@ in the caller thread, avoiding deadlock when the process pipe buffer is smaller
 than the input. Supports any format that `dot -T` accepts; the CLI uses
 `"png"`, `"jpeg"`, and `"svg"`.
 
-#### `DiagnosticReport`
+#### `CollectDiagnostics`
 
-**Type:** `Transformation<Unit, String>`  
+**Type:** `Transformation<Unit, DiagnosticSnapshot>`  
 **Package:** `compiler.steps.transformations`
 
-Produces a human-readable diagnostic report from the compiled `Unit` and
-`CompilationContext`. Used by the `diagnostic` CLI command instead of an
-export. The report has four sections: Diagnostics, Action Statistics, Model
-Summary (type, parent, element counts per model), and Symbol Table (element
-ids with source locations and alias mappings from composition operators).
+Gathers everything a diagnostic report shows — diagnostics, statistics, per
+model element counts, symbols with resolved locations, aliases, and the
+executed-action trace — into an immutable `DiagnosticSnapshot`. This is the
+only step that walks the `Unit` for reporting purposes; the renderers below
+consume the snapshot and never touch the model, which is what keeps the two
+report formats describing the same compilation.
+
+#### `DiagnosticReport`
+
+**Type:** `Transformation<DiagnosticSnapshot, String>`  
+**Package:** `compiler.steps.transformations`
+
+Renders the snapshot as the human-readable report printed by the `diagnostic`
+CLI command instead of an export. Five sections: Diagnostics, Action
+Statistics, Model Summary (type, parent, element counts per model), Symbol
+Table (element ids with source locations and alias mappings from composition
+operators), and Executed Actions. Sections whose data is absent are omitted.
+
+#### `JsonDiagnosticReport`
+
+**Type:** `Transformation<DiagnosticSnapshot, String>`  
+**Package:** `compiler.steps.transformations`
+
+Renders the same snapshot as JSON for tooling — selected by `diagnostic -f
+json`. Uses `org.json` internally as a builder for correct escaping while the
+pipeline type stays `String` (ADR-0013). The document declares a
+`schemaVersion`; see [`cli.md`](cli.md) for its shape.
 
 ---
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,182 @@
+# Releasing a new version
+
+This is the release checklist. Work through the phases in order; each one ends
+with a single command or a single decision.
+
+**The shape of a release.** Day-to-day work accumulates on `dev`. A release closes
+out the `CHANGELOG.md` `[Unreleased]` section, merges `dev` into `main` through a
+pull request, and pushes a `vX.Y.Z` tag on `main`. The tag — nothing else —
+triggers `release.yml`, which publishes the GitHub Release and updates Homebrew,
+Scoop and the Ubuntu PPA. See [ADR-0024](adr/0024-git-branching-model.md) for the
+branch model and [ADR-0020](adr/0020-tag-triggered-release-pipeline.md) for the
+pipeline mechanics and the list of required repository secrets.
+
+`scripts/release.sh` does the mechanical parts. It never merges, never tags, and
+never pushes — those stay in your hands.
+
+---
+
+## Phase 0 — Decide
+
+Three judgement calls, none of which a script can make for you.
+
+**Pick the version number.** Read the `[Unreleased]` section and apply semantic
+versioning ([ADR-0001](adr/0001-semver-versioning.md)): a breaking change to a
+public API — `jpipe-operators` above all — is a MAJOR bump, new behaviour is
+MINOR, fixes alone are PATCH. What `pom.xml` currently says is *not* an input to
+this decision; Phase 1 sets the pom to whatever you choose here.
+
+**Review dependencies** ([ADR-0007](adr/0007-dependency-freshness-policy.md)) —
+a required step, not optional housekeeping:
+
+```bash
+mvn versions:display-dependency-updates
+mvn versions:display-plugin-updates
+```
+
+**Review the Ubuntu series matrix**
+([ADR-0023](adr/0023-ubuntu-release-target-policy.md)). Compare the `distro:` list
+in `.github/workflows/release.yml` against the policy: every LTS released in or
+after 2024 that is still in standard support, plus the next LTS once its series
+opens on Launchpad, plus every interim release inside its nine-month window. Add
+a series when it enters support; drop one in the release that follows its EOL.
+
+---
+
+## Phase 1 — Prepare, on `dev`
+
+```bash
+git switch dev && git pull --ff-only
+scripts/release.sh prepare X.Y.Z
+```
+
+This sets every pom to `X.Y.Z-SNAPSHOT`, renames `## [Unreleased]` to
+`## [X.Y.Z] — <today>`, opens a fresh empty `[Unreleased]` above it, adds the
+`[X.Y.Z]` compare link at the bottom of the changelog, runs `mvn verify`, and
+commits. Add `--dry-run` to see the diff without writing anything.
+
+Setting the pom here is what makes the version safe. The pipeline compares the
+tag against the pom version and fails **after the tag has been pushed**, so the
+pom must say `X.Y.Z-SNAPSHOT` before you tag `vX.Y.Z` — whatever `dev` happened
+to be bumped to earlier is irrelevant once `prepare` has run.
+
+Then push. A release chore does not need a pull request
+([ADR-0024, amended](adr/0024-git-branching-model.md#amendment-2026-08-07-pull-requests-are-not-required-for-dev)):
+
+```bash
+git push
+```
+
+---
+
+## Phase 2 — Release pull request
+
+```bash
+scripts/release.sh preflight X.Y.Z
+```
+
+Preflight re-runs every check `release.yml` performs, while the tag still does
+not exist: clean tree, branch in sync, pom version against the tag base, tag not
+already taken, changelog closed out, `mvn verify` green. It also reports whether
+`HEAD` is on `main` yet — expect a warning here, since the merge has not
+happened.
+
+Open a pull request from `dev` to `main` titled `Release vX.Y.Z`, and merge it
+once the checks are green. This is the one merge in the process that must go
+through a pull request: `main` is release-only, and every commit on it is a
+published version.
+
+---
+
+## Phase 3 — Tag, on `main`
+
+```bash
+git switch main && git pull --ff-only
+scripts/release.sh preflight X.Y.Z    # now expect "HEAD is on main"
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Pushing the tag is what starts the release. `release.yml` verifies the tag is an
+ancestor of `main`, re-checks it against `pom.xml`, stamps the version into the
+fat JAR manifest, builds once, and publishes the GitHub Release with three
+assets. The Homebrew, Scoop and PPA jobs then run in parallel off that release.
+
+A tag containing a hyphen (`v2.4.0-rc1`) is published as a GitHub pre-release and
+**every** channel job is skipped
+([ADR-0025](adr/0025-mainstream-platform-distribution.md)). A release candidate is
+cut from an already-prepared version — do not run `prepare` for it.
+
+Watch the run: <https://github.com/jpipe-mcscert/jpipe-compiler/actions>
+
+---
+
+## Phase 4 — Verify
+
+Package indices take up to about thirty minutes to settle.
+
+```bash
+# macOS
+brew tap jpipe-mcscert/mcscert
+brew install jpipe && jpipe doctor
+
+# Ubuntu
+sudo add-apt-repository ppa:mcscert/ppa
+sudo apt update && sudo apt install jpipe && jpipe doctor
+```
+
+```powershell
+# Windows
+scoop bucket add mcscert https://github.com/jpipe-mcscert/scoop-mcscert
+scoop install mcscert/jpipe
+jpipe doctor
+```
+
+`jpipe doctor` should report the version you just tagged. **The Windows check is
+manual and required** — it is the one channel CI cannot smoke-test
+([ADR-0025](adr/0025-mainstream-platform-distribution.md)).
+
+---
+
+## Phase 5 — Merge back and reopen development
+
+```bash
+git switch dev && git pull --ff-only
+git merge origin/main
+scripts/release.sh post-release X.Y.Z+1-SNAPSHOT
+git push
+```
+
+Merging `main` back into `dev` keeps the release commit shared between the two
+branches; `post-release` refuses to run until you have. The next patch version is
+the low-surprise default — since Phase 1 sets the release version explicitly, an
+over-bump here is harmless, but it is what confused the 2.3.1 release.
+
+---
+
+## Troubleshooting
+
+**The tag is pushed and the pipeline failed on the version check.** The tag is
+not on the release yet, so it is safe to withdraw:
+
+```bash
+git push --delete origin vX.Y.Z
+git tag -d vX.Y.Z
+```
+
+Fix the pom on `dev` (`scripts/release.sh prepare X.Y.Z`), merge to `main` again,
+and re-tag. Running `preflight` in Phase 3 is what prevents this.
+
+**The release published but a channel job failed.** By design, a missing
+credential or a broken index fails one channel, not the release — the GitHub
+Release and its assets are already live. Fix the cause and re-run the failed job
+from the Actions run page; the channel jobs consume release assets rather than
+rebuilding, so re-running is safe and produces identical bytecode.
+
+**`prepare` says `[Unreleased]` is empty.** Nothing has been merged into `dev`
+since the last release, or the entries were never written. The changelog is the
+release notes — write them before releasing, not after.
+
+**`post-release` says main is not merged back.** Run `git merge origin/main` on
+`dev` first. Skipping this leaves the release commit on `main` only, and the next
+release's `dev` → `main` merge becomes a conflict.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -143,14 +143,17 @@ manual and required** — it is the one channel CI cannot smoke-test
 ```bash
 git switch dev && git pull --ff-only
 git merge origin/main
-scripts/release.sh post-release X.Y.Z+1-SNAPSHOT
+scripts/release.sh post-release <next>-SNAPSHOT   # e.g. 2.4.1-SNAPSHOT
 git push
 ```
 
-Merging `main` back into `dev` keeps the release commit shared between the two
-branches; `post-release` refuses to run until you have. The next patch version is
-the low-surprise default — since Phase 1 sets the release version explicitly, an
+Pass the next version literally — `<next>` is a placeholder, and the script
+rejects anything that is not a valid Maven version. The next **patch** is the
+low-surprise default: since Phase 1 sets the release version explicitly, an
 over-bump here is harmless, but it is what confused the 2.3.1 release.
+
+Merging `main` back into `dev` keeps the release commit shared between the two
+branches; `post-release` refuses to run until you have.
 
 ---
 

--- a/jpipe-cli/pom.xml
+++ b/jpipe-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-cli</artifactId>

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/DiagnosticCommand.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/DiagnosticCommand.java
@@ -1,21 +1,44 @@
 package ca.mcscert.jpipe.cli;
 
+import ca.mcscert.jpipe.compiler.CompilationConfig;
 import ca.mcscert.jpipe.compiler.CompilerFactory;
+import ca.mcscert.jpipe.compiler.DiagnosticFormat;
 import java.io.IOException;
 import java.io.OutputStream;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
 /**
- * Parses a {@code .jd} source file and prints a human-readable diagnostic
- * report without exporting any model.
+ * Parses a {@code .jd} source file and reports on it without exporting any
+ * model, either as a human-readable report or as JSON for tooling.
  */
 @Command(name = "diagnostic", description = "Parse and report diagnostics without exporting.", mixinStandardHelpOptions = true)
 class DiagnosticCommand extends InputOutputCommand {
 
+	/**
+	 * Initialised as well as declared with a picocli default, so that the
+	 * command behaves identically whether picocli populated it or a caller
+	 * instantiated the command directly.
+	 */
+	@Option(names = {"-f",
+			"--format"}, description = "Report format: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE}).", defaultValue = "TEXT")
+	protected DiagnosticFormat format = DiagnosticFormat.TEXT;
+
 	@Override
 	protected Integer doCall(OutputStream out) throws IOException {
-		boolean hasErrors = CompilerFactory.buildDiagnosticCompiler(out)
+		boolean hasErrors = CompilerFactory.buildDiagnosticCompiler(format, out)
 				.compile(input, output);
 		return hasErrors ? Main.EXIT_JPIPE_ERROR : Main.EXIT_OK;
+	}
+
+	/**
+	 * The logo would sit in front of the JSON document and make it unparseable,
+	 * so it is suppressed whenever a machine-readable report goes to standard
+	 * output. Writing to a file keeps the banner: the two streams are separate.
+	 */
+	@Override
+	protected boolean suppressLogo() {
+		return format == DiagnosticFormat.JSON
+				&& CompilationConfig.STDOUT.equals(output);
 	}
 }

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/InputOutputCommand.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/InputOutputCommand.java
@@ -35,7 +35,7 @@ abstract class InputOutputCommand implements Callable<Integer> {
 	@SuppressWarnings("java:S106") // intentional: output stream and CLI error
 									// messages target stdout/stderr
 	public final Integer call() {
-		if (!parent.headless) {
+		if (!parent.headless && !suppressLogo()) {
 			Logo.sout();
 		}
 		try (FileOutputStream fileOut = output.equals(CompilationConfig.STDOUT)
@@ -50,6 +50,21 @@ abstract class InputOutputCommand implements Callable<Integer> {
 			System.err.println("unexpected error: " + e.getMessage());
 			return Main.EXIT_SYSTEM_ERROR;
 		}
+	}
+
+	/**
+	 * Whether this invocation must not print the logo, over and above the
+	 * global {@code --headless} flag.
+	 *
+	 * <p>
+	 * Subcommands override this when their output is machine-readable and the
+	 * banner would corrupt it. The default is {@code false}: the logo is shown
+	 * unless {@code --headless} was passed.
+	 *
+	 * @return true to suppress the logo for this invocation.
+	 */
+	protected boolean suppressLogo() {
+		return false;
 	}
 
 	/**

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Main.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Main.java
@@ -96,9 +96,24 @@ public class Main {
 		return adjusted;
 	}
 
-	public static void main(String[] args) {
-		CommandLine cmd = new CommandLine(new Main())
+	/**
+	 * The configured CLI parser.
+	 *
+	 * <p>
+	 * Both {@link #main(String[])} and the acceptance tests go through here, so
+	 * that tests exercise the same parser configuration users get — notably
+	 * case-insensitive enum values, which let {@code -f json} work as well as
+	 * {@code -f JSON}.
+	 *
+	 * @return a {@link CommandLine} bound to a fresh {@link Main}.
+	 */
+	static CommandLine commandLine() {
+		return new CommandLine(new Main())
 				.setCaseInsensitiveEnumValuesAllowed(true);
+	}
+
+	public static void main(String[] args) {
+		CommandLine cmd = commandLine();
 		System.exit(cmd.execute(withDefaultSubcommand(args, cmd)));
 	}
 }

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DiagnosticCommandTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DiagnosticCommandTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ca.mcscert.jpipe.compiler.CompilationConfig;
+import ca.mcscert.jpipe.compiler.DiagnosticFormat;
 import ca.mcscert.jpipe.compiler.model.CompilationException;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 class DiagnosticCommandTest {
@@ -31,6 +34,50 @@ class DiagnosticCommandTest {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		assertThatThrownBy(() -> cmd.doCall(out))
 				.isInstanceOf(CompilationException.class);
+	}
+
+	@Test
+	void doCall_defaults_to_the_text_report() throws Exception {
+		DiagnosticCommand cmd = new DiagnosticCommand();
+		cmd.input = resourcePath("test_minimal.jd");
+		cmd.output = CompilationConfig.STDOUT;
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		cmd.doCall(out);
+
+		assertThat(out.toString(StandardCharsets.UTF_8))
+				.contains("=== Diagnostics ===");
+	}
+
+	@Test
+	void doCall_json_format_writes_a_json_document() throws Exception {
+		DiagnosticCommand cmd = new DiagnosticCommand();
+		cmd.input = resourcePath("test_minimal.jd");
+		cmd.output = CompilationConfig.STDOUT;
+		cmd.format = DiagnosticFormat.JSON;
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		cmd.doCall(out);
+
+		JSONObject report = new JSONObject(
+				out.toString(StandardCharsets.UTF_8));
+		assertThat(report.getString("status")).isEqualTo("ok");
+		assertThat(report.getJSONArray("diagnostics")).isEmpty();
+	}
+
+	@Test
+	void suppressLogo_onlyForJsonOnStdout() {
+		DiagnosticCommand cmd = new DiagnosticCommand();
+		cmd.output = CompilationConfig.STDOUT;
+
+		cmd.format = DiagnosticFormat.TEXT;
+		assertThat(cmd.suppressLogo()).isFalse();
+
+		cmd.format = DiagnosticFormat.JSON;
+		assertThat(cmd.suppressLogo()).isTrue();
+
+		cmd.output = "report.json";
+		assertThat(cmd.suppressLogo()).isFalse();
 	}
 
 	private static String resourcePath(String name) {

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/InputOutputCommandTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/InputOutputCommandTest.java
@@ -2,66 +2,131 @@ package ca.mcscert.jpipe.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
-import picocli.CommandLine;
 
 class InputOutputCommandTest {
 
 	@Test
 	void call_valid_file_returns_exit_ok() {
 		String input = resourcePath("test_minimal.jd");
-		int result = new CommandLine(new Main()).execute("--headless",
-				"diagnostic", "-i", input, "-o", "<stdout>");
+		int result = Main.commandLine().execute("--headless", "diagnostic",
+				"-i", input, "-o", "<stdout>");
 		assertThat(result).isEqualTo(Main.EXIT_OK);
 	}
 
 	@Test
 	void call_invalid_file_returns_jpipe_error() {
 		String input = resourcePath("test_invalid.jd");
-		int result = new CommandLine(new Main()).execute("--headless",
-				"diagnostic", "-i", input, "-o", "<stdout>");
+		int result = Main.commandLine().execute("--headless", "diagnostic",
+				"-i", input, "-o", "<stdout>");
 		assertThat(result).isEqualTo(Main.EXIT_JPIPE_ERROR);
 	}
 
 	@Test
 	void call_missing_file_returns_system_error() {
-		int result = new CommandLine(new Main()).execute("--headless",
-				"diagnostic", "-i", "/no/such/file.jd", "-o", "<stdout>");
+		int result = Main.commandLine().execute("--headless", "diagnostic",
+				"-i", "/no/such/file.jd", "-o", "<stdout>");
 		assertThat(result).isEqualTo(Main.EXIT_SYSTEM_ERROR);
 	}
 
 	@Test
 	void process_valid_file_returns_exit_ok() {
 		String input = resourcePath("test_minimal.jd");
-		int result = new CommandLine(new Main()).execute("--headless",
-				"process", "-i", input, "-m", "minimal", "-o", "<stdout>");
+		int result = Main.commandLine().execute("--headless", "process", "-i",
+				input, "-m", "minimal", "-o", "<stdout>");
 		assertThat(result).isEqualTo(Main.EXIT_OK);
 	}
 
 	@Test
 	void process_unknown_model_returns_jpipe_error() {
 		String input = resourcePath("test_minimal.jd");
-		int result = new CommandLine(new Main()).execute("--headless",
-				"process", "-i", input, "-m", "no_such_model", "-o",
-				"<stdout>");
+		int result = Main.commandLine().execute("--headless", "process", "-i",
+				input, "-m", "no_such_model", "-o", "<stdout>");
 		assertThat(result).isEqualTo(Main.EXIT_JPIPE_ERROR);
 	}
 
 	@Test
 	void doctor_subcommand_returns_result() {
-		int result = new CommandLine(new Main()).execute("--headless",
-				"doctor");
+		int result = Main.commandLine().execute("--headless", "doctor");
 		assertThat(result).isIn(Main.EXIT_OK, Main.EXIT_JPIPE_ERROR);
 	}
 
 	@Test
 	void log_level_option_is_accepted() {
 		String input = resourcePath("test_minimal.jd");
-		int result = new CommandLine(new Main()).execute("--headless",
-				"--log-level", "INFO", "diagnostic", "-i", input, "-o",
-				"<stdout>");
+		int result = Main.commandLine().execute("--headless", "--log-level",
+				"INFO", "diagnostic", "-i", input, "-o", "<stdout>");
 		assertThat(result).isEqualTo(Main.EXIT_OK);
+	}
+
+	@Test
+	void diagnostic_json_format_is_accepted() {
+		String input = resourcePath("test_minimal.jd");
+		int result = Main.commandLine().execute("--headless", "diagnostic",
+				"-i", input, "-f", "json", "-o", "<stdout>");
+		assertThat(result).isEqualTo(Main.EXIT_OK);
+	}
+
+	@Test
+	void diagnostic_json_format_is_case_insensitive() {
+		String input = resourcePath("test_minimal.jd");
+		int result = Main.commandLine().execute("--headless", "diagnostic",
+				"-i", input, "-f", "JSON", "-o", "<stdout>");
+		assertThat(result).isEqualTo(Main.EXIT_OK);
+	}
+
+	@Test
+	void diagnostic_unknown_format_is_rejected() {
+		String input = resourcePath("test_minimal.jd");
+		int result = Main.commandLine().execute("--headless", "diagnostic",
+				"-i", input, "-f", "yaml", "-o", "<stdout>");
+		assertThat(result).isNotEqualTo(Main.EXIT_OK);
+	}
+
+	@Test
+	void diagnostic_json_to_stdout_emits_a_parseable_document() {
+		String input = resourcePath("test_minimal.jd");
+		PrintStream original = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		int result;
+		try {
+			System.setOut(
+					new PrintStream(captured, true, StandardCharsets.UTF_8));
+			// Deliberately NOT --headless: the logo must step aside on its own,
+			// or every IDE integration would have to strip it.
+			result = Main.commandLine().execute("diagnostic", "-i", input, "-f",
+					"json", "-o", "<stdout>");
+		} finally {
+			System.setOut(original);
+		}
+
+		assertThat(result).isEqualTo(Main.EXIT_OK);
+		String output = captured.toString(StandardCharsets.UTF_8);
+		assertThat(output).doesNotContain("McMaster").startsWith("{");
+		assertThat(new JSONObject(output).getInt("schemaVersion")).isEqualTo(1);
+	}
+
+	@Test
+	void diagnostic_text_to_stdout_still_shows_the_logo() {
+		String input = resourcePath("test_minimal.jd");
+		PrintStream original = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		try {
+			System.setOut(
+					new PrintStream(captured, true, StandardCharsets.UTF_8));
+			Main.commandLine().execute("diagnostic", "-i", input, "-o",
+					"<stdout>");
+		} finally {
+			System.setOut(original);
+		}
+
+		assertThat(captured.toString(StandardCharsets.UTF_8))
+				.contains("McMaster");
 	}
 
 	private static String resourcePath(String name) {

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/InputOutputCommandTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/InputOutputCommandTest.java
@@ -94,9 +94,9 @@ class InputOutputCommandTest {
 		PrintStream original = System.out;
 		ByteArrayOutputStream captured = new ByteArrayOutputStream();
 		int result;
-		try {
-			System.setOut(
-					new PrintStream(captured, true, StandardCharsets.UTF_8));
+		try (PrintStream redirected = new PrintStream(captured, true,
+				StandardCharsets.UTF_8)) {
+			System.setOut(redirected);
 			// Deliberately NOT --headless: the logo must step aside on its own,
 			// or every IDE integration would have to strip it.
 			result = Main.commandLine().execute("diagnostic", "-i", input, "-f",
@@ -116,9 +116,9 @@ class InputOutputCommandTest {
 		String input = resourcePath("test_minimal.jd");
 		PrintStream original = System.out;
 		ByteArrayOutputStream captured = new ByteArrayOutputStream();
-		try {
-			System.setOut(
-					new PrintStream(captured, true, StandardCharsets.UTF_8));
+		try (PrintStream redirected = new PrintStream(captured, true,
+				StandardCharsets.UTF_8)) {
+			System.setOut(redirected);
 			Main.commandLine().execute("diagnostic", "-i", input, "-o",
 					"<stdout>");
 		} finally {

--- a/jpipe-compiler/pom.xml
+++ b/jpipe-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-compiler</artifactId>

--- a/jpipe-compiler/pom.xml
+++ b/jpipe-compiler/pom.xml
@@ -32,6 +32,15 @@
             <artifactId>log4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>

--- a/jpipe-compiler/pom.xml
+++ b/jpipe-compiler/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -59,7 +58,6 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
@@ -2,6 +2,7 @@ package ca.mcscert.jpipe.compiler;
 
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.compiler.model.ChainBuilder;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
 import ca.mcscert.jpipe.operators.OperatorRegistry;
 import ca.mcscert.jpipe.operators.UnificationEquivalenceRegistry;
 import ca.mcscert.jpipe.operators.equivalences.SameLabel;
@@ -16,11 +17,13 @@ import ca.mcscert.jpipe.compiler.steps.transformations.ActionListInterpretation;
 import ca.mcscert.jpipe.compiler.steps.transformations.ActionListProvider;
 import ca.mcscert.jpipe.compiler.steps.transformations.LoadResolver;
 import ca.mcscert.jpipe.compiler.steps.transformations.CharStreamProvider;
+import ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics;
 import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
 import ca.mcscert.jpipe.compiler.steps.transformations.ExportToDot;
 import ca.mcscert.jpipe.compiler.steps.transformations.ExportToJson;
 import ca.mcscert.jpipe.compiler.steps.transformations.ExportToJpipe;
 import ca.mcscert.jpipe.compiler.steps.transformations.ExportToPython;
+import ca.mcscert.jpipe.compiler.steps.transformations.JsonDiagnosticReport;
 import ca.mcscert.jpipe.compiler.steps.transformations.Lexer;
 import ca.mcscert.jpipe.compiler.steps.transformations.Parser;
 import ca.mcscert.jpipe.compiler.steps.transformations.RenderWithDot;
@@ -89,8 +92,10 @@ public final class CompilerFactory {
 	}
 
 	/**
-	 * Build a diagnostic-mode compiler that parses the source and produces a
-	 * human-readable report without exporting any model.
+	 * Build a diagnostic-mode compiler producing a human-readable report.
+	 * Equivalent to
+	 * {@link #buildDiagnosticCompiler(DiagnosticFormat, OutputStream)} with
+	 * {@link DiagnosticFormat#TEXT}.
 	 *
 	 * @param stdout
 	 *            stream to use when the output target is
@@ -98,8 +103,32 @@ public final class CompilerFactory {
 	 * @return a ready-to-use {@link Compiler}.
 	 */
 	public static Compiler buildDiagnosticCompiler(OutputStream stdout) {
+		return buildDiagnosticCompiler(DiagnosticFormat.TEXT, stdout);
+	}
+
+	/**
+	 * Build a diagnostic-mode compiler that parses the source and reports on it
+	 * without exporting any model.
+	 *
+	 * <p>
+	 * Both formats share the {@link CollectDiagnostics} step and differ only in
+	 * their renderer, so they always describe the same compilation.
+	 *
+	 * @param format
+	 *            how to render the report.
+	 * @param stdout
+	 *            stream to use when the output target is
+	 *            {@link CompilationConfig#STDOUT}.
+	 * @return a ready-to-use {@link Compiler}.
+	 */
+	public static Compiler buildDiagnosticCompiler(DiagnosticFormat format,
+			OutputStream stdout) {
+		Transformation<DiagnosticSnapshot, String> renderer = switch (format) {
+			case TEXT -> new DiagnosticReport();
+			case JSON -> new JsonDiagnosticReport();
+		};
 		return parsingChain().andThen(unitBuilder())
-				.andThen(new DiagnosticReport())
+				.andThen(new CollectDiagnostics()).andThen(renderer)
 				.andThen(new StringSink(stdout));
 	}
 

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticFormat.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticFormat.java
@@ -1,0 +1,19 @@
+package ca.mcscert.jpipe.compiler;
+
+/**
+ * Output formats of the {@code diagnostic} command's report.
+ *
+ * <p>
+ * Deliberately distinct from {@link Format}, which enumerates <em>model
+ * export</em> targets (DOT, PNG, Python, …): none of those mean anything for a
+ * compilation report, and conflating the two would offer combinations that
+ * cannot be produced.
+ */
+public enum DiagnosticFormat {
+
+	/** Human-readable report, for terminal use. This is the default. */
+	TEXT,
+
+	/** Machine-readable report, for IDEs and other tooling. */
+	JSON
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/ChainCompiler.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/ChainCompiler.java
@@ -54,7 +54,9 @@ public final class ChainCompiler<I, O> implements Compiler {
 						? d.source() + ":" + d.line() + ":" + d.column() + ": "
 						: d.source() + ": ";
 				String level = d.level().name().toLowerCase();
-				String msg = d.message();
+				String msg = d.hasCode()
+						? "[" + d.code() + "] " + d.message()
+						: d.message();
 				logger.error("{}{}: {}", loc, level, msg);
 			}
 		}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/CompilationContext.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/CompilationContext.java
@@ -63,6 +63,35 @@ public final class CompilationContext {
 		report(Diagnostic.error(sourcePath, line, column, message));
 	}
 
+	/**
+	 * Convenience: append a coded non-fatal ERROR diagnostic.
+	 *
+	 * @param code
+	 *            stable kebab-case identifier, see {@link DiagnosticCodes}.
+	 * @param message
+	 *            human-readable description, without the code.
+	 */
+	public void error(String code, String message) {
+		report(Diagnostic.error(code, sourcePath, message));
+	}
+
+	/**
+	 * Convenience: append a coded non-fatal ERROR diagnostic with source
+	 * location.
+	 *
+	 * @param code
+	 *            stable kebab-case identifier, see {@link DiagnosticCodes}.
+	 * @param line
+	 *            1-based source line.
+	 * @param column
+	 *            0-based column offset.
+	 * @param message
+	 *            human-readable description, without the code.
+	 */
+	public void error(String code, int line, int column, String message) {
+		report(Diagnostic.error(code, sourcePath, line, column, message));
+	}
+
 	/** Convenience: append a FATAL diagnostic. */
 	public void fatal(String message) {
 		report(Diagnostic.fatal(sourcePath, message));

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/Diagnostic.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/Diagnostic.java
@@ -8,8 +8,18 @@ package ca.mcscert.jpipe.compiler.model;
  * are {@code 0} when no location is available (ANTLR lines are 1-based, so
  * {@code 0} is a safe sentinel).
  *
+ * <p>
+ * {@code code} is a stable, bare kebab-case identifier such as
+ * {@code "unknown-model"} (see {@link DiagnosticCodes}) or a validation rule
+ * name coming from {@link ca.mcscert.jpipe.model.Violation#rule()}. It is
+ * {@code null} when the diagnostic has no code. The code is <em>data</em>, not
+ * text: renderers decide how to display it (the human-readable report prefixes
+ * it as {@code "[code] "}, the JSON report emits it as a separate field).
+ *
  * @param level
  *            severity of the diagnostic.
+ * @param code
+ *            stable kebab-case identifier, or {@code null} when absent.
  * @param source
  *            path to the file that triggered it.
  * @param line
@@ -17,10 +27,10 @@ package ca.mcscert.jpipe.compiler.model;
  * @param column
  *            0-based column offset, or {@code 0} if unknown.
  * @param message
- *            human-readable description.
+ *            human-readable description, without the code.
  */
-public record Diagnostic(Level level, String source, int line, int column,
-		String message) {
+public record Diagnostic(Level level, String code, String source, int line,
+		int column, String message) {
 
 	/**
 	 * Sentinel value for {@code line} and {@code column} when no location is
@@ -37,15 +47,35 @@ public record Diagnostic(Level level, String source, int line, int column,
 		return line > UNKNOWN_LOCATION;
 	}
 
+	/** True if this diagnostic carries a code. */
+	public boolean hasCode() {
+		return code != null && !code.isEmpty();
+	}
+
 	// ── without location ────────────────────────────────────────────────────
 
 	public static Diagnostic error(String source, String message) {
-		return new Diagnostic(Level.ERROR, source, UNKNOWN_LOCATION,
-				UNKNOWN_LOCATION, message);
+		return error(null, source, message);
 	}
 
 	public static Diagnostic fatal(String source, String message) {
-		return new Diagnostic(Level.FATAL, source, UNKNOWN_LOCATION,
+		return new Diagnostic(Level.FATAL, null, source, UNKNOWN_LOCATION,
+				UNKNOWN_LOCATION, message);
+	}
+
+	/**
+	 * A non-fatal ERROR carrying a code but no source location.
+	 *
+	 * @param code
+	 *            stable kebab-case identifier, or {@code null}.
+	 * @param source
+	 *            path to the file that triggered it.
+	 * @param message
+	 *            human-readable description, without the code.
+	 * @return the diagnostic.
+	 */
+	public static Diagnostic error(String code, String source, String message) {
+		return new Diagnostic(Level.ERROR, code, source, UNKNOWN_LOCATION,
 				UNKNOWN_LOCATION, message);
 	}
 
@@ -53,12 +83,32 @@ public record Diagnostic(Level level, String source, int line, int column,
 
 	public static Diagnostic error(String source, int line, int column,
 			String message) {
-		return new Diagnostic(Level.ERROR, source, line, column, message);
+		return error(null, source, line, column, message);
 	}
 
 	public static Diagnostic fatal(String source, int line, int column,
 			String message) {
-		return new Diagnostic(Level.FATAL, source, line, column, message);
+		return new Diagnostic(Level.FATAL, null, source, line, column, message);
+	}
+
+	/**
+	 * A non-fatal ERROR carrying both a code and a source location.
+	 *
+	 * @param code
+	 *            stable kebab-case identifier, or {@code null}.
+	 * @param source
+	 *            path to the file that triggered it.
+	 * @param line
+	 *            1-based source line.
+	 * @param column
+	 *            0-based column offset.
+	 * @param message
+	 *            human-readable description, without the code.
+	 * @return the diagnostic.
+	 */
+	public static Diagnostic error(String code, String source, int line,
+			int column, String message) {
+		return new Diagnostic(Level.ERROR, code, source, line, column, message);
 	}
 
 	/** True for ERROR and FATAL. */

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticCodes.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticCodes.java
@@ -1,14 +1,20 @@
 package ca.mcscert.jpipe.compiler.model;
 
 /**
- * Compiler diagnostic error-code tags embedded in error messages.
+ * Compiler diagnostic error codes.
  *
  * <p>
- * Each constant is the bracketed tag that appears at the start of a diagnostic
- * message, e.g. {@code "[unknown-model] unknown model 'foo'"}. Centralising
- * them here makes them greppable and prevents silent drift between the site
- * that emits a diagnostic and any tooling (tests, IDEs) that matches on the tag
- * string.
+ * Each constant is a stable, bare kebab-case identifier carried by
+ * {@link Diagnostic#code()}, e.g. {@code "unknown-model"}. Centralising them
+ * here makes them greppable and prevents silent drift between the site that
+ * emits a diagnostic and any tooling (tests, IDEs) that matches on the code.
+ *
+ * <p>
+ * The identifiers carry no brackets: presentation belongs to the renderer. The
+ * human-readable report displays them as {@code "[unknown-model] "} prefixes,
+ * while the JSON report emits them as a separate {@code code} field. Validation
+ * rules reach {@code Diagnostic.code()} the same way, via
+ * {@link ca.mcscert.jpipe.model.Violation#rule()}, and are not listed here.
  */
 public final class DiagnosticCodes {
 
@@ -18,49 +24,49 @@ public final class DiagnosticCodes {
 	// ---- model construction -------------------------------------------------
 
 	/** A justification model declares more than one conclusion element. */
-	public static final String SINGLE_CONCLUSION = "[single-conclusion]";
+	public static final String SINGLE_CONCLUSION = "single-conclusion";
 
 	/**
 	 * A qualified override reference appears in a model that does not implement
 	 * any template.
 	 */
-	public static final String UNRESOLVED_OVERRIDE = "[unresolved-override]";
+	public static final String UNRESOLVED_OVERRIDE = "unresolved-override";
 
 	// ---- template linking ---------------------------------------------------
 
 	/** Two models mutually implement each other, creating a cycle. */
-	public static final String CYCLIC_IMPLEMENTS = "[cyclic-implements]";
+	public static final String CYCLIC_IMPLEMENTS = "cyclic-implements";
 
 	/** An {@code implements} directive could not be applied. */
-	public static final String IMPLEMENTS_ERROR = "[implements-error]";
+	public static final String IMPLEMENTS_ERROR = "implements-error";
 
 	/**
 	 * A model implementing a template references a template-internal element (a
 	 * strategy or conclusion) instead of only overriding its {@code @support}
 	 * placeholders.
 	 */
-	public static final String REFERENCE_INTO_TEMPLATE = "[reference-into-template]";
+	public static final String REFERENCE_INTO_TEMPLATE = "reference-into-template";
 
 	// ---- support / element resolution ---------------------------------------
 
 	/**
 	 * An {@code AddSupport} command references an element that does not exist.
 	 */
-	public static final String INVALID_SUPPORT = "[invalid-support]";
+	public static final String INVALID_SUPPORT = "invalid-support";
 
 	/** A command references a model name that does not exist in the unit. */
-	public static final String UNKNOWN_MODEL = "[unknown-model]";
+	public static final String UNKNOWN_MODEL = "unknown-model";
 
 	/** A command references an element ID that does not exist in its model. */
-	public static final String UNKNOWN_ELEMENT = "[unknown-element]";
+	public static final String UNKNOWN_ELEMENT = "unknown-element";
 
 	// ---- execution ----------------------------------------------------------
 
 	/** A command could not be executed (catch-all for unexpected failures). */
-	public static final String EXECUTION_ERROR = "[execution-error]";
+	public static final String EXECUTION_ERROR = "execution-error";
 
 	/**
 	 * A command remained unexecuted after all dependency rounds were exhausted.
 	 */
-	public static final String UNRESOLVED_SYMBOL = "[unresolved-symbol]";
+	public static final String UNRESOLVED_SYMBOL = "unresolved-symbol";
 }

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticSnapshot.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticSnapshot.java
@@ -1,0 +1,170 @@
+package ca.mcscert.jpipe.compiler.model;
+
+import ca.mcscert.jpipe.model.SourceLocation;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An immutable, render-agnostic view of everything a diagnostic report shows.
+ *
+ * <p>
+ * Produced once by
+ * {@code ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics}
+ * from a compiled {@link ca.mcscert.jpipe.model.Unit} and its
+ * {@link CompilationContext}, then consumed by every report renderer. Holding
+ * the collection step in common is what keeps the human-readable and JSON
+ * reports from drifting apart: a section added here surfaces in both, and
+ * neither renderer walks the model itself.
+ *
+ * <p>
+ * This record carries <em>data only</em> — no formatting. Presentation choices
+ * (bracketing codes, padding columns, eliding unknown locations) belong to the
+ * renderers.
+ *
+ * @param source
+ *            path of the compiled source file.
+ * @param diagnostics
+ *            all diagnostics reported during compilation, in report order.
+ * @param stats
+ *            named compilation statistics in insertion order; empty when the
+ *            interpretation step did not run.
+ * @param models
+ *            one entry per model in the unit, in declaration order.
+ * @param actions
+ *            the ordered list of executed actions; empty when not recorded.
+ */
+public record DiagnosticSnapshot(String source, List<Diagnostic> diagnostics,
+		Map<String, Long> stats, List<ModelInfo> models,
+		List<ActionInfo> actions) {
+
+	/** Model kind discriminator: a concrete justification. */
+	public static final String KIND_JUSTIFICATION = "justification";
+
+	/** Model kind discriminator: a reusable template. */
+	public static final String KIND_TEMPLATE = "template";
+
+	/** True if any ERROR or FATAL diagnostic was reported. */
+	public boolean hasErrors() {
+		return diagnostics.stream().anyMatch(Diagnostic::isError);
+	}
+
+	/**
+	 * A single model: its identity, its element census, and its symbols.
+	 *
+	 * @param name
+	 *            the model's name.
+	 * @param kind
+	 *            {@link #KIND_JUSTIFICATION} or {@link #KIND_TEMPLATE}.
+	 * @param implementedTemplate
+	 *            name of the template this model implements, or {@code null}.
+	 * @param location
+	 *            where the model is declared.
+	 * @param counts
+	 *            how many elements of each type the model holds.
+	 * @param usedBy
+	 *            models implementing this one; always empty for a
+	 *            justification.
+	 * @param symbols
+	 *            the model's elements, in stable display order.
+	 * @param aliases
+	 *            element ids rewritten during composition.
+	 */
+	public record ModelInfo(String name, String kind,
+			String implementedTemplate, SourceLocation location,
+			ElementCounts counts, List<ImplementorInfo> usedBy,
+			List<SymbolInfo> symbols, List<AliasInfo> aliases) {
+
+		/** True if this model implements a template. */
+		public boolean implementsTemplate() {
+			return implementedTemplate != null;
+		}
+
+		/** True if this model is a template rather than a justification. */
+		public boolean isTemplate() {
+			return KIND_TEMPLATE.equals(kind);
+		}
+	}
+
+	/**
+	 * How many elements of each type a model holds. {@code conclusion} is 0 or
+	 * 1: the model owns at most one.
+	 *
+	 * @param conclusion
+	 *            1 when the model has a conclusion, 0 otherwise.
+	 * @param subConclusion
+	 *            number of sub-conclusions.
+	 * @param strategy
+	 *            number of strategies.
+	 * @param evidence
+	 *            number of evidence elements.
+	 * @param abstractSupport
+	 *            number of abstract support placeholders.
+	 */
+	public record ElementCounts(int conclusion, int subConclusion, int strategy,
+			int evidence, int abstractSupport) {
+
+		/** True when the model holds no elements at all. */
+		public boolean isEmpty() {
+			return conclusion + subConclusion + strategy + evidence
+					+ abstractSupport == 0;
+		}
+	}
+
+	/**
+	 * A model that implements the template being described.
+	 *
+	 * @param name
+	 *            the implementing model's name.
+	 * @param location
+	 *            where the implementing model is declared.
+	 */
+	public record ImplementorInfo(String name, SourceLocation location) {
+	}
+
+	/**
+	 * One entry of a model's symbol table.
+	 *
+	 * @param id
+	 *            the element's id within its model.
+	 * @param kind
+	 *            element type, kebab-case (e.g. {@code "sub-conclusion"}).
+	 * @param location
+	 *            where the element is declared, or
+	 *            {@link SourceLocation#UNKNOWN} when it was synthesized during
+	 *            template expansion or composition.
+	 */
+	public record SymbolInfo(String id, String kind, SourceLocation location) {
+
+		/** True when the element has no source location of its own. */
+		public boolean isSynthesized() {
+			return !location.isKnown();
+		}
+	}
+
+	/**
+	 * An element id rewritten during composition.
+	 *
+	 * @param from
+	 *            the original id.
+	 * @param to
+	 *            the id it now resolves to.
+	 */
+	public record AliasInfo(String from, String to) {
+	}
+
+	/**
+	 * One executed model-construction action.
+	 *
+	 * @param index
+	 *            1-based position in the execution order.
+	 * @param depth
+	 *            nesting depth inside macro expansions.
+	 * @param macro
+	 *            true when the action is a macro command.
+	 * @param description
+	 *            the command's own rendering of itself.
+	 */
+	public record ActionInfo(int index, int depth, boolean macro,
+			String description) {
+	}
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticSnapshot.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticSnapshot.java
@@ -1,6 +1,8 @@
 package ca.mcscert.jpipe.compiler.model;
 
 import ca.mcscert.jpipe.model.SourceLocation;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +38,28 @@ import java.util.Map;
 public record DiagnosticSnapshot(String source, List<Diagnostic> diagnostics,
 		Map<String, Long> stats, List<ModelInfo> models,
 		List<ActionInfo> actions) {
+
+	/**
+	 * Copies every collection on the way in.
+	 *
+	 * <p>
+	 * {@link CompilationContext#diagnostics()} and
+	 * {@link CompilationContext#stats()} hand out unmodifiable <em>views</em>
+	 * of live state, so a snapshot that merely held those references would keep
+	 * changing as the context did — and two renderings of "the same" snapshot
+	 * could then disagree. Copying here makes the immutability this record
+	 * advertises structural rather than a convention its callers must respect.
+	 *
+	 * <p>
+	 * {@code stats} is copied into a {@link LinkedHashMap} rather than via
+	 * {@code Map.copyOf}, which does not preserve iteration order.
+	 */
+	public DiagnosticSnapshot {
+		diagnostics = List.copyOf(diagnostics);
+		stats = Collections.unmodifiableMap(new LinkedHashMap<>(stats));
+		models = List.copyOf(models);
+		actions = List.copyOf(actions);
+	}
 
 	/** Model kind discriminator: a concrete justification. */
 	public static final String KIND_JUSTIFICATION = "justification";
@@ -73,6 +97,15 @@ public record DiagnosticSnapshot(String source, List<Diagnostic> diagnostics,
 			String implementedTemplate, SourceLocation location,
 			ElementCounts counts, List<ImplementorInfo> usedBy,
 			List<SymbolInfo> symbols, List<AliasInfo> aliases) {
+
+		/**
+		 * Copies every collection on the way in, as the enclosing record does.
+		 */
+		public ModelInfo {
+			usedBy = List.copyOf(usedBy);
+			symbols = List.copyOf(symbols);
+			aliases = List.copyOf(aliases);
+		}
 
 		/** True if this model implements a template. */
 		public boolean implementsTemplate() {

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/CompletenessChecker.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/CompletenessChecker.java
@@ -16,11 +16,11 @@ public final class CompletenessChecker extends Checker<Unit> {
 	@Override
 	protected void check(Unit unit, CompilationContext ctx) {
 		new CompletenessValidator().validate(unit).forEach(v -> {
-			String msg = "[" + v.rule() + "] " + v.message();
 			if (v.location().isKnown()) {
-				ctx.error(v.location().line(), v.location().column(), msg);
+				ctx.error(v.rule(), v.location().line(), v.location().column(),
+						v.message());
 			} else {
-				ctx.error(msg);
+				ctx.error(v.rule(), v.message());
 			}
 		});
 	}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/ConsistencyChecker.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/checkers/ConsistencyChecker.java
@@ -16,11 +16,11 @@ public final class ConsistencyChecker extends Checker<Unit> {
 	@Override
 	protected void check(Unit unit, CompilationContext ctx) {
 		new ConsistencyValidator().validate(unit).forEach(v -> {
-			String msg = "[" + v.rule() + "] " + v.message();
 			if (v.location().isKnown()) {
-				ctx.error(v.location().line(), v.location().column(), msg);
+				ctx.error(v.rule(), v.location().line(), v.location().column(),
+						v.message());
 			} else {
-				ctx.error(msg);
+				ctx.error(v.rule(), v.message());
 			}
 		});
 	}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ActionListProvider.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ActionListProvider.java
@@ -274,8 +274,8 @@ public final class ActionListProvider
 					ctx.element().id.getStart().getCharPositionInLine());
 			String modelId = buildContext.justificationId;
 			if (!seenConclusionModels.add(modelId)) {
-				compilationCtx.error(loc.line(), loc.column(),
-						DiagnosticCodes.SINGLE_CONCLUSION + " Model '" + modelId
+				compilationCtx.error(DiagnosticCodes.SINGLE_CONCLUSION,
+						loc.line(), loc.column(), "Model '" + modelId
 								+ "' declares multiple conclusions");
 				return;
 			}
@@ -357,9 +357,9 @@ public final class ActionListProvider
 				SourceLocation loc) {
 			String parent = buildContext.parentTemplateName;
 			if (parent == null) {
-				compilationCtx.error(loc.line(), loc.column(),
-						DiagnosticCodes.UNRESOLVED_OVERRIDE + " '" + identifier
-								+ "' is qualified but model '"
+				compilationCtx.error(DiagnosticCodes.UNRESOLVED_OVERRIDE,
+						loc.line(), loc.column(),
+						"'" + identifier + "' is qualified but model '"
 								+ buildContext.justificationId
 								+ "' implements no template");
 				return false;

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnostics.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnostics.java
@@ -1,0 +1,178 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import ca.mcscert.jpipe.commands.ExecutedAction;
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ActionInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.AliasInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ElementCounts;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ImplementorInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ModelInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.SymbolInfo;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+import ca.mcscert.jpipe.model.JustificationModel;
+import ca.mcscert.jpipe.model.SourceLocation;
+import ca.mcscert.jpipe.model.Template;
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Gathers everything a diagnostic report shows into a single
+ * {@link DiagnosticSnapshot}.
+ *
+ * <p>
+ * This is the one place that walks the {@link Unit} for reporting purposes. The
+ * renderers downstream ({@link DiagnosticReport} for text,
+ * {@link JsonDiagnosticReport} for JSON) consume the snapshot and never touch
+ * the model, which is what guarantees the two formats describe the same thing.
+ */
+public final class CollectDiagnostics
+		extends
+			Transformation<Unit, DiagnosticSnapshot> {
+
+	private static final String KIND_CONCLUSION = "conclusion";
+	private static final String KIND_SUB_CONCLUSION = "sub-conclusion";
+	private static final String KIND_STRATEGY = "strategy";
+	private static final String KIND_EVIDENCE = "evidence";
+	private static final String KIND_ABSTRACT_SUPPORT = "abstract-support";
+
+	@Override
+	protected DiagnosticSnapshot run(Unit input, CompilationContext ctx) {
+		Map<String, List<ImplementorInfo>> implementors = implementorsOf(input);
+		Map<String, Map<String, String>> aliases = groupAliasesByModel(input);
+		List<ModelInfo> models = new ArrayList<>();
+		for (JustificationModel<?> model : input.getModels()) {
+			models.add(describe(input, model, implementors, aliases));
+		}
+		return new DiagnosticSnapshot(ctx.sourcePath(), ctx.diagnostics(),
+				ctx.stats(), List.copyOf(models), actionsOf(ctx));
+	}
+
+	// -------------------------------------------------------------------------
+	// Models
+	// -------------------------------------------------------------------------
+
+	private ModelInfo describe(Unit unit, JustificationModel<?> model,
+			Map<String, List<ImplementorInfo>> implementors,
+			Map<String, Map<String, String>> aliasesByModel) {
+		String name = model.getName();
+		boolean isTemplate = model instanceof Template;
+		String parent = model.getParent().map(JustificationModel::getName)
+				.orElse(null);
+		List<ImplementorInfo> usedBy = isTemplate
+				? implementors.getOrDefault(name, List.of())
+				: List.of();
+		return new ModelInfo(name,
+				isTemplate
+						? DiagnosticSnapshot.KIND_TEMPLATE
+						: DiagnosticSnapshot.KIND_JUSTIFICATION,
+				parent, unit.locationOf(name), countElements(model), usedBy,
+				collectSymbols(unit, model),
+				collectAliases(aliasesByModel.getOrDefault(name, Map.of())));
+	}
+
+	/** Maps each template name to the models implementing it. */
+	private Map<String, List<ImplementorInfo>> implementorsOf(Unit unit) {
+		Map<String, List<ImplementorInfo>> implementors = new LinkedHashMap<>();
+		for (JustificationModel<?> model : unit.getModels()) {
+			model.getParent()
+					.ifPresent(t -> implementors
+							.computeIfAbsent(t.getName(),
+									k -> new ArrayList<>())
+							.add(new ImplementorInfo(model.getName(),
+									unit.locationOf(model.getName()))));
+		}
+		return implementors;
+	}
+
+	private ElementCounts countElements(JustificationModel<?> model) {
+		return new ElementCounts(model.conclusion().isPresent() ? 1 : 0,
+				model.subConclusions().size(), model.strategies().size(),
+				model.evidence().size(),
+				model.elementsOfType(AbstractSupport.class).size());
+	}
+
+	// -------------------------------------------------------------------------
+	// Symbols and aliases
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Collects the model's elements in stable display order: conclusion,
+	 * sub-conclusions, strategies, evidence, abstract supports.
+	 */
+	private List<SymbolInfo> collectSymbols(Unit unit,
+			JustificationModel<?> model) {
+		List<SymbolInfo> symbols = new ArrayList<>();
+		model.conclusion().ifPresent(
+				c -> symbols.add(symbol(unit, model, c, KIND_CONCLUSION)));
+		addAll(symbols, unit, model, model.subConclusions(),
+				KIND_SUB_CONCLUSION);
+		addAll(symbols, unit, model, model.strategies(), KIND_STRATEGY);
+		addAll(symbols, unit, model, model.evidence(), KIND_EVIDENCE);
+		addAll(symbols, unit, model,
+				model.elementsOfType(AbstractSupport.class),
+				KIND_ABSTRACT_SUPPORT);
+		return List.copyOf(symbols);
+	}
+
+	private void addAll(List<SymbolInfo> target, Unit unit,
+			JustificationModel<?> model,
+			List<? extends JustificationElement> elements, String kind) {
+		for (JustificationElement element : elements) {
+			target.add(symbol(unit, model, element, kind));
+		}
+	}
+
+	private SymbolInfo symbol(Unit unit, JustificationModel<?> model,
+			JustificationElement element, String kind) {
+		SourceLocation location = unit.locationOf(model.getName(),
+				element.id());
+		return new SymbolInfo(element.id(), kind, location);
+	}
+
+	private List<AliasInfo> collectAliases(Map<String, String> aliases) {
+		return aliases.entrySet().stream()
+				.map(e -> new AliasInfo(e.getKey(), e.getValue())).toList();
+	}
+
+	/**
+	 * Pre-groups the unit's alias map by model name for O(1) lookup per model.
+	 *
+	 * <p>
+	 * Alias keys use the convention {@code "modelName/elementId"}; the slash
+	 * separates the model scope from the element id within it.
+	 */
+	private static Map<String, Map<String, String>> groupAliasesByModel(
+			Unit unit) {
+		Map<String, Map<String, String>> byModel = new LinkedHashMap<>();
+		unit.aliases().forEach((key, newId) -> {
+			int slash = key.indexOf('/');
+			if (slash >= 0) {
+				byModel.computeIfAbsent(key.substring(0, slash),
+						k -> new LinkedHashMap<>())
+						.put(key.substring(slash + 1), newId);
+			}
+		});
+		return byModel;
+	}
+
+	// -------------------------------------------------------------------------
+	// Actions
+	// -------------------------------------------------------------------------
+
+	private List<ActionInfo> actionsOf(CompilationContext ctx) {
+		List<ExecutedAction> actions = ctx.executedActions();
+		List<ActionInfo> result = new ArrayList<>(actions.size());
+		for (int i = 0; i < actions.size(); i++) {
+			ExecutedAction action = actions.get(i);
+			result.add(new ActionInfo(i + 1, action.depth(), action.isMacro(),
+					String.valueOf(action.command())));
+		}
+		return List.copyOf(result);
+	}
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReport.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReport.java
@@ -1,38 +1,47 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
-import ca.mcscert.jpipe.commands.ExecutedAction;
 import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_DEFERRALS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_MACROS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
 import ca.mcscert.jpipe.compiler.model.Diagnostic;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ActionInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.AliasInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ElementCounts;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ModelInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.SymbolInfo;
 import ca.mcscert.jpipe.compiler.model.Transformation;
-import ca.mcscert.jpipe.model.JustificationModel;
 import ca.mcscert.jpipe.model.SourceLocation;
-import ca.mcscert.jpipe.model.Template;
-import ca.mcscert.jpipe.model.Unit;
-import ca.mcscert.jpipe.model.elements.AbstractSupport;
-import ca.mcscert.jpipe.model.elements.JustificationElement;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Produces a human-readable diagnostic report from the compiled {@link Unit}
- * and the {@link CompilationContext}.
+ * Renders a {@link DiagnosticSnapshot} as the human-readable report printed by
+ * the {@code diagnostic} CLI command.
  *
  * <p>
- * The report has four sections:
+ * The report has five sections, in this order:
  * <ol>
  * <li><b>Diagnostics</b> — errors from compilation.</li>
  * <li><b>Action Statistics</b> — command counts and deferral count.</li>
  * <li><b>Model Summary</b> — per model: type, parent, element counts.</li>
  * <li><b>Symbol Table</b> — full location registry.</li>
+ * <li><b>Executed Actions</b> — the model-construction command trace.</li>
  * </ol>
+ *
+ * <p>
+ * Sections whose underlying data is absent (no statistics recorded, no actions
+ * executed) are omitted entirely rather than printed empty.
+ *
+ * @see CollectDiagnostics
+ * @see JsonDiagnosticReport
  */
-public final class DiagnosticReport extends Transformation<Unit, String> {
+public final class DiagnosticReport
+		extends
+			Transformation<DiagnosticSnapshot, String> {
 
 	private static final String HDR_DIAGNOSTICS = "=== Diagnostics ===\n";
 	private static final String HDR_ACTION_STATS = "\n=== Action Statistics ===\n";
@@ -43,36 +52,39 @@ public final class DiagnosticReport extends Transformation<Unit, String> {
 	private static final String ARROW = "\u2192";
 
 	@Override
-	protected String run(Unit input, CompilationContext ctx) {
+	protected String run(DiagnosticSnapshot input, CompilationContext ctx) {
 		StringBuilder sb = new StringBuilder();
-		appendDiagnostics(sb, ctx);
-		appendActionStats(sb, ctx);
+		appendDiagnostics(sb, input);
+		appendActionStats(sb, input);
 		appendModelSummary(sb, input);
 		appendSymbolTable(sb, input);
-		appendActionList(sb, ctx);
+		appendActionList(sb, input);
 		ctx.markDiagnosticsRendered();
 		return sb.toString();
 	}
 
-	private void appendDiagnostics(StringBuilder sb, CompilationContext ctx) {
+	private void appendDiagnostics(StringBuilder sb, DiagnosticSnapshot input) {
 		sb.append(HDR_DIAGNOSTICS);
-		if (ctx.diagnostics().isEmpty()) {
+		if (input.diagnostics().isEmpty()) {
 			sb.append("(none)\n");
 		} else {
-			for (Diagnostic d : ctx.diagnostics()) {
+			for (Diagnostic d : input.diagnostics()) {
+				String message = d.hasCode()
+						? "[" + d.code() + "] " + d.message()
+						: d.message();
 				if (d.hasLocation()) {
 					sb.append(String.format("[%s] %s:%d:%d: %s%n", d.level(),
-							d.source(), d.line(), d.column(), d.message()));
+							d.source(), d.line(), d.column(), message));
 				} else {
 					sb.append(String.format("[%s] %s: %s%n", d.level(),
-							d.source(), d.message()));
+							d.source(), message));
 				}
 			}
 		}
 	}
 
-	private void appendActionStats(StringBuilder sb, CompilationContext ctx) {
-		Map<String, Long> stats = ctx.stats();
+	private void appendActionStats(StringBuilder sb, DiagnosticSnapshot input) {
+		Map<String, Long> stats = input.stats();
 		if (stats.isEmpty()) {
 			return;
 		}
@@ -85,64 +97,47 @@ public final class DiagnosticReport extends Transformation<Unit, String> {
 		sb.append(String.format("deferrals: %d%n", deferrals));
 	}
 
-	private void appendModelSummary(StringBuilder sb, Unit unit) {
+	private void appendModelSummary(StringBuilder sb,
+			DiagnosticSnapshot input) {
 		sb.append(HDR_MODEL_SUMMARY);
-		Map<String, List<String>> implementors = new LinkedHashMap<>();
-		for (JustificationModel<?> model : unit.getModels()) {
-			model.getParent()
-					.ifPresent(t -> implementors
-							.computeIfAbsent(t.getName(),
-									k -> new ArrayList<>())
-							.add(model.getName()));
-		}
 		boolean first = true;
-		for (JustificationModel<?> model : unit.getModels()) {
+		for (ModelInfo model : input.models()) {
 			if (!first) {
 				sb.append("\n");
 			}
 			first = false;
-			String kind = model instanceof Template
-					? "template"
-					: "justification";
-			String parent = model.getParent()
-					.map(t -> "  [implements \"" + t.getName() + "\"]")
-					.orElse("");
-			sb.append(String.format("%s \"%s\"%s%n", kind, model.getName(),
+			String parent = model.implementsTemplate()
+					? "  [implements \"" + model.implementedTemplate() + "\"]"
+					: "";
+			sb.append(String.format("%s \"%s\"%s%n", model.kind(), model.name(),
 					parent));
-			sb.append(
-					String.format("  elements:  %s%n", elementSummary(model)));
-			appendTemplateImplementors(sb, unit, model, implementors);
+			sb.append(String.format("  elements:  %s%n",
+					elementSummary(model.counts())));
+			appendTemplateImplementors(sb, model);
 		}
 	}
 
-	private void appendTemplateImplementors(StringBuilder sb, Unit unit,
-			JustificationModel<?> model,
-			Map<String, List<String>> implementors) {
-		if (!(model instanceof Template)) {
+	private void appendTemplateImplementors(StringBuilder sb, ModelInfo model) {
+		if (model.usedBy().isEmpty()) {
 			return;
 		}
-		List<String> impls = implementors.getOrDefault(model.getName(),
-				List.of());
-		if (!impls.isEmpty()) {
-			String names = impls.stream().map(n -> {
-				SourceLocation loc = unit.locationOf(n);
-				return "\"" + n + "\""
-						+ (loc.isKnown()
-								? " @ " + loc.line() + ":" + loc.column()
-								: "");
-			}).collect(Collectors.joining(", "));
-			sb.append(String.format("  used by:   %s%n", names));
-		}
+		String names = model.usedBy().stream().map(impl -> {
+			SourceLocation loc = impl.location();
+			return "\"" + impl.name() + "\""
+					+ (loc.isKnown()
+							? " @ " + loc.line() + ":" + loc.column()
+							: "");
+		}).collect(Collectors.joining(", "));
+		sb.append(String.format("  used by:   %s%n", names));
 	}
 
-	private String elementSummary(JustificationModel<?> model) {
+	private String elementSummary(ElementCounts counts) {
 		List<String> parts = new ArrayList<>();
-		model.conclusion().ifPresent(c -> parts.add("conclusion(1)"));
-		count(parts, "sub-conclusion", model.subConclusions().size());
-		count(parts, "strategy", model.strategies().size());
-		count(parts, "evidence", model.evidence().size());
-		count(parts, "abstract-support",
-				model.elementsOfType(AbstractSupport.class).size());
+		count(parts, "conclusion", counts.conclusion());
+		count(parts, "sub-conclusion", counts.subConclusion());
+		count(parts, "strategy", counts.strategy());
+		count(parts, "evidence", counts.evidence());
+		count(parts, "abstract-support", counts.abstractSupport());
 		return parts.isEmpty() ? "(empty)" : String.join(", ", parts);
 	}
 
@@ -152,87 +147,75 @@ public final class DiagnosticReport extends Transformation<Unit, String> {
 		}
 	}
 
-	private void appendActionList(StringBuilder sb, CompilationContext ctx) {
-		List<ExecutedAction> actions = ctx.executedActions();
-		if (actions.isEmpty()) {
+	private void appendActionList(StringBuilder sb, DiagnosticSnapshot input) {
+		if (input.actions().isEmpty()) {
 			return;
 		}
 		sb.append(HDR_EXECUTED_ACTIONS);
-		for (int i = 0; i < actions.size(); i++) {
-			ExecutedAction action = actions.get(i);
+		for (ActionInfo action : input.actions()) {
 			String indent = INDENT.repeat(action.depth());
-			String label = action.isMacro() ? "[macro] " : "";
-			sb.append(String.format("%3d. %s%s%s%n", i + 1, indent, label,
-					action.command()));
+			String label = action.macro() ? "[macro] " : "";
+			sb.append(String.format("%3d. %s%s%s%n", action.index(), indent,
+					label, action.description()));
 		}
 	}
 
-	private void appendSymbolTable(StringBuilder sb, Unit unit) {
+	private void appendSymbolTable(StringBuilder sb, DiagnosticSnapshot input) {
 		sb.append(HDR_SYMBOL_TABLE);
-		if (unit.getModels().isEmpty()) {
+		if (input.models().isEmpty()) {
 			sb.append("(empty)\n");
 			return;
 		}
-
-		Map<String, Map<String, String>> aliasesByModel = groupAliasesByModel(
-				unit);
-
-		for (JustificationModel<?> model : unit.getModels()) {
-			appendModelSymbolEntry(sb, unit, model, aliasesByModel);
+		for (ModelInfo model : input.models()) {
+			appendModelSymbolEntry(sb, model);
 		}
 	}
 
-	private void appendModelSymbolEntry(StringBuilder sb, Unit unit,
-			JustificationModel<?> model,
-			Map<String, Map<String, String>> aliasesByModel) {
-		String modelName = model.getName();
-		SourceLocation modelLoc = unit.locationOf(modelName);
-		String kind = (model instanceof Template)
-				? "template"
-				: "justification";
-		sb.append(
-				String.format("%s \"%s\"  [%s]%n", kind, modelName, modelLoc));
-		appendElementEntries(sb, unit, modelName, modelLoc,
-				collectElements(model));
-		appendAliasEntries(sb,
-				aliasesByModel.getOrDefault(modelName, Map.of()));
+	private void appendModelSymbolEntry(StringBuilder sb, ModelInfo model) {
+		sb.append(String.format("%s \"%s\"  [%s]%n", model.kind(), model.name(),
+				model.location()));
+		appendElementEntries(sb, model);
+		appendAliasEntries(sb, model.aliases());
 	}
 
-	private void appendElementEntries(StringBuilder sb, Unit unit,
-			String modelName, SourceLocation modelLoc,
-			List<JustificationElement> elements) {
-		if (elements.isEmpty()) {
+	private void appendElementEntries(StringBuilder sb, ModelInfo model) {
+		List<SymbolInfo> symbols = model.symbols();
+		if (symbols.isEmpty()) {
 			return;
 		}
-		int maxLen = elements.stream().mapToInt(e -> e.id().length()).max()
+		int maxLen = symbols.stream().mapToInt(s -> s.id().length()).max()
 				.orElse(0);
-		String modelSource = modelLoc.source();
-		for (JustificationElement e : elements) {
-			SourceLocation elemLoc = unit.locationOf(modelName, e.id());
-			String locStr;
-			if (elemLoc.isKnown()) {
-				locStr = (modelSource != null
-						&& modelSource.equals(elemLoc.source()))
-								? elemLoc.line() + ":" + elemLoc.column()
-								: elemLoc.toString();
-			} else {
-				locStr = "[synthesized]";
-			}
-			sb.append(String.format("  %s  %s%n", padEnd(e.id(), maxLen),
-					locStr));
+		String modelSource = model.location().source();
+		for (SymbolInfo symbol : symbols) {
+			sb.append(String.format("  %s  %s%n", padEnd(symbol.id(), maxLen),
+					locationOf(symbol, modelSource)));
 		}
 	}
 
-	private void appendAliasEntries(StringBuilder sb,
-			Map<String, String> aliases) {
+	/**
+	 * Renders an element's location relative to its model: bare
+	 * {@code line:column} when the element sits in the same file as its model,
+	 * fully qualified when it was pulled in from another one.
+	 */
+	private String locationOf(SymbolInfo symbol, String modelSource) {
+		if (symbol.isSynthesized()) {
+			return "[synthesized]";
+		}
+		SourceLocation loc = symbol.location();
+		boolean sameFile = modelSource != null
+				&& modelSource.equals(loc.source());
+		return sameFile ? loc.line() + ":" + loc.column() : loc.toString();
+	}
+
+	private void appendAliasEntries(StringBuilder sb, List<AliasInfo> aliases) {
 		if (aliases.isEmpty()) {
 			return;
 		}
-		int maxLen = aliases.keySet().stream().mapToInt(String::length).max()
+		int maxLen = aliases.stream().mapToInt(a -> a.from().length()).max()
 				.orElse(0);
-		for (Map.Entry<String, String> entry : aliases.entrySet()) {
+		for (AliasInfo alias : aliases) {
 			sb.append(String.format("  %s  %s %s  [alias]%n",
-					padEnd(entry.getKey(), maxLen), ARROW, entry.getValue()));
+					padEnd(alias.from(), maxLen), ARROW, alias.to()));
 		}
 	}
 
@@ -242,41 +225,5 @@ public final class DiagnosticReport extends Transformation<Unit, String> {
 			sb.append(' ');
 		}
 		return sb.toString();
-	}
-
-	/**
-	 * Pre-groups the unit's alias map by model name for O(1) lookup per model.
-	 *
-	 * <p>
-	 * Alias keys use the convention {@code "modelName/elementId"}; the slash
-	 * separates the model scope from the element id within it.
-	 */
-	private static Map<String, Map<String, String>> groupAliasesByModel(
-			Unit unit) {
-		Map<String, Map<String, String>> byModel = new LinkedHashMap<>();
-		unit.aliases().forEach((key, newId) -> {
-			int slash = key.indexOf('/');
-			if (slash >= 0) {
-				byModel.computeIfAbsent(key.substring(0, slash),
-						k -> new LinkedHashMap<>())
-						.put(key.substring(slash + 1), newId);
-			}
-		});
-		return byModel;
-	}
-
-	/**
-	 * Collects all elements of {@code model} in stable display order:
-	 * conclusion, sub-conclusions, strategies, evidence, abstract supports.
-	 */
-	private static List<JustificationElement> collectElements(
-			JustificationModel<?> model) {
-		List<JustificationElement> elements = new ArrayList<>();
-		model.conclusion().ifPresent(elements::add);
-		elements.addAll(model.subConclusions());
-		elements.addAll(model.strategies());
-		elements.addAll(model.evidence());
-		elements.addAll(model.elementsOfType(AbstractSupport.class));
-		return elements;
 	}
 }

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ExecutionFailureDiagnostics.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ExecutionFailureDiagnostics.java
@@ -24,8 +24,8 @@ import java.util.List;
  */
 final class ExecutionFailureDiagnostics {
 
-	private static final String UNKNOWN_MODEL_MSG = " unknown model '";
-	private static final String UNKNOWN_ELEMENT_MSG = " unknown element '";
+	private static final String UNKNOWN_MODEL_MSG = "unknown model '";
+	private static final String UNKNOWN_ELEMENT_MSG = "unknown element '";
 	private static final String IN_MODEL = "' in model '";
 
 	private ExecutionFailureDiagnostics() {
@@ -44,8 +44,8 @@ final class ExecutionFailureDiagnostics {
 					diagnoseImplementsTemplate(c, unit, ctx);
 				case OverrideAbstractSupport c ->
 					diagnoseOverrideAbstractSupport(c, unit, ctx);
-				default -> ctx.error(DiagnosticCodes.UNRESOLVED_SYMBOL
-						+ " cannot execute: " + cmd);
+				default -> ctx.error(DiagnosticCodes.UNRESOLVED_SYMBOL,
+						"cannot execute: " + cmd);
 			}
 		}
 		ctx.error("unresolved symbol(s) — model cannot be built");
@@ -63,26 +63,25 @@ final class ExecutionFailureDiagnostics {
 				boolean modelHasParent = unit.findModel(c.modelName())
 						.flatMap(m -> m.getParent()).isPresent();
 				if (modelHasParent) {
-					error(ctx, loc,
-							DiagnosticCodes.CYCLIC_IMPLEMENTS
-									+ " cycle detected: '" + c.modelName()
-									+ "' and '" + c.templateName()
+					error(ctx, DiagnosticCodes.CYCLIC_IMPLEMENTS, loc,
+							"cycle detected: '" + c.modelName() + "' and '"
+									+ c.templateName()
 									+ "' mutually implement each other");
 				} else {
-					error(ctx, loc, DiagnosticCodes.IMPLEMENTS_ERROR
-							+ " cannot apply 'implements' for '" + c.modelName()
-							+ "' extends '" + c.templateName() + "': "
-							+ cause.getMessage());
+					error(ctx, DiagnosticCodes.IMPLEMENTS_ERROR, loc,
+							"cannot apply 'implements' for '" + c.modelName()
+									+ "' extends '" + c.templateName() + "': "
+									+ cause.getMessage());
 				}
 			}
 			case AddSupport c -> {
 				String code = cause instanceof ReferenceIntoTemplateException
 						? DiagnosticCodes.REFERENCE_INTO_TEMPLATE
 						: DiagnosticCodes.INVALID_SUPPORT;
-				error(ctx, c.location(), code + " " + cause.getMessage());
+				error(ctx, code, c.location(), cause.getMessage());
 			}
-			default -> ctx.error(DiagnosticCodes.EXECUTION_ERROR + " " + cmd
-					+ ": " + cause.getMessage());
+			default -> ctx.error(DiagnosticCodes.EXECUTION_ERROR,
+					cmd + ": " + cause.getMessage());
 		}
 		ctx.error("model construction failed — see errors above");
 	}
@@ -96,21 +95,18 @@ final class ExecutionFailureDiagnostics {
 		SourceLocation loc = c.location();
 		var modelOpt = unit.findModel(c.container());
 		if (modelOpt.isEmpty()) {
-			error(ctx, loc, DiagnosticCodes.UNKNOWN_MODEL + UNKNOWN_MODEL_MSG
-					+ c.container() + "'");
+			error(ctx, DiagnosticCodes.UNKNOWN_MODEL, loc,
+					UNKNOWN_MODEL_MSG + c.container() + "'");
 			return;
 		}
 		var model = modelOpt.get();
 		if (model.findById(c.supportableId()).isEmpty()) {
-			error(ctx, loc,
-					DiagnosticCodes.UNKNOWN_ELEMENT + UNKNOWN_ELEMENT_MSG
-							+ c.supportableId() + IN_MODEL + c.container()
-							+ "'");
+			error(ctx, DiagnosticCodes.UNKNOWN_ELEMENT, loc, UNKNOWN_ELEMENT_MSG
+					+ c.supportableId() + IN_MODEL + c.container() + "'");
 		}
 		if (model.findById(c.supporterId()).isEmpty()) {
-			error(ctx, loc,
-					DiagnosticCodes.UNKNOWN_ELEMENT + UNKNOWN_ELEMENT_MSG
-							+ c.supporterId() + IN_MODEL + c.container() + "'");
+			error(ctx, DiagnosticCodes.UNKNOWN_ELEMENT, loc, UNKNOWN_ELEMENT_MSG
+					+ c.supporterId() + IN_MODEL + c.container() + "'");
 		}
 	}
 
@@ -118,13 +114,13 @@ final class ExecutionFailureDiagnostics {
 			Unit unit, CompilationContext ctx) {
 		SourceLocation loc = c.location();
 		if (unit.findModel(c.modelName()).isEmpty()) {
-			error(ctx, loc, DiagnosticCodes.UNKNOWN_MODEL + UNKNOWN_MODEL_MSG
-					+ c.modelName() + "'");
+			error(ctx, DiagnosticCodes.UNKNOWN_MODEL, loc,
+					UNKNOWN_MODEL_MSG + c.modelName() + "'");
 			return;
 		}
 		if (unit.findModel(c.templateName()).isEmpty()) {
-			error(ctx, loc, DiagnosticCodes.UNKNOWN_MODEL + UNKNOWN_MODEL_MSG
-					+ c.templateName() + "'");
+			error(ctx, DiagnosticCodes.UNKNOWN_MODEL, loc,
+					UNKNOWN_MODEL_MSG + c.templateName() + "'");
 		}
 	}
 
@@ -133,15 +129,14 @@ final class ExecutionFailureDiagnostics {
 		SourceLocation loc = c.location();
 		var modelOpt = unit.findModel(c.container());
 		if (modelOpt.isEmpty()) {
-			error(ctx, loc, DiagnosticCodes.UNKNOWN_MODEL + UNKNOWN_MODEL_MSG
-					+ c.container() + "'");
+			error(ctx, DiagnosticCodes.UNKNOWN_MODEL, loc,
+					UNKNOWN_MODEL_MSG + c.container() + "'");
 			return;
 		}
 		var model = modelOpt.get();
 		if (model.findById(c.qualifiedId()).isEmpty()) {
-			error(ctx, loc,
-					DiagnosticCodes.UNKNOWN_ELEMENT + UNKNOWN_ELEMENT_MSG
-							+ c.qualifiedId() + IN_MODEL + c.container() + "'");
+			error(ctx, DiagnosticCodes.UNKNOWN_ELEMENT, loc, UNKNOWN_ELEMENT_MSG
+					+ c.qualifiedId() + IN_MODEL + c.container() + "'");
 		}
 	}
 
@@ -149,12 +144,12 @@ final class ExecutionFailureDiagnostics {
 	// Utility
 	// -------------------------------------------------------------------------
 
-	private static void error(CompilationContext ctx, SourceLocation loc,
-			String message) {
+	private static void error(CompilationContext ctx, String code,
+			SourceLocation loc, String message) {
 		if (loc.isKnown()) {
-			ctx.error(loc.line(), loc.column(), message);
+			ctx.error(code, loc.line(), loc.column(), message);
 		} else {
-			ctx.error(message);
+			ctx.error(code, message);
 		}
 	}
 }

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReport.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReport.java
@@ -1,0 +1,223 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_DEFERRALS;
+import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_MACROS;
+import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
+import ca.mcscert.jpipe.compiler.model.Diagnostic;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ActionInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.AliasInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ElementCounts;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ImplementorInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ModelInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.SymbolInfo;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+import ca.mcscert.jpipe.model.SourceLocation;
+import java.util.Map;
+import java.util.Optional;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Renders a {@link DiagnosticSnapshot} as JSON, for tools that consume the
+ * diagnostic report programmatically (IDE integrations, CI dashboards).
+ *
+ * <p>
+ * The document mirrors the human-readable report section for section:
+ *
+ * <pre>
+ * {
+ *   "schemaVersion": 1,
+ *   "source": "examples/foo.jd",
+ *   "status": "ok" | "errors",
+ *   "diagnostics": [ { "severity", "code"?, "source", "line"?, "column"?, "message" } ],
+ *   "stats": { "commands": { "total", "macros" }, "deferrals" },
+ *   "models": [ { "name", "kind", "implements"?, "location",
+ *                 "elements": { … }, "usedBy": [ … ],
+ *                 "symbols": [ … ], "aliases": [ … ] } ],
+ *   "actions": [ { "index", "depth", "macro", "description" } ]
+ * }
+ * </pre>
+ *
+ * <p>
+ * Optional keys are <em>omitted</em> rather than emitted as {@code null}: a
+ * diagnostic without a code has no {@code code} key, and one without a source
+ * location has neither {@code line} nor {@code column}. {@code schemaVersion}
+ * lets consumers detect the shape; later additions stay additive.
+ *
+ * <p>
+ * Uses {@code org.json} internally as a builder for correct string escaping;
+ * the pipeline type remains {@link String}, consistent with the other text
+ * emitters (ADR-0013).
+ *
+ * @see CollectDiagnostics
+ * @see DiagnosticReport
+ */
+public final class JsonDiagnosticReport
+		extends
+			Transformation<DiagnosticSnapshot, String> {
+
+	/** Version of the emitted document shape. */
+	public static final int SCHEMA_VERSION = 1;
+
+	private static final int INDENT = 2;
+	private static final String KEY_LINE = "line";
+	private static final String KEY_COLUMN = "column";
+	private static final String KEY_SOURCE = "source";
+	private static final String KEY_NAME = "name";
+
+	@Override
+	protected String run(DiagnosticSnapshot input, CompilationContext ctx) {
+		JSONObject result = new JSONObject();
+		result.put("schemaVersion", SCHEMA_VERSION);
+		result.put(KEY_SOURCE, input.source());
+		result.put("status", input.hasErrors() ? "errors" : "ok");
+		result.put("diagnostics", diagnostics(input));
+		result.put("stats", stats(input.stats()));
+		result.put("models", models(input));
+		result.put("actions", actions(input));
+		ctx.markDiagnosticsRendered();
+		return result.toString(INDENT);
+	}
+
+	// -------------------------------------------------------------------------
+	// Sections
+	// -------------------------------------------------------------------------
+
+	private JSONArray diagnostics(DiagnosticSnapshot input) {
+		JSONArray array = new JSONArray();
+		for (Diagnostic d : input.diagnostics()) {
+			JSONObject entry = new JSONObject();
+			entry.put("severity", d.level().name().toLowerCase());
+			if (d.hasCode()) {
+				entry.put("code", d.code());
+			}
+			entry.put(KEY_SOURCE, d.source());
+			if (d.hasLocation()) {
+				entry.put(KEY_LINE, d.line());
+				entry.put(KEY_COLUMN, d.column());
+			}
+			entry.put("message", d.message());
+			array.put(entry);
+		}
+		return array;
+	}
+
+	/**
+	 * Statistics are reported as an object of zero values when the
+	 * interpretation step did not run, so consumers can read the keys
+	 * unconditionally.
+	 */
+	private JSONObject stats(Map<String, Long> stats) {
+		JSONObject commands = new JSONObject();
+		commands.put("total", stats.getOrDefault(STAT_COMMANDS_TOTAL, 0L));
+		commands.put("macros", stats.getOrDefault(STAT_COMMANDS_MACROS, 0L));
+		JSONObject result = new JSONObject();
+		result.put("commands", commands);
+		result.put("deferrals",
+				stats.getOrDefault(STAT_COMMANDS_DEFERRALS, 0L));
+		return result;
+	}
+
+	private JSONArray models(DiagnosticSnapshot input) {
+		JSONArray array = new JSONArray();
+		for (ModelInfo model : input.models()) {
+			JSONObject entry = new JSONObject();
+			entry.put(KEY_NAME, model.name());
+			entry.put("kind", model.kind());
+			if (model.implementsTemplate()) {
+				entry.put("implements", model.implementedTemplate());
+			}
+			location(model.location())
+					.ifPresent(loc -> entry.put("location", loc));
+			entry.put("elements", elements(model.counts()));
+			entry.put("usedBy", usedBy(model));
+			entry.put("symbols", symbols(model));
+			entry.put("aliases", aliases(model));
+			array.put(entry);
+		}
+		return array;
+	}
+
+	private JSONObject elements(ElementCounts counts) {
+		JSONObject entry = new JSONObject();
+		entry.put("conclusion", counts.conclusion());
+		entry.put("subConclusion", counts.subConclusion());
+		entry.put("strategy", counts.strategy());
+		entry.put("evidence", counts.evidence());
+		entry.put("abstractSupport", counts.abstractSupport());
+		return entry;
+	}
+
+	private JSONArray usedBy(ModelInfo model) {
+		JSONArray array = new JSONArray();
+		for (ImplementorInfo impl : model.usedBy()) {
+			JSONObject entry = new JSONObject();
+			entry.put(KEY_NAME, impl.name());
+			location(impl.location())
+					.ifPresent(loc -> entry.put("location", loc));
+			array.put(entry);
+		}
+		return array;
+	}
+
+	private JSONArray symbols(ModelInfo model) {
+		JSONArray array = new JSONArray();
+		for (SymbolInfo symbol : model.symbols()) {
+			JSONObject entry = new JSONObject();
+			entry.put("id", symbol.id());
+			entry.put("kind", symbol.kind());
+			entry.put("synthesized", symbol.isSynthesized());
+			location(symbol.location())
+					.ifPresent(loc -> entry.put("location", loc));
+			array.put(entry);
+		}
+		return array;
+	}
+
+	private JSONArray aliases(ModelInfo model) {
+		JSONArray array = new JSONArray();
+		for (AliasInfo alias : model.aliases()) {
+			JSONObject entry = new JSONObject();
+			entry.put("from", alias.from());
+			entry.put("to", alias.to());
+			array.put(entry);
+		}
+		return array;
+	}
+
+	private JSONArray actions(DiagnosticSnapshot input) {
+		JSONArray array = new JSONArray();
+		for (ActionInfo action : input.actions()) {
+			JSONObject entry = new JSONObject();
+			entry.put("index", action.index());
+			entry.put("depth", action.depth());
+			entry.put("macro", action.macro());
+			entry.put("description", action.description());
+			array.put(entry);
+		}
+		return array;
+	}
+
+	// -------------------------------------------------------------------------
+	// Utility
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A location object, or empty when the position is unknown — the key is
+	 * then omitted rather than emitted as null.
+	 */
+	private Optional<JSONObject> location(SourceLocation loc) {
+		if (loc == null || !loc.isKnown()) {
+			return Optional.empty();
+		}
+		JSONObject entry = new JSONObject();
+		if (loc.source() != null) {
+			entry.put(KEY_SOURCE, loc.source());
+		}
+		entry.put(KEY_LINE, loc.line());
+		entry.put(KEY_COLUMN, loc.column());
+		return Optional.of(entry);
+	}
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReport.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReport.java
@@ -43,8 +43,13 @@ import org.json.JSONObject;
  * <p>
  * Optional keys are <em>omitted</em> rather than emitted as {@code null}: a
  * diagnostic without a code has no {@code code} key, and one without a source
- * location has neither {@code line} nor {@code column}. {@code schemaVersion}
- * lets consumers detect the shape; later additions stay additive.
+ * location has neither {@code line} nor {@code column}.
+ *
+ * <p>
+ * The document is described by a strict published JSON Schema, so any change to
+ * the set of members — including adding one — means publishing a new schema and
+ * incrementing {@link #SCHEMA_VERSION}. See
+ * {@code docs/design/diagnostic-schema.md}.
  *
  * <p>
  * Uses {@code org.json} internally as a builder for correct string escaping;
@@ -66,6 +71,7 @@ public final class JsonDiagnosticReport
 	private static final String KEY_COLUMN = "column";
 	private static final String KEY_SOURCE = "source";
 	private static final String KEY_NAME = "name";
+	private static final String KEY_LOCATION = "location";
 
 	@Override
 	protected String run(DiagnosticSnapshot input, CompilationContext ctx) {
@@ -130,7 +136,7 @@ public final class JsonDiagnosticReport
 				entry.put("implements", model.implementedTemplate());
 			}
 			location(model.location())
-					.ifPresent(loc -> entry.put("location", loc));
+					.ifPresent(loc -> entry.put(KEY_LOCATION, loc));
 			entry.put("elements", elements(model.counts()));
 			entry.put("usedBy", usedBy(model));
 			entry.put("symbols", symbols(model));
@@ -156,7 +162,7 @@ public final class JsonDiagnosticReport
 			JSONObject entry = new JSONObject();
 			entry.put(KEY_NAME, impl.name());
 			location(impl.location())
-					.ifPresent(loc -> entry.put("location", loc));
+					.ifPresent(loc -> entry.put(KEY_LOCATION, loc));
 			array.put(entry);
 		}
 		return array;
@@ -170,7 +176,7 @@ public final class JsonDiagnosticReport
 			entry.put("kind", symbol.kind());
 			entry.put("synthesized", symbol.isSynthesized());
 			location(symbol.location())
-					.ifPresent(loc -> entry.put("location", loc));
+					.ifPresent(loc -> entry.put(KEY_LOCATION, loc));
 			array.put(entry);
 		}
 		return array;

--- a/jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json
+++ b/jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ace-design.github.io/jpipe/schema/diagnostic-report-v1.schema.json",
+  "title": "jPipe diagnostic report (v1)",
+  "description": "The document produced by `jpipe diagnostic -f json`. This schema is the contract between the compiler and its consumers; it describes exactly what version 1 emits. Optional members are omitted rather than emitted as null.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "source",
+    "status",
+    "diagnostics",
+    "stats",
+    "models",
+    "actions"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "description": "Version of this document shape. Bumped only on a breaking change; additive changes keep it stable.",
+      "const": 1
+    },
+    "source": {
+      "description": "Path of the compiled source file, as given to the compiler.",
+      "type": "string"
+    },
+    "status": {
+      "description": "Whether any ERROR or FATAL diagnostic was reported. Mirrors the process exit code: 'ok' is 0, 'errors' is 1.",
+      "enum": ["ok", "errors"]
+    },
+    "diagnostics": {
+      "description": "All diagnostics, in the order the compiler reported them.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/diagnostic" }
+    },
+    "stats": { "$ref": "#/$defs/stats" },
+    "models": {
+      "description": "One entry per model in the unit, in declaration order.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/model" }
+    },
+    "actions": {
+      "description": "The ordered model-construction command trace. Empty when interpretation did not run.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/action" }
+    }
+  },
+
+  "$defs": {
+    "code": {
+      "description": "A stable, bare kebab-case identifier: either a compiler diagnostic code (`unknown-model`) or a validation rule name (`no-duplicate-ids`). Never bracketed — presentation belongs to the renderer.",
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+    },
+
+    "location": {
+      "description": "A source position. Line is 1-based, column is 0-based. Present only when the position is known.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["line", "column"],
+      "properties": {
+        "source": {
+          "description": "File the position belongs to. Omitted when the source is not tracked; differs from the report's top-level source for elements pulled in by a `load` directive.",
+          "type": "string"
+        },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 0 }
+      }
+    },
+
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["severity", "source", "message"],
+      "properties": {
+        "severity": {
+          "description": "'error' accumulates and sets the exit code (ADR-0016). 'fatal' is reserved: a fatal aborts the pipeline before any report is rendered, so it does not currently appear in a document — consumers should still handle it.",
+          "enum": ["error", "fatal"]
+        },
+        "code": { "$ref": "#/$defs/code" },
+        "source": { "type": "string" },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 0 },
+        "message": {
+          "description": "Human-readable description. Never carries the code — read `code` for that.",
+          "type": "string"
+        }
+      },
+      "dependentRequired": {
+        "line": ["column"],
+        "column": ["line"]
+      }
+    },
+
+    "stats": {
+      "description": "Compilation statistics. Always readable: the members are zero when interpretation did not run.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commands", "deferrals"],
+      "properties": {
+        "commands": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total", "macros"],
+          "properties": {
+            "total": { "type": "integer", "minimum": 0 },
+            "macros": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "deferrals": {
+          "description": "Number of execution-engine deferral rounds.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "kind", "elements", "usedBy", "symbols", "aliases"],
+      "properties": {
+        "name": { "type": "string" },
+        "kind": { "enum": ["justification", "template"] },
+        "implements": {
+          "description": "Name of the template this model implements. Omitted when it implements none.",
+          "type": "string"
+        },
+        "location": { "$ref": "#/$defs/location" },
+        "elements": {
+          "description": "Element census, matching the text report's `elements:` line.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "conclusion",
+            "subConclusion",
+            "strategy",
+            "evidence",
+            "abstractSupport"
+          ],
+          "properties": {
+            "conclusion": {
+              "description": "0 or 1: a model owns at most one conclusion.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "subConclusion": { "type": "integer", "minimum": 0 },
+            "strategy": { "type": "integer", "minimum": 0 },
+            "evidence": { "type": "integer", "minimum": 0 },
+            "abstractSupport": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "usedBy": {
+          "description": "Models implementing this one. Always empty for a justification.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string" },
+              "location": { "$ref": "#/$defs/location" }
+            }
+          }
+        },
+        "symbols": {
+          "description": "The model's elements, in stable display order: conclusion, sub-conclusions, strategies, evidence, abstract supports.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/symbol" }
+        },
+        "aliases": {
+          "description": "Element ids rewritten during composition.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["from", "to"],
+            "properties": {
+              "from": { "type": "string" },
+              "to": { "type": "string" }
+            }
+          }
+        }
+      },
+      "if": {
+        "properties": { "kind": { "const": "justification" } },
+        "required": ["kind"]
+      },
+      "then": {
+        "properties": { "usedBy": { "maxItems": 0 } }
+      }
+    },
+
+    "symbol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "synthesized"],
+      "properties": {
+        "id": { "type": "string" },
+        "kind": {
+          "enum": [
+            "conclusion",
+            "sub-conclusion",
+            "strategy",
+            "evidence",
+            "abstract-support"
+          ]
+        },
+        "synthesized": {
+          "description": "True when the element has no source position of its own, because it was produced by template expansion or composition.",
+          "type": "boolean"
+        },
+        "location": { "$ref": "#/$defs/location" }
+      },
+      "if": {
+        "properties": { "synthesized": { "const": false } },
+        "required": ["synthesized"]
+      },
+      "then": {
+        "description": "A non-synthesized element always carries its position.",
+        "required": ["location"]
+      },
+      "else": {
+        "description": "A synthesized element never does.",
+        "not": { "required": ["location"] }
+      }
+    },
+
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index", "depth", "macro", "description"],
+      "properties": {
+        "index": {
+          "description": "1-based position in the execution order.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "depth": {
+          "description": "Nesting depth inside macro expansions.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "macro": { "type": "boolean" },
+        "description": { "type": "string" }
+      }
+    }
+  }
+}

--- a/jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json
+++ b/jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json
@@ -17,7 +17,7 @@
   ],
   "properties": {
     "schemaVersion": {
-      "description": "Version of this document shape. Bumped only on a breaking change; additive changes keep it stable.",
+      "description": "Version of this document shape. Because this schema is strict (additionalProperties: false), any change to the set of members — including adding one — publishes a new schema file and increments this number. Read it before anything else; a version you do not know is one you should refuse rather than mis-read.",
       "const": 1
     },
     "source": {

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/CompilerFactoryTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/CompilerFactoryTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class CompilerFactoryTest {
 
@@ -21,6 +23,15 @@ class CompilerFactoryTest {
 	void buildDiagnosticCompiler_returns_non_null() {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		assertThat(CompilerFactory.buildDiagnosticCompiler(out)).isNotNull();
+	}
+
+	@ParameterizedTest
+	@EnumSource(DiagnosticFormat.class)
+	void buildDiagnosticCompiler_supports_every_format(
+			DiagnosticFormat format) {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		assertThat(CompilerFactory.buildDiagnosticCompiler(format, out))
+				.isNotNull();
 	}
 
 	@Test

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
@@ -22,8 +22,15 @@ import ca.mcscert.jpipe.visitor.PythonExporter;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics;
+import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
+import ca.mcscert.jpipe.compiler.steps.transformations.JsonDiagnosticReport;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 /** Step definitions for end-to-end compilation scenarios. */
 public class CompilationSteps {
@@ -38,6 +45,8 @@ public class CompilationSteps {
 	private String dotOutput;
 	private String pythonOutput;
 	private String jsonOutput;
+	private String textReport;
+	private JSONObject jsonReport;
 
 	@Given("the source file {string}")
 	public void theSourceFile(String filename) {
@@ -184,6 +193,84 @@ public class CompilationSteps {
 		assertThat(loc.line()).isEqualTo(line);
 	}
 
+	// -------------------------------------------------------------------------
+	// Diagnostic reports
+	// -------------------------------------------------------------------------
+
+	@When("I produce a text diagnostic report")
+	public void iProduceATextDiagnosticReport() {
+		textReport = new CollectDiagnostics().andThen(new DiagnosticReport())
+				.fire(unit, ctx);
+	}
+
+	@When("I produce a JSON diagnostic report")
+	public void iProduceAJsonDiagnosticReport() {
+		jsonReport = new JSONObject(new CollectDiagnostics()
+				.andThen(new JsonDiagnosticReport()).fire(unit, ctx));
+	}
+
+	@Then("the text report contains {string}")
+	public void theTextReportContains(String fragment) {
+		assertThat(textReport).contains(fragment);
+	}
+
+	@Then("the JSON report status is {string}")
+	public void theJsonReportStatusIs(String status) {
+		assertThat(jsonReport.getString("status")).isEqualTo(status);
+	}
+
+	@Then("the JSON report declares a schema version")
+	public void theJsonReportDeclaresASchemaVersion() {
+		assertThat(jsonReport.getInt("schemaVersion")).isPositive();
+	}
+
+	@Then("the JSON report has a diagnostic with code {string}")
+	public void theJsonReportHasADiagnosticWithCode(String code) {
+		assertThat(codesIn(jsonReport)).contains(code);
+	}
+
+	@Then("no JSON diagnostic message contains its own code")
+	public void noJsonDiagnosticMessageContainsItsOwnCode() {
+		JSONArray diagnostics = jsonReport.getJSONArray("diagnostics");
+		for (int i = 0; i < diagnostics.length(); i++) {
+			JSONObject d = diagnostics.getJSONObject(i);
+			if (d.has("code")) {
+				assertThat(d.getString("message"))
+						.doesNotContain(d.getString("code"));
+			}
+		}
+	}
+
+	@Then("the JSON report describes a {string} named {string}")
+	public void theJsonReportDescribesAModelNamed(String kind, String name) {
+		JSONArray models = jsonReport.getJSONArray("models");
+		boolean found = false;
+		for (int i = 0; i < models.length(); i++) {
+			JSONObject model = models.getJSONObject(i);
+			found = found || (name.equals(model.getString("name"))
+					&& kind.equals(model.getString("kind")));
+		}
+		assertThat(found).as("a %s named %s", kind, name).isTrue();
+	}
+
+	@Then("both reports agree on the number of diagnostics")
+	public void bothReportsAgreeOnTheNumberOfDiagnostics() {
+		assertThat(jsonReport.getJSONArray("diagnostics").length())
+				.isEqualTo(ctx.diagnostics().size());
+	}
+
+	private static List<String> codesIn(JSONObject report) {
+		JSONArray diagnostics = report.getJSONArray("diagnostics");
+		List<String> codes = new ArrayList<>();
+		for (int i = 0; i < diagnostics.length(); i++) {
+			JSONObject d = diagnostics.getJSONObject(i);
+			if (d.has("code")) {
+				codes.add(d.getString("code"));
+			}
+		}
+		return codes;
+	}
+
 	@When("I export the current model to DOT format")
 	public void iExportTheCurrentModelToDotFormat() {
 		dotOutput = new DotExporter().export(currentModel);
@@ -241,8 +328,7 @@ public class CompilationSteps {
 	@Then("a validation error is reported for rule {string}")
 	public void aValidationErrorIsReportedForRule(String rule) {
 		assertThat(ctx.diagnostics()).filteredOn(Diagnostic::isError)
-				.extracting(Diagnostic::message)
-				.anySatisfy(msg -> assertThat(msg).contains("[" + rule + "]"));
+				.extracting(Diagnostic::code).contains(rule);
 	}
 
 	@Then("a validation error mentions {string}")

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/model/CompilationContextTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/model/CompilationContextTest.java
@@ -64,4 +64,33 @@ class CompilationContextTest {
 				.containsExactly("first", "second");
 	}
 
+	@Test
+	void codedError_carriesTheCodeAndTheSourcePath() {
+		ctx.error(DiagnosticCodes.UNKNOWN_MODEL, "unknown model 'foo'");
+
+		Diagnostic d = ctx.diagnostics().get(0);
+		assertThat(d.code()).isEqualTo("unknown-model");
+		assertThat(d.source()).isEqualTo("file.jd");
+		assertThat(d.message()).isEqualTo("unknown model 'foo'");
+		assertThat(d.hasLocation()).isFalse();
+	}
+
+	@Test
+	void codedErrorWithLocation_carriesEverything() {
+		ctx.error(DiagnosticCodes.UNKNOWN_ELEMENT, 7, 3, "unknown element 'e'");
+
+		Diagnostic d = ctx.diagnostics().get(0);
+		assertThat(d.code()).isEqualTo("unknown-element");
+		assertThat(d.line()).isEqualTo(7);
+		assertThat(d.column()).isEqualTo(3);
+		assertThat(d.message()).isEqualTo("unknown element 'e'");
+	}
+
+	@Test
+	void uncodedError_hasNoCode() {
+		ctx.error(7, 3, "plain message");
+
+		assertThat(ctx.diagnostics().get(0).hasCode()).isFalse();
+	}
+
 }

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/model/DiagnosticTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/model/DiagnosticTest.java
@@ -23,4 +23,49 @@ class DiagnosticTest {
 		assertThat(d.isFatal()).isTrue();
 	}
 
+	@Test
+	void error_withoutCode_hasNoCode() {
+		Diagnostic d = Diagnostic.error("file.jd", "something wrong");
+		assertThat(d.code()).isNull();
+		assertThat(d.hasCode()).isFalse();
+	}
+
+	@Test
+	void error_withCode_keepsTheCodeOutOfTheMessage() {
+		Diagnostic d = Diagnostic.error(DiagnosticCodes.UNKNOWN_MODEL,
+				"file.jd", "unknown model 'foo'");
+		assertThat(d.hasCode()).isTrue();
+		assertThat(d.code()).isEqualTo("unknown-model");
+		assertThat(d.message()).isEqualTo("unknown model 'foo'")
+				.doesNotContain("unknown-model");
+	}
+
+	@Test
+	void error_withCodeAndLocation_carriesBoth() {
+		Diagnostic d = Diagnostic.error(DiagnosticCodes.UNKNOWN_ELEMENT,
+				"file.jd", 12, 4, "unknown element 'e'");
+		assertThat(d.code()).isEqualTo("unknown-element");
+		assertThat(d.hasLocation()).isTrue();
+		assertThat(d.line()).isEqualTo(12);
+		assertThat(d.column()).isEqualTo(4);
+	}
+
+	@Test
+	void diagnosticCodes_areBareKebabCase() {
+		assertThat(DiagnosticCodes.UNKNOWN_MODEL).doesNotContain("[")
+				.doesNotContain("]").isEqualTo("unknown-model");
+	}
+
+	@Test
+	void emptyCode_countsAsNoCode() {
+		Diagnostic d = Diagnostic.error("", "file.jd", "message");
+		assertThat(d.hasCode()).isFalse();
+	}
+
+	@Test
+	void fatal_neverCarriesACode() {
+		Diagnostic d = Diagnostic.fatal("file.jd", 1, 2, "unrecoverable");
+		assertThat(d.hasCode()).isFalse();
+	}
+
 }

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/checkers/CompletenessCheckerTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/checkers/CompletenessCheckerTest.java
@@ -46,14 +46,25 @@ class CompletenessCheckerTest {
 	}
 
 	@Test
-	void error_diagnostic_message_contains_rule_name() {
+	void error_diagnostic_carries_rule_name_as_code() {
+		Unit unit = new Unit("src");
+		unit.add(new Justification("j"));
+
+		new CompletenessChecker().fire(unit, ctx);
+
+		assertThat(ctx.diagnostics()).extracting(Diagnostic::code)
+				.contains("conclusion-present");
+	}
+
+	@Test
+	void error_diagnostic_message_excludes_the_rule_name() {
 		Unit unit = new Unit("src");
 		unit.add(new Justification("j"));
 
 		new CompletenessChecker().fire(unit, ctx);
 
 		assertThat(ctx.diagnostics()).extracting(Diagnostic::message)
-				.anyMatch(m -> m.contains("conclusion-present"));
+				.noneMatch(m -> m.contains("conclusion-present"));
 	}
 
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
@@ -109,11 +109,15 @@ class CollectDiagnosticsTest {
 		ctx.error("boom");
 		DiagnosticSnapshot snapshot = collect();
 
-		assertThatThrownBy(() -> snapshot.diagnostics().clear())
+		var diagnostics = snapshot.diagnostics();
+		var models = snapshot.models();
+		var symbols = models.get(0).symbols();
+
+		assertThatThrownBy(diagnostics::clear)
 				.isInstanceOf(UnsupportedOperationException.class);
-		assertThatThrownBy(() -> snapshot.models().clear())
+		assertThatThrownBy(models::clear)
 				.isInstanceOf(UnsupportedOperationException.class);
-		assertThatThrownBy(() -> snapshot.models().get(0).symbols().clear())
+		assertThatThrownBy(symbols::clear)
 				.isInstanceOf(UnsupportedOperationException.class);
 	}
 

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
@@ -1,6 +1,7 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
 
 import ca.mcscert.jpipe.commands.ExecutedAction;
@@ -80,6 +81,40 @@ class CollectDiagnosticsTest {
 		assertThat(collect().actions()).extracting(a -> a.index())
 				.containsExactly(1, 2);
 		assertThat(collect().actions().get(1).depth()).isEqualTo(1);
+	}
+
+	/**
+	 * The context hands out unmodifiable <em>views</em> of live state, so a
+	 * snapshot that kept those references would keep changing after collection
+	 * and two renderings of it could disagree.
+	 */
+	@Test
+	void snapshotIsUnaffectedByLaterChangesToTheContext() {
+		ctx.error("reported before collection");
+		DiagnosticSnapshot snapshot = collect();
+
+		ctx.error("reported after collection");
+		ctx.recordStat(STAT_COMMANDS_TOTAL, 99L);
+		ctx.recordActions(List
+				.of(new ExecutedAction(new CreateJustification("late"), 0)));
+
+		assertThat(snapshot.diagnostics()).hasSize(1);
+		assertThat(snapshot.stats()).isEmpty();
+		assertThat(snapshot.actions()).isEmpty();
+	}
+
+	@Test
+	void snapshotCollectionsRejectModification() {
+		unit.add(new Justification("j"));
+		ctx.error("boom");
+		DiagnosticSnapshot snapshot = collect();
+
+		assertThatThrownBy(() -> snapshot.diagnostics().clear())
+				.isInstanceOf(UnsupportedOperationException.class);
+		assertThatThrownBy(() -> snapshot.models().clear())
+				.isInstanceOf(UnsupportedOperationException.class);
+		assertThatThrownBy(() -> snapshot.models().get(0).symbols().clear())
+				.isInstanceOf(UnsupportedOperationException.class);
 	}
 
 	@Test

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
@@ -1,0 +1,225 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
+
+import ca.mcscert.jpipe.commands.ExecutedAction;
+import ca.mcscert.jpipe.commands.creation.CreateJustification;
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ModelInfo;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.SymbolInfo;
+import ca.mcscert.jpipe.model.Justification;
+import ca.mcscert.jpipe.model.SourceLocation;
+import ca.mcscert.jpipe.model.Template;
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the model traversal that both report renderers depend on. Everything
+ * asserted here is what keeps the text and JSON reports describing the same
+ * compilation.
+ */
+class CollectDiagnosticsTest {
+
+	private CollectDiagnostics step;
+	private CompilationContext ctx;
+	private Unit unit;
+
+	@BeforeEach
+	void setUp() {
+		step = new CollectDiagnostics();
+		ctx = new CompilationContext("test.jd");
+		unit = new Unit("test.jd");
+	}
+
+	// -------------------------------------------------------------------------
+	// Context pass-through
+	// -------------------------------------------------------------------------
+
+	@Test
+	void carriesTheSourcePathFromTheContext() {
+		assertThat(collect().source()).isEqualTo("test.jd");
+	}
+
+	@Test
+	void carriesDiagnosticsInReportOrder() {
+		ctx.error("first");
+		ctx.error("second");
+
+		assertThat(collect().diagnostics()).extracting(d -> d.message())
+				.containsExactly("first", "second");
+	}
+
+	@Test
+	void hasErrorsMirrorsTheContext() {
+		assertThat(collect().hasErrors()).isFalse();
+		ctx.error("boom");
+		assertThat(collect().hasErrors()).isTrue();
+	}
+
+	@Test
+	void carriesRecordedStats() {
+		ctx.recordStat(STAT_COMMANDS_TOTAL, 7L);
+
+		assertThat(collect().stats()).containsEntry(STAT_COMMANDS_TOTAL, 7L);
+	}
+
+	@Test
+	void numbersActionsFromOne() {
+		ctx.recordActions(
+				List.of(new ExecutedAction(new CreateJustification("j1"), 0),
+						new ExecutedAction(new CreateJustification("j2"), 1)));
+
+		assertThat(collect().actions()).extracting(a -> a.index())
+				.containsExactly(1, 2);
+		assertThat(collect().actions().get(1).depth()).isEqualTo(1);
+	}
+
+	@Test
+	void collectingDoesNotMarkDiagnosticsRendered() {
+		collect();
+
+		// Only a renderer may claim the diagnostics were shown to the user;
+		// otherwise a failure between collect and render would silently
+		// swallow ChainCompiler's fallback dump.
+		assertThat(ctx.diagnosticsRendered()).isFalse();
+	}
+
+	// -------------------------------------------------------------------------
+	// Models
+	// -------------------------------------------------------------------------
+
+	@Test
+	void distinguishesJustificationsFromTemplates() {
+		unit.add(new Justification("j"));
+		unit.add(new Template("t"));
+
+		assertThat(collect().models()).extracting(ModelInfo::kind)
+				.containsExactly("justification", "template");
+	}
+
+	@Test
+	void countsElementsByType() {
+		Justification j = new Justification("j");
+		j.setConclusion(new Conclusion("c", "A conclusion"));
+		j.addElement(new SubConclusion("sc", "A sub-conclusion"));
+		j.addElement(new Strategy("s", "A strategy"));
+		j.addElement(new Evidence("e", "An evidence"));
+		unit.add(j);
+
+		var counts = collect().models().get(0).counts();
+
+		assertThat(counts.conclusion()).isEqualTo(1);
+		assertThat(counts.subConclusion()).isEqualTo(1);
+		assertThat(counts.strategy()).isEqualTo(1);
+		assertThat(counts.evidence()).isEqualTo(1);
+		assertThat(counts.abstractSupport()).isZero();
+		assertThat(counts.isEmpty()).isFalse();
+	}
+
+	@Test
+	void emptyModelHasEmptyCounts() {
+		unit.add(new Justification("j"));
+
+		assertThat(collect().models().get(0).counts().isEmpty()).isTrue();
+	}
+
+	@Test
+	void linksATemplateToItsImplementors() {
+		Template t = new Template("base");
+		unit.add(t);
+		Justification j = new Justification("impl");
+		j.inline(t, "base");
+		unit.add(j);
+
+		ModelInfo template = modelNamed("base");
+		ModelInfo impl = modelNamed("impl");
+
+		assertThat(template.isTemplate()).isTrue();
+		assertThat(template.usedBy()).extracting(u -> u.name())
+				.containsExactly("impl");
+		assertThat(impl.implementsTemplate()).isTrue();
+		assertThat(impl.implementedTemplate()).isEqualTo("base");
+	}
+
+	@Test
+	void justificationNeverReportsImplementors() {
+		unit.add(new Justification("j"));
+
+		assertThat(modelNamed("j").usedBy()).isEmpty();
+	}
+
+	// -------------------------------------------------------------------------
+	// Symbols and aliases
+	// -------------------------------------------------------------------------
+
+	@Test
+	void collectsSymbolsInStableDisplayOrder() {
+		Justification j = new Justification("j");
+		j.setConclusion(new Conclusion("c", "A conclusion"));
+		j.addElement(new SubConclusion("sc", "A sub-conclusion"));
+		j.addElement(new Strategy("s", "A strategy"));
+		j.addElement(new Evidence("e", "An evidence"));
+		unit.add(j);
+
+		assertThat(modelNamed("j").symbols()).extracting(SymbolInfo::kind)
+				.containsExactly("conclusion", "sub-conclusion", "strategy",
+						"evidence");
+	}
+
+	@Test
+	void resolvesElementLocations() {
+		Justification j = new Justification("j");
+		j.setConclusion(new Conclusion("c", "A conclusion"));
+		unit.add(j);
+		unit.recordLocation("j", new SourceLocation("test.jd", 1, 1));
+		unit.recordLocation("j", "c", new SourceLocation("test.jd", 2, 3));
+
+		SymbolInfo symbol = modelNamed("j").symbols().get(0);
+
+		assertThat(symbol.isSynthesized()).isFalse();
+		assertThat(symbol.location().line()).isEqualTo(2);
+		assertThat(symbol.location().column()).isEqualTo(3);
+	}
+
+	@Test
+	void flagsElementsWithoutALocationAsSynthesized() {
+		Justification j = new Justification("j");
+		j.setConclusion(new Conclusion("c", "A conclusion"));
+		unit.add(j);
+
+		assertThat(modelNamed("j").symbols().get(0).isSynthesized()).isTrue();
+	}
+
+	@Test
+	void groupsAliasesUnderTheirOwningModel() {
+		unit.add(new Justification("j"));
+		unit.add(new Justification("other"));
+		unit.recordAlias("j", "oldId", "newId");
+
+		assertThat(modelNamed("j").aliases()).extracting(a -> a.from())
+				.containsExactly("oldId");
+		assertThat(modelNamed("other").aliases()).isEmpty();
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private DiagnosticSnapshot collect() {
+		return step.run(unit, ctx);
+	}
+
+	private ModelInfo modelNamed(String name) {
+		return collect().models().stream().filter(m -> name.equals(m.name()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("no model " + name));
+	}
+}

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReportTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReportTest.java
@@ -10,6 +10,7 @@ import ca.mcscert.jpipe.commands.ExecutedAction;
 import ca.mcscert.jpipe.commands.MacroCommand;
 import ca.mcscert.jpipe.commands.creation.CreateJustification;
 import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.DiagnosticCodes;
 import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Template;
@@ -48,7 +49,7 @@ class DiagnosticReportTest {
 
 		@Test
 		void sectionIsAbsentWhenNoActionsWereRecorded() {
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).doesNotContain("Executed Actions");
 		}
 
@@ -57,21 +58,21 @@ class DiagnosticReportTest {
 		void singleAction_reportContains(int depth, String expected) {
 			ctx.recordActions(
 					List.of(action(new CreateJustification("j1"), depth)));
-			assertThat(step.run(unit, ctx)).contains(expected);
+			assertThat(report()).contains(expected);
 		}
 
 		@Test
 		void actionsAreNumberedSequentially() {
 			ctx.recordActions(List.of(action(new CreateJustification("j1"), 0),
 					action(new CreateJustification("j2"), 0)));
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("  1.").contains("  2.");
 		}
 
 		@Test
 		void macroActionIsLabelledWithMacroPrefix() {
 			ctx.recordActions(List.of(action(macro("my_macro"), 0)));
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("[macro] my_macro");
 		}
 
@@ -79,7 +80,7 @@ class DiagnosticReportTest {
 		void depth2ActionIsIndentedMoreThanDepth1() {
 			ctx.recordActions(List.of(action(new CreateJustification("j1"), 1),
 					action(new CreateJustification("j2"), 2)));
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).containsSubsequence(
 					"  1.   create_justification('j1').",
 					"  2.     create_justification('j2').");
@@ -101,7 +102,7 @@ class DiagnosticReportTest {
 
 		@Test
 		void noDiagnostics_prints_none() {
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("=== Diagnostics ===")
 					.contains("(none)");
 		}
@@ -109,7 +110,7 @@ class DiagnosticReportTest {
 		@Test
 		void errorWithoutLocation_prints_level_source_message() {
 			ctx.error("something went wrong");
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("[ERROR]")
 					.contains("something went wrong");
 		}
@@ -117,13 +118,13 @@ class DiagnosticReportTest {
 		@Test
 		void errorWithLocation_includes_line_and_column() {
 			ctx.error(5, 10, "bad token");
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("5:10").contains("bad token");
 		}
 
 		@Test
 		void markDiagnosticsRendered_is_called_after_run() {
-			step.run(unit, ctx);
+			report();
 			assertThat(ctx.diagnosticsRendered()).isTrue();
 		}
 	}
@@ -137,7 +138,7 @@ class DiagnosticReportTest {
 
 		@Test
 		void sectionIsAbsentWhenNoStatsRecorded() {
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).doesNotContain("Action Statistics");
 		}
 
@@ -146,7 +147,7 @@ class DiagnosticReportTest {
 			ctx.recordStat(STAT_COMMANDS_TOTAL, 3L);
 			ctx.recordStat(STAT_COMMANDS_MACROS, 1L);
 			ctx.recordStat(STAT_COMMANDS_DEFERRALS, 0L);
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("=== Action Statistics ===");
 		}
 
@@ -155,7 +156,7 @@ class DiagnosticReportTest {
 			ctx.recordStat(STAT_COMMANDS_TOTAL, 5L);
 			ctx.recordStat(STAT_COMMANDS_MACROS, 2L);
 			ctx.recordStat(STAT_COMMANDS_DEFERRALS, 1L);
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("commands: 5 total (2 macro)")
 					.contains("deferrals: 1");
 		}
@@ -170,21 +171,21 @@ class DiagnosticReportTest {
 
 		@Test
 		void emptyUnit_shows_header_only() {
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("=== Model Summary ===");
 		}
 
 		@Test
 		void justification_shows_kind_and_name() {
 			unit.add(new Justification("myJ"));
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("justification \"myJ\"");
 		}
 
 		@Test
 		void template_shows_kind_and_name() {
 			unit.add(new Template("myT"));
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("template \"myT\"");
 		}
 
@@ -193,7 +194,7 @@ class DiagnosticReportTest {
 			Justification j = new Justification("j");
 			j.setConclusion(new Conclusion("c", "A conclusion"));
 			unit.add(j);
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("conclusion(1)");
 		}
 
@@ -204,7 +205,7 @@ class DiagnosticReportTest {
 			j.addElement(new Strategy("s", "A strategy"));
 			j.addElement(new Evidence("e", "An evidence"));
 			unit.add(j);
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("conclusion(1)").contains("strategy(1)")
 					.contains("evidence(1)");
 		}
@@ -216,7 +217,7 @@ class DiagnosticReportTest {
 			Justification j = new Justification("impl");
 			j.inline(t, "base");
 			unit.add(j);
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("used by").contains("\"impl\"");
 		}
 	}
@@ -230,7 +231,7 @@ class DiagnosticReportTest {
 
 		@Test
 		void emptyUnit_shows_empty_symbol_table() {
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("=== Symbol Table ===")
 					.contains("(empty)");
 		}
@@ -239,7 +240,7 @@ class DiagnosticReportTest {
 		void model_with_known_location_shows_location() {
 			unit.add(new Justification("j"));
 			unit.recordLocation("j", new SourceLocation("test.jd", 1, 1));
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("justification \"j\"");
 		}
 
@@ -250,7 +251,7 @@ class DiagnosticReportTest {
 			unit.add(j);
 			unit.recordLocation("j", new SourceLocation("test.jd", 1, 1));
 			unit.recordLocation("j", "c", new SourceLocation("test.jd", 2, 3));
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("2:3");
 		}
 
@@ -259,14 +260,89 @@ class DiagnosticReportTest {
 			unit.add(new Justification("j"));
 			unit.recordAlias("j", "oldId", "newId");
 			unit.recordLocation("j", new SourceLocation("test.jd", 1, 1));
-			String report = step.run(unit, ctx);
+			String report = report();
 			assertThat(report).contains("[alias]");
 		}
 	}
 
 	// -------------------------------------------------------------------------
+	// Whole-report golden text
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Pins the exact rendering of a report exercising every section at once.
+	 *
+	 * <p>
+	 * The per-section tests above assert on substrings and would not notice a
+	 * lost space, a reordered section or a stray blank line. This one would —
+	 * which is what makes it the guard for changes that move text around, such
+	 * as lifting diagnostic codes out of message strings into their own field.
+	 */
+	@Test
+	void wholeReport_rendersExactly() {
+		Template t = new Template("base");
+		t.setConclusion(new Conclusion("tc", "Template conclusion"));
+		t.addElement(new Strategy("ts", "Template strategy"));
+		unit.add(t);
+		unit.recordLocation("base", new SourceLocation("test.jd", 3, 8));
+		unit.recordLocation("base", "tc", new SourceLocation("test.jd", 4, 2));
+		unit.recordLocation("base", "ts", new SourceLocation("test.jd", 5, 4));
+
+		Justification j = new Justification("impl");
+		j.inline(t, "base");
+		j.addElement(new Evidence("ev", "Some evidence"));
+		unit.add(j);
+		unit.recordLocation("impl", new SourceLocation("test.jd", 10, 0));
+		unit.recordLocation("impl", "ev", new SourceLocation("test.jd", 11, 6));
+		unit.recordAlias("impl", "old", "new");
+
+		ctx.error(DiagnosticCodes.UNKNOWN_MODEL, 12, 4, "unknown model 'foo'");
+		ctx.error("model construction failed");
+		ctx.recordStat(STAT_COMMANDS_TOTAL, 4L);
+		ctx.recordStat(STAT_COMMANDS_MACROS, 1L);
+		ctx.recordStat(STAT_COMMANDS_DEFERRALS, 2L);
+		ctx.recordActions(List.of(action(new CreateJustification("impl"), 0),
+				action(macro("expand_base"), 1)));
+
+		assertThat(report()).isEqualTo(GOLDEN_REPORT);
+	}
+
+	/**
+	 * Written as explicit concatenation rather than a text block so that no
+	 * source formatter can silently re-indent the expectation and weaken the
+	 * assertion. {@code →} is the alias arrow.
+	 */
+	private static final String GOLDEN_REPORT = "=== Diagnostics ===\n"
+			+ "[ERROR] test.jd:12:4: [unknown-model] unknown model 'foo'\n"
+			+ "[ERROR] test.jd: model construction failed\n" + "\n"
+			+ "=== Action Statistics ===\n" + "commands: 4 total (1 macro)\n"
+			+ "deferrals: 2\n" + "\n" + "=== Model Summary ===\n"
+			+ "template \"base\"\n"
+			+ "  elements:  conclusion(1), strategy(1)\n"
+			+ "  used by:   \"impl\" @ 10:0\n" + "\n"
+			+ "justification \"impl\"  [implements \"base\"]\n"
+			+ "  elements:  conclusion(1), strategy(1), evidence(1)\n" + "\n"
+			+ "=== Symbol Table ===\n" + "template \"base\"  [test.jd:3:8]\n"
+			+ "  tc  4:2\n" + "  ts  5:4\n"
+			+ "justification \"impl\"  [test.jd:10:0]\n"
+			+ "  base:tc  [synthesized]\n" + "  base:ts  [synthesized]\n"
+			+ "  ev       11:6\n" + "  old  \u2192 new  [alias]\n" + "\n"
+			+ "=== Executed Actions ===\n"
+			+ "  1. create_justification('impl').\n"
+			+ "  2.   [macro] expand_base\n";
+
+	// -------------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Renders the current fixture the way the pipeline does: collect the
+	 * snapshot, then format it. Exercising the pair together is deliberate —
+	 * the renderer is only meaningful over a snapshot the collector produced.
+	 */
+	private String report() {
+		return step.run(new CollectDiagnostics().run(unit, ctx), ctx);
+	}
 
 	private static ExecutedAction action(Command command, int depth) {
 		return new ExecutedAction(command, depth);

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReportTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReportTest.java
@@ -307,29 +307,38 @@ class DiagnosticReportTest {
 		assertThat(report()).isEqualTo(GOLDEN_REPORT);
 	}
 
-	/**
-	 * Written as explicit concatenation rather than a text block so that no
-	 * source formatter can silently re-indent the expectation and weaken the
-	 * assertion. {@code →} is the alias arrow.
-	 */
-	private static final String GOLDEN_REPORT = "=== Diagnostics ===\n"
-			+ "[ERROR] test.jd:12:4: [unknown-model] unknown model 'foo'\n"
-			+ "[ERROR] test.jd: model construction failed\n" + "\n"
-			+ "=== Action Statistics ===\n" + "commands: 4 total (1 macro)\n"
-			+ "deferrals: 2\n" + "\n" + "=== Model Summary ===\n"
-			+ "template \"base\"\n"
-			+ "  elements:  conclusion(1), strategy(1)\n"
-			+ "  used by:   \"impl\" @ 10:0\n" + "\n"
-			+ "justification \"impl\"  [implements \"base\"]\n"
-			+ "  elements:  conclusion(1), strategy(1), evidence(1)\n" + "\n"
-			+ "=== Symbol Table ===\n" + "template \"base\"  [test.jd:3:8]\n"
-			+ "  tc  4:2\n" + "  ts  5:4\n"
-			+ "justification \"impl\"  [test.jd:10:0]\n"
-			+ "  base:tc  [synthesized]\n" + "  base:ts  [synthesized]\n"
-			+ "  ev       11:6\n" + "  old  \u2192 new  [alias]\n" + "\n"
-			+ "=== Executed Actions ===\n"
-			+ "  1. create_justification('impl').\n"
-			+ "  2.   [macro] expand_base\n";
+	/** The exact report the fixture above must render, arrow included. */
+	private static final String GOLDEN_REPORT = """
+			=== Diagnostics ===
+			[ERROR] test.jd:12:4: [unknown-model] unknown model 'foo'
+			[ERROR] test.jd: model construction failed
+
+			=== Action Statistics ===
+			commands: 4 total (1 macro)
+			deferrals: 2
+
+			=== Model Summary ===
+			template "base"
+			  elements:  conclusion(1), strategy(1)
+			  used by:   "impl" @ 10:0
+
+			justification "impl"  [implements "base"]
+			  elements:  conclusion(1), strategy(1), evidence(1)
+
+			=== Symbol Table ===
+			template "base"  [test.jd:3:8]
+			  tc  4:2
+			  ts  5:4
+			justification "impl"  [test.jd:10:0]
+			  base:tc  [synthesized]
+			  base:ts  [synthesized]
+			  ev       11:6
+			  old  \u2192 new  [alias]
+
+			=== Executed Actions ===
+			  1. create_justification('impl').
+			  2.   [macro] expand_base
+			""";
 
 	// -------------------------------------------------------------------------
 	// Helpers

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportSchemaTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportSchemaTest.java
@@ -1,0 +1,281 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.mcscert.jpipe.compiler.CompilerFactory;
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.CompilationException;
+import ca.mcscert.jpipe.compiler.model.DiagnosticCodes;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+import ca.mcscert.jpipe.model.Justification;
+import ca.mcscert.jpipe.model.SourceLocation;
+import ca.mcscert.jpipe.model.Template;
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Holds the published JSON Schema and the emitter to the same contract.
+ *
+ * <p>
+ * The schema is validated here rather than at runtime: the document is built by
+ * straight-line code from a typed {@code DiagnosticSnapshot}, so no external
+ * input can make it structurally invalid — only a code change can, and that is
+ * a build-time concern. This test is where that guarantee lives.
+ *
+ * <p>
+ * The schema is loaded from the <em>classpath</em>, which also proves it is
+ * packaged into the artifact for consumers to load the same way.
+ */
+class JsonDiagnosticReportSchemaTest {
+
+	private static final String SCHEMA_RESOURCE = "/schema/diagnostic-report-v1.schema.json";
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final JsonSchema SCHEMA = loadSchema();
+
+	private static JsonSchema loadSchema() {
+		try (InputStream in = JsonDiagnosticReportSchemaTest.class
+				.getResourceAsStream(SCHEMA_RESOURCE)) {
+			if (in == null) {
+				throw new IllegalStateException(
+						"Schema not on the classpath: " + SCHEMA_RESOURCE);
+			}
+			return JsonSchemaFactory
+					.getInstance(SpecVersion.VersionFlag.V202012).getSchema(in);
+		} catch (IOException e) {
+			throw new IllegalStateException("Cannot read the schema", e);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// The schema is reachable the way consumers reach it
+	// -------------------------------------------------------------------------
+
+	@Test
+	void schemaIsPackagedOnTheClasspath() {
+		assertThat(JsonDiagnosticReportSchemaTest.class
+				.getResourceAsStream(SCHEMA_RESOURCE)).isNotNull();
+	}
+
+	@Test
+	void schemaDeclaresTheVersionTheEmitterWrites() throws IOException {
+		JsonNode schema = MAPPER.readTree(JsonDiagnosticReportSchemaTest.class
+				.getResourceAsStream(SCHEMA_RESOURCE));
+
+		assertThat(schema.at("/properties/schemaVersion/const").asInt())
+				.isEqualTo(JsonDiagnosticReport.SCHEMA_VERSION);
+	}
+
+	// -------------------------------------------------------------------------
+	// Real output conforms
+	// -------------------------------------------------------------------------
+
+	@Test
+	void emptyUnitConforms() {
+		assertConforms(reportOf(new Unit("test.jd"),
+				new CompilationContext("test.jd")));
+	}
+
+	@Test
+	void unitWithDiagnosticsConforms() {
+		CompilationContext ctx = new CompilationContext("test.jd");
+		ctx.error(DiagnosticCodes.UNKNOWN_MODEL, 12, 4, "unknown model 'foo'");
+		ctx.error("model construction failed");
+
+		assertConforms(reportOf(new Unit("test.jd"), ctx));
+	}
+
+	/**
+	 * No fatal fixture exists above because one cannot: {@code fire()}
+	 * fast-fails on a fatal, so a report is never produced for a compilation
+	 * that has one. The schema still admits the value — see
+	 * {@link #schemaAdmitsFatalSeverityForFutureUse()}.
+	 */
+	@Test
+	void aFatalPreventsAnyReportFromBeingProduced() {
+		CompilationContext ctx = new CompilationContext("test.jd");
+		ctx.fatal("unrecoverable");
+		Unit unit = new Unit("test.jd");
+
+		assertThatThrownBy(() -> reportOf(unit, ctx))
+				.isInstanceOf(CompilationException.class);
+	}
+
+	@Test
+	void unitWithTemplateImplementorAliasesAndSymbolsConforms() {
+		Unit unit = new Unit("test.jd");
+		Template t = new Template("base");
+		t.setConclusion(new Conclusion("tc", "Template conclusion"));
+		t.addElement(new Strategy("ts", "Template strategy"));
+		unit.add(t);
+		unit.recordLocation("base", new SourceLocation("test.jd", 3, 8));
+		unit.recordLocation("base", "tc", new SourceLocation("test.jd", 4, 2));
+
+		Justification j = new Justification("impl");
+		j.inline(t, "base");
+		j.addElement(new Evidence("ev", "Some evidence"));
+		unit.add(j);
+		unit.recordLocation("impl", new SourceLocation("test.jd", 10, 0));
+		unit.recordAlias("impl", "old", "new");
+
+		assertConforms(reportOf(unit, new CompilationContext("test.jd")));
+	}
+
+	/**
+	 * The whole example corpus, compiled for real. Sources that fail fatally
+	 * produce no report at all (documented behaviour), so they are skipped
+	 * rather than asserted on.
+	 */
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("exampleSources")
+	void everyExampleConformsToTheSchema(Path source) throws IOException {
+		Transformation<InputStream, Unit> pipeline = CompilerFactory
+				.parsingChain().andThen(CompilerFactory.unitBuilder())
+				.asTransformation();
+		CompilationContext ctx = new CompilationContext(source.toString());
+		Unit unit;
+		try (FileInputStream stream = new FileInputStream(source.toFile())) {
+			unit = pipeline.fire(stream, ctx);
+		} catch (CompilationException _) {
+			return; // fatal: no report is produced, in either format
+		}
+
+		assertConforms(reportOf(unit, ctx));
+	}
+
+	static Stream<Path> exampleSources() throws IOException {
+		Path root = Path.of(System.getProperty("examples.dir"));
+		try (Stream<Path> paths = Files.walk(root)) {
+			return paths.filter(p -> p.toString().endsWith(".jd"))
+					.sorted(Comparator.naturalOrder()).toList().stream();
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// The schema actually bites
+	// -------------------------------------------------------------------------
+	// A schema that accepts everything would make every test above vacuous.
+	// These pin the constraints that matter most.
+
+	@Test
+	void schemaRejectsAnUnexpectedKey() throws IOException {
+		JsonNode report = MAPPER.readTree(
+				reportOf(new Unit("test.jd"), new CompilationContext("t.jd")));
+		((ObjectNode) report).put("oops", 1);
+
+		assertThat(SCHEMA.validate(report)).isNotEmpty();
+	}
+
+	@Test
+	void schemaRejectsABracketedCode() throws IOException {
+		JsonNode report = MAPPER.readTree(reportWithCode("[unknown-model]"));
+
+		assertThat(SCHEMA.validate(report)).isNotEmpty();
+	}
+
+	@Test
+	void schemaAcceptsABareCode() throws IOException {
+		JsonNode report = MAPPER.readTree(reportWithCode("unknown-model"));
+
+		assertThat(SCHEMA.validate(report)).isEmpty();
+	}
+
+	/**
+	 * The value is reserved rather than reachable today: a fatal aborts before
+	 * any report is rendered. Pinned so the schema stays ready if that
+	 * limitation is lifted.
+	 */
+	@Test
+	void schemaAdmitsFatalSeverityForFutureUse() throws IOException {
+		JsonNode report = MAPPER.readTree(reportWithCode("unknown-model"));
+		((ObjectNode) report.at("/diagnostics/0")).put("severity", "fatal");
+
+		assertThat(SCHEMA.validate(report)).isEmpty();
+	}
+
+	@Test
+	void schemaRejectsAnUnknownSeverity() throws IOException {
+		JsonNode report = MAPPER.readTree(reportWithCode("unknown-model"));
+		((ObjectNode) report.at("/diagnostics/0")).put("severity", "warning");
+
+		assertThat(SCHEMA.validate(report)).isNotEmpty();
+	}
+
+	@Test
+	void schemaRejectsASynthesizedSymbolCarryingALocation() throws IOException {
+		JsonNode report = MAPPER.readTree(
+				reportOf(unitWithOneSymbol(), new CompilationContext("t.jd")));
+		ObjectNode symbol = (ObjectNode) report.at("/models/0/symbols/0");
+		symbol.put("synthesized", true);
+
+		assertThat(SCHEMA.validate(report))
+				.as("a synthesized element must not carry a location")
+				.isNotEmpty();
+	}
+
+	@Test
+	void schemaRejectsADiagnosticWithALineButNoColumn() throws IOException {
+		CompilationContext ctx = new CompilationContext("t.jd");
+		ctx.error(DiagnosticCodes.UNKNOWN_MODEL, 3, 1, "unknown model 'x'");
+		JsonNode report = MAPPER.readTree(reportOf(new Unit("t.jd"), ctx));
+		((ObjectNode) report.at("/diagnostics/0")).remove("column");
+
+		assertThat(SCHEMA.validate(report)).isNotEmpty();
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private void assertConforms(String json) {
+		Set<ValidationMessage> errors;
+		try {
+			errors = SCHEMA.validate(MAPPER.readTree(json));
+		} catch (IOException e) {
+			throw new AssertionError("report is not valid JSON", e);
+		}
+		assertThat(errors).as("schema violations in:%n%s", json).isEmpty();
+	}
+
+	private static String reportOf(Unit unit, CompilationContext ctx) {
+		return new CollectDiagnostics().andThen(new JsonDiagnosticReport())
+				.fire(unit, ctx);
+	}
+
+	private static String reportWithCode(String code) {
+		CompilationContext ctx = new CompilationContext("t.jd");
+		ctx.error(code, 1, 0, "a message");
+		return reportOf(new Unit("t.jd"), ctx);
+	}
+
+	private static Unit unitWithOneSymbol() {
+		Unit unit = new Unit("t.jd");
+		Justification j = new Justification("j");
+		j.setConclusion(new Conclusion("c", "A conclusion"));
+		unit.add(j);
+		unit.recordLocation("j", new SourceLocation("t.jd", 1, 0));
+		unit.recordLocation("j", "c", new SourceLocation("t.jd", 2, 3));
+		return unit;
+	}
+}

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportTest.java
@@ -1,0 +1,348 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_DEFERRALS;
+import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_MACROS;
+import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
+
+import ca.mcscert.jpipe.commands.Command;
+import ca.mcscert.jpipe.commands.ExecutedAction;
+import ca.mcscert.jpipe.commands.creation.CreateJustification;
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.DiagnosticCodes;
+import ca.mcscert.jpipe.model.Justification;
+import ca.mcscert.jpipe.model.SourceLocation;
+import ca.mcscert.jpipe.model.Template;
+import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Asserts on the parsed document rather than on substrings: the point of the
+ * JSON report is its structure, and a substring match would pass on malformed
+ * output.
+ */
+class JsonDiagnosticReportTest {
+
+	private JsonDiagnosticReport step;
+	private CompilationContext ctx;
+	private Unit unit;
+
+	@BeforeEach
+	void setUp() {
+		step = new JsonDiagnosticReport();
+		ctx = new CompilationContext("test.jd");
+		unit = new Unit("test.jd");
+	}
+
+	// -------------------------------------------------------------------------
+	// Document shape
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class Document {
+
+		@Test
+		void outputIsWellFormedJson() {
+			assertThat(report()).isNotNull();
+		}
+
+		@Test
+		void everySectionOfTheTextReportIsPresent() {
+			assertThat(report().keySet()).contains("schemaVersion", "source",
+					"status", "diagnostics", "stats", "models", "actions");
+		}
+
+		@Test
+		void schemaVersionIsDeclared() {
+			assertThat(report().getInt("schemaVersion"))
+					.isEqualTo(JsonDiagnosticReport.SCHEMA_VERSION);
+		}
+
+		@Test
+		void sourceIsTheCompiledFile() {
+			assertThat(report().getString("source")).isEqualTo("test.jd");
+		}
+
+		@Test
+		void statusIsOkWhenNothingWasReported() {
+			assertThat(report().getString("status")).isEqualTo("ok");
+		}
+
+		@Test
+		void statusIsErrorsWhenADiagnosticWasReported() {
+			ctx.error("something went wrong");
+			assertThat(report().getString("status")).isEqualTo("errors");
+		}
+
+		@Test
+		void markDiagnosticsRenderedIsCalled() {
+			report();
+			assertThat(ctx.diagnosticsRendered()).isTrue();
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Diagnostics
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class Diagnostics {
+
+		@Test
+		void codeIsASeparateFieldAndNotInlinedInTheMessage() {
+			ctx.error(DiagnosticCodes.UNKNOWN_MODEL, "unknown model 'foo'");
+
+			JSONObject d = report().getJSONArray("diagnostics")
+					.getJSONObject(0);
+
+			assertThat(d.getString("code")).isEqualTo("unknown-model");
+			assertThat(d.getString("message")).isEqualTo("unknown model 'foo'")
+					.doesNotContain("unknown-model");
+		}
+
+		@Test
+		void codeKeyIsAbsentWhenTheDiagnosticHasNoCode() {
+			ctx.error("something went wrong");
+
+			JSONObject d = report().getJSONArray("diagnostics")
+					.getJSONObject(0);
+
+			assertThat(d.has("code")).isFalse();
+		}
+
+		@Test
+		void locationKeysAreAbsentWhenThePositionIsUnknown() {
+			ctx.error("something went wrong");
+
+			JSONObject d = report().getJSONArray("diagnostics")
+					.getJSONObject(0);
+
+			assertThat(d.has("line")).isFalse();
+			assertThat(d.has("column")).isFalse();
+		}
+
+		@Test
+		void locationIsReportedWhenKnown() {
+			ctx.error(DiagnosticCodes.UNKNOWN_ELEMENT, 5, 10, "bad token");
+
+			JSONObject d = report().getJSONArray("diagnostics")
+					.getJSONObject(0);
+
+			assertThat(d.getInt("line")).isEqualTo(5);
+			assertThat(d.getInt("column")).isEqualTo(10);
+			assertThat(d.getString("source")).isEqualTo("test.jd");
+		}
+
+		@Test
+		void severityIsLowerCased() {
+			ctx.error("an error");
+			ctx.fatal("a fatal one");
+
+			JSONArray diagnostics = report().getJSONArray("diagnostics");
+
+			assertThat(diagnostics.getJSONObject(0).getString("severity"))
+					.isEqualTo("error");
+			assertThat(diagnostics.getJSONObject(1).getString("severity"))
+					.isEqualTo("fatal");
+		}
+
+		@Test
+		void diagnosticsKeepReportOrder() {
+			ctx.error("first");
+			ctx.error("second");
+
+			JSONArray diagnostics = report().getJSONArray("diagnostics");
+
+			assertThat(diagnostics.getJSONObject(0).getString("message"))
+					.isEqualTo("first");
+			assertThat(diagnostics.getJSONObject(1).getString("message"))
+					.isEqualTo("second");
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Statistics and actions
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class StatsAndActions {
+
+		@Test
+		void statsAreReadableUnconditionallyEvenWhenNoneWereRecorded() {
+			JSONObject stats = report().getJSONObject("stats");
+
+			assertThat(stats.getJSONObject("commands").getInt("total"))
+					.isZero();
+			assertThat(stats.getInt("deferrals")).isZero();
+		}
+
+		@Test
+		void recordedStatsAreReported() {
+			ctx.recordStat(STAT_COMMANDS_TOTAL, 5L);
+			ctx.recordStat(STAT_COMMANDS_MACROS, 2L);
+			ctx.recordStat(STAT_COMMANDS_DEFERRALS, 1L);
+
+			JSONObject stats = report().getJSONObject("stats");
+
+			assertThat(stats.getJSONObject("commands").getInt("total"))
+					.isEqualTo(5);
+			assertThat(stats.getJSONObject("commands").getInt("macros"))
+					.isEqualTo(2);
+			assertThat(stats.getInt("deferrals")).isEqualTo(1);
+		}
+
+		@Test
+		void actionsAreEmptyWhenNoneWereRecorded() {
+			assertThat(report().getJSONArray("actions")).isEmpty();
+		}
+
+		@Test
+		void actionsCarryIndexDepthAndMacroFlag() {
+			ctx.recordActions(
+					List.of(action(new CreateJustification("j1"), 0)));
+
+			JSONObject a = report().getJSONArray("actions").getJSONObject(0);
+
+			assertThat(a.getInt("index")).isEqualTo(1);
+			assertThat(a.getInt("depth")).isZero();
+			assertThat(a.getBoolean("macro")).isFalse();
+			assertThat(a.getString("description"))
+					.isEqualTo("create_justification('j1').");
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Models and symbols
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class Models {
+
+		@Test
+		void modelsAreEmptyForAnEmptyUnit() {
+			assertThat(report().getJSONArray("models")).isEmpty();
+		}
+
+		@Test
+		void justificationReportsItsKindAndElementCensus() {
+			Justification j = new Justification("j");
+			j.setConclusion(new Conclusion("c", "A conclusion"));
+			j.addElement(new Strategy("s", "A strategy"));
+			j.addElement(new Evidence("e", "An evidence"));
+			unit.add(j);
+
+			JSONObject model = report().getJSONArray("models").getJSONObject(0);
+
+			assertThat(model.getString("name")).isEqualTo("j");
+			assertThat(model.getString("kind")).isEqualTo("justification");
+			JSONObject elements = model.getJSONObject("elements");
+			assertThat(elements.getInt("conclusion")).isEqualTo(1);
+			assertThat(elements.getInt("strategy")).isEqualTo(1);
+			assertThat(elements.getInt("evidence")).isEqualTo(1);
+			assertThat(elements.getInt("subConclusion")).isZero();
+		}
+
+		@Test
+		void implementsKeyIsAbsentWhenTheModelImplementsNothing() {
+			unit.add(new Justification("j"));
+
+			JSONObject model = report().getJSONArray("models").getJSONObject(0);
+
+			assertThat(model.has("implements")).isFalse();
+		}
+
+		@Test
+		void templateAndItsImplementorAreLinkedBothWays() {
+			Template t = new Template("base");
+			unit.add(t);
+			Justification j = new Justification("impl");
+			j.inline(t, "base");
+			unit.add(j);
+
+			JSONArray models = report().getJSONArray("models");
+			JSONObject template = byName(models, "base");
+			JSONObject impl = byName(models, "impl");
+
+			assertThat(template.getString("kind")).isEqualTo("template");
+			assertThat(template.getJSONArray("usedBy").getJSONObject(0)
+					.getString("name")).isEqualTo("impl");
+			assertThat(impl.getString("implements")).isEqualTo("base");
+		}
+
+		@Test
+		void symbolCarriesIdKindAndLocation() {
+			Justification j = new Justification("j");
+			j.setConclusion(new Conclusion("c", "A conclusion"));
+			unit.add(j);
+			unit.recordLocation("j", new SourceLocation("test.jd", 1, 1));
+			unit.recordLocation("j", "c", new SourceLocation("test.jd", 2, 3));
+
+			JSONObject symbol = report().getJSONArray("models").getJSONObject(0)
+					.getJSONArray("symbols").getJSONObject(0);
+
+			assertThat(symbol.getString("id")).isEqualTo("c");
+			assertThat(symbol.getString("kind")).isEqualTo("conclusion");
+			assertThat(symbol.getBoolean("synthesized")).isFalse();
+			assertThat(symbol.getJSONObject("location").getInt("line"))
+					.isEqualTo(2);
+			assertThat(symbol.getJSONObject("location").getInt("column"))
+					.isEqualTo(3);
+		}
+
+		@Test
+		void synthesizedSymbolIsFlaggedAndHasNoLocation() {
+			Justification j = new Justification("j");
+			j.setConclusion(new Conclusion("c", "A conclusion"));
+			unit.add(j);
+
+			JSONObject symbol = report().getJSONArray("models").getJSONObject(0)
+					.getJSONArray("symbols").getJSONObject(0);
+
+			assertThat(symbol.getBoolean("synthesized")).isTrue();
+			assertThat(symbol.has("location")).isFalse();
+		}
+
+		@Test
+		void aliasesAreReportedAsFromToPairs() {
+			unit.add(new Justification("j"));
+			unit.recordAlias("j", "oldId", "newId");
+
+			JSONObject alias = report().getJSONArray("models").getJSONObject(0)
+					.getJSONArray("aliases").getJSONObject(0);
+
+			assertThat(alias.getString("from")).isEqualTo("oldId");
+			assertThat(alias.getString("to")).isEqualTo("newId");
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private JSONObject report() {
+		return new JSONObject(
+				step.run(new CollectDiagnostics().run(unit, ctx), ctx));
+	}
+
+	private static JSONObject byName(JSONArray models, String name) {
+		for (int i = 0; i < models.length(); i++) {
+			JSONObject model = models.getJSONObject(i);
+			if (name.equals(model.getString("name"))) {
+				return model;
+			}
+		}
+		throw new AssertionError("no model named " + name);
+	}
+
+	private static ExecutedAction action(Command command, int depth) {
+		return new ExecutedAction(command, depth);
+	}
+}

--- a/jpipe-compiler/src/test/resources/features/diagnostic.feature
+++ b/jpipe-compiler/src/test/resources/features/diagnostic.feature
@@ -1,0 +1,62 @@
+Feature: Reporting on a compilation unit
+
+  The diagnostic report describes a compilation without exporting any model.
+  It is rendered either as human-readable text or as JSON for tooling; both
+  formats are built from the same collected snapshot, so they always describe
+  the same compilation.
+
+  Scenario: The text report describes a clean compilation section by section
+    Given the source file "000_minimal.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+    When I produce a text diagnostic report
+    Then the text report contains "=== Diagnostics ==="
+      And the text report contains "(none)"
+      And the text report contains "=== Model Summary ==="
+      And the text report contains "justification \"minimal\""
+      And the text report contains "=== Symbol Table ==="
+      And the text report contains "=== Executed Actions ==="
+
+  Scenario: The JSON report describes a clean compilation
+    Given the source file "000_minimal.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+    When I produce a JSON diagnostic report
+    Then the JSON report declares a schema version
+      And the JSON report status is "ok"
+      And the JSON report describes a "justification" named "minimal"
+
+  Scenario: The JSON report exposes validation rules as machine-readable codes
+    Given the source file "invalid/000_duplicate_ids.jd"
+    When I compile it into a unit
+    Then the compilation has validation errors
+    When I produce a JSON diagnostic report
+    Then the JSON report status is "errors"
+      And the JSON report has a diagnostic with code "no-duplicate-ids"
+      And no JSON diagnostic message contains its own code
+
+  Scenario: Compiler diagnostics carry their code as data too
+    Given the source file "invalid/003_unknown_symbol.jd"
+    When I compile it into a unit
+    Then the compilation has validation errors
+    When I produce a JSON diagnostic report
+    Then the JSON report has a diagnostic with code "unknown-element"
+      And no JSON diagnostic message contains its own code
+
+  Scenario: Both renderings describe the same compilation
+    Given the source file "invalid/002_unsupported_elements.jd"
+    When I compile it into a unit
+    Then the compilation has validation errors
+    When I produce a text diagnostic report
+      And I produce a JSON diagnostic report
+    Then both reports agree on the number of diagnostics
+      And the text report contains "[conclusion-supported]"
+      And the JSON report has a diagnostic with code "conclusion-supported"
+
+  Scenario: A template and its implementors appear in the JSON report
+    Given the source file "004_template.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+    When I produce a JSON diagnostic report
+    Then the JSON report describes a "template" named "t"
+      And the JSON report status is "ok"

--- a/jpipe-lang/pom.xml
+++ b/jpipe-lang/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-lang</artifactId>

--- a/jpipe-model/pom.xml
+++ b/jpipe-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-model</artifactId>

--- a/jpipe-operators/pom.xml
+++ b/jpipe-operators/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-operators</artifactId>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ extra_css:
 nav:
   - Home: index.md
   - API Reference: api-reference.md
+  - Releasing: releasing.md
   - Design:
       - design/language.md
       - design/model.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - design/steps.md
       - design/operators.md
       - design/cli.md
+      - design/diagnostic-schema.md
   - Architecture Decisions:
       - adr/0001-semver-versioning.md
       - adr/0002-multi-module-structure.md

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <jacoco-plugin.version>0.8.15</jacoco-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <sonar-plugin.version>5.7.0.6970</sonar-plugin.version>
+        <versions-plugin.version>2.21.0</versions-plugin.version>
 
         <!-- SonarCloud -->
         <sonar.projectKey>jpipe-mcscert_jpipe-compiler</sonar.projectKey>
@@ -318,6 +319,14 @@
                             <phase>verify</phase>
                         </execution>
                     </executions>
+                </plugin>
+
+                <!-- Used by scripts/release.sh and by release.yml; pinned so a
+                     release never depends on whatever version resolves today. -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${versions-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jpipe</groupId>
     <artifactId>jpipe</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>jPipe</name>

--- a/pom.xml
+++ b/pom.xml
@@ -75,22 +75,22 @@
         <!-- Dependency versions -->
         <antlr4.version>4.13.2</antlr4.version>
         <picocli.version>4.7.7</picocli.version>
-        <json.version>20260522</json.version>
-        <json-schema-validator.version>1.5.6</json-schema-validator.version>
-        <log4j.version>2.24.3</log4j.version>
-        <junit.version>5.14.2</junit.version>
-        <junit-platform.version>1.14.2</junit-platform.version>
-        <assertj.version>3.27.3</assertj.version>
-        <cucumber.version>7.34.4</cucumber.version>
+        <json.version>20260719</json.version>
+        <json-schema-validator.version>1.5.9</json-schema-validator.version>
+        <log4j.version>2.26.1</log4j.version>
+        <junit.version>5.14.4</junit.version>
+        <junit-platform.version>1.14.4</junit-platform.version>
+        <assertj.version>3.27.7</assertj.version>
+        <cucumber.version>7.34.6</cucumber.version>
 
         <!-- Plugin versions -->
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <log4j-transform.version>0.1.0</log4j-transform.version>
-        <spotless-plugin.version>3.8.0</spotless-plugin.version>
+        <spotless-plugin.version>3.9.0</spotless-plugin.version>
         <checkstyle-plugin.version>3.6.0</checkstyle-plugin.version>
-        <checkstyle.version>13.8.0</checkstyle.version>
+        <checkstyle.version>13.10.0</checkstyle.version>
         <jacoco-plugin.version>0.8.15</jacoco-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <sonar-plugin.version>5.7.0.6970</sonar-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <antlr4.version>4.13.2</antlr4.version>
         <picocli.version>4.7.7</picocli.version>
         <json.version>20260522</json.version>
+        <json-schema-validator.version>1.5.6</json-schema-validator.version>
         <log4j.version>2.24.3</log4j.version>
         <junit.version>5.14.2</junit.version>
         <junit-platform.version>1.14.2</junit-platform.version>
@@ -144,6 +145,17 @@
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>${json.version}</version>
+            </dependency>
+            <!--
+              Test scope only: the published JSON Schema is validated against
+              real compiler output in CI, never at runtime. Keeping it out of
+              compile scope also keeps its Jackson dependency out of the fat JAR.
+            -->
+            <dependency>
+                <groupId>com.networknt</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${json-schema-validator.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- Logging -->

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,6 +18,7 @@ REPO_URL_FALLBACK="https://github.com/jpipe-mcscert/jpipe-compiler"
 
 DRY_RUN=0
 FAILURES=0
+ON_MAIN=0
 
 # ----------------------------------------------------------------------------
 # output helpers
@@ -118,13 +119,16 @@ check_branch_is() {
 }
 
 check_in_sync() {
-  local branch upstream
+  local branch upstream remote
   branch=$(current_branch)
   if ! upstream=$(git rev-parse --abbrev-ref "@{upstream}" 2>/dev/null); then
     warn "$branch has no upstream — cannot check whether it is current"
     return
   fi
-  git fetch --quiet origin
+  # Refresh the remote the branch actually tracks, which is not necessarily
+  # origin — otherwise a stale ref reads as "in sync".
+  remote=${upstream%%/*}
+  git fetch --quiet "$remote"
   if [ "$(git rev-parse HEAD)" = "$(git rev-parse "$upstream")" ]; then
     pass "$branch is in sync with $upstream"
   elif git merge-base --is-ancestor "$upstream" HEAD; then
@@ -138,6 +142,7 @@ check_in_sync() {
 check_on_main() {
   git fetch --quiet origin main
   if git merge-base --is-ancestor HEAD origin/main; then
+    ON_MAIN=1
     pass "HEAD is on main — release.yml's branch check will pass"
   else
     warn "HEAD is not on main yet — merge the dev → main release PR before tagging"
@@ -241,9 +246,14 @@ cmd_preflight() {
     printf '\n%s%d check(s) failed.%s Fix them before tagging.\n' "$C_RED" "$FAILURES" "$C_OFF"
     exit 1
   fi
-  printf '\n%sReady.%s Next: merge the dev → main PR, then tag on main:\n' "$C_GREEN" "$C_OFF"
-  printf '  git switch main && git pull --ff-only\n'
-  printf '  git tag v%s && git push origin v%s\n' "$version" "$version"
+  if [ "$ON_MAIN" -eq 1 ]; then
+    printf '\n%sReady to tag.%s This is the last check before the release fires:\n' "$C_GREEN" "$C_OFF"
+    printf '  git tag v%s && git push origin v%s\n' "$version" "$version"
+  else
+    printf '\n%sReady.%s Next: merge the dev → main PR, then re-run this on main:\n' "$C_GREEN" "$C_OFF"
+    printf '  git switch main && git pull --ff-only\n'
+    printf '  scripts/release.sh preflight %s\n' "$version"
+  fi
 }
 
 rewrite_changelog() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+#
+# release.sh — drive a jPipe release from the command line.
+#
+# Three verbs, matching the phases in docs/releasing.md:
+#
+#   preflight X.Y.Z          re-run release.yml's checks locally, before the tag exists
+#   prepare   X.Y.Z          set the pom version and close out the changelog, on dev
+#   post-release X.Y.Z-SNAPSHOT   bump to the next development version, on dev
+#
+# The script never merges a branch, never creates or pushes a tag, and never
+# pushes anything. Those stay human actions (see CLAUDE.md).
+
+set -euo pipefail
+
+MVN=${MVN:-mvn}
+REPO_URL_FALLBACK="https://github.com/jpipe-mcscert/jpipe-compiler"
+
+DRY_RUN=0
+FAILURES=0
+
+# ----------------------------------------------------------------------------
+# output helpers
+# ----------------------------------------------------------------------------
+
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'
+  C_BOLD=$'\033[1m'; C_OFF=$'\033[0m'
+else
+  C_RED=''; C_GREEN=''; C_YELLOW=''; C_BOLD=''; C_OFF=''
+fi
+
+pass() { printf '  %sok%s   %s\n' "$C_GREEN" "$C_OFF" "$1"; }
+warn() { printf '  %swarn%s %s\n' "$C_YELLOW" "$C_OFF" "$1"; }
+fail() { printf '  %sFAIL%s %s\n' "$C_RED" "$C_OFF" "$1"; FAILURES=$((FAILURES + 1)); }
+head2() { printf '\n%s%s%s\n' "$C_BOLD" "$1" "$C_OFF"; }
+die() { printf '%serror:%s %s\n' "$C_RED" "$C_OFF" "$1" >&2; exit 1; }
+note() { printf '       %s\n' "$1"; }
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release.sh <verb> [options]
+
+Verbs:
+  preflight X.Y.Z            Check that everything release.yml validates would pass,
+                             before the tag exists. Read-only. Runs `mvn verify`.
+  prepare X.Y.Z              On dev: set the pom to X.Y.Z-SNAPSHOT, close out the
+                             CHANGELOG [Unreleased] section, verify, and commit.
+  post-release X.Y.Z-SNAPSHOT
+                             On dev, after main has been merged back: set the next
+                             development version and commit.
+
+Options:
+  --dry-run                  Show what would change without writing anything
+                             (prepare and post-release only).
+  --skip-verify              Skip `mvn verify` (preflight and prepare).
+  -h, --help                 This message.
+
+The full runbook is in docs/releasing.md.
+EOF
+}
+
+# ----------------------------------------------------------------------------
+# small utilities
+# ----------------------------------------------------------------------------
+
+# A release version: X.Y.Z, optionally with a pre-release suffix (2.4.0-rc1).
+valid_version() {
+  printf '%s' "$1" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+}
+
+pom_version() {
+  "$MVN" -B -q help:evaluate -Dexpression=project.version -DforceStdout 2>/dev/null | tail -1
+}
+
+current_branch() {
+  git rev-parse --abbrev-ref HEAD
+}
+
+# Content of the CHANGELOG [Unreleased] section, blank lines stripped.
+unreleased_body() {
+  awk '
+    /^## \[Unreleased\]/ { inside = 1; next }
+    inside && /^---[[:space:]]*$/ { exit }
+    inside && NF { print }
+  ' CHANGELOG.md
+}
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  %s[dry-run]%s %s\n' "$C_YELLOW" "$C_OFF" "$*"
+  else
+    "$@"
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# individual checks
+# ----------------------------------------------------------------------------
+
+check_clean_tree() {
+  if [ -n "$(git status --porcelain)" ]; then
+    fail "working tree is dirty — commit or stash first"
+    git status --short | sed 's/^/       /'
+  else
+    pass "working tree is clean"
+  fi
+}
+
+check_branch_is() {
+  local expected=$1 actual
+  actual=$(current_branch)
+  if [ "$actual" = "$expected" ]; then
+    pass "on branch $expected"
+  else
+    fail "on branch $actual, expected $expected"
+  fi
+}
+
+check_in_sync() {
+  local branch upstream
+  branch=$(current_branch)
+  if ! upstream=$(git rev-parse --abbrev-ref "@{upstream}" 2>/dev/null); then
+    warn "$branch has no upstream — cannot check whether it is current"
+    return
+  fi
+  git fetch --quiet origin
+  if [ "$(git rev-parse HEAD)" = "$(git rev-parse "$upstream")" ]; then
+    pass "$branch is in sync with $upstream"
+  elif git merge-base --is-ancestor "$upstream" HEAD; then
+    warn "$branch is ahead of $upstream — remember to push"
+  else
+    fail "$branch is behind or diverged from $upstream — pull first"
+  fi
+}
+
+# release.yml:22-28 — the tag must point at a commit on main.
+check_on_main() {
+  git fetch --quiet origin main
+  if git merge-base --is-ancestor HEAD origin/main; then
+    pass "HEAD is on main — release.yml's branch check will pass"
+  else
+    warn "HEAD is not on main yet — merge the dev → main release PR before tagging"
+    note "release.yml refuses a tag that is not an ancestor of main"
+  fi
+}
+
+# release.yml:50-58 — the tag base must equal the pom version with -SNAPSHOT stripped.
+check_version_matches_pom() {
+  local version=$1 pom base
+  pom=$(pom_version)
+  pom=${pom%-SNAPSHOT}
+  base=${version%%-*}
+  if [ "$base" = "$pom" ]; then
+    pass "pom version ($pom) matches tag base ($base)"
+  else
+    fail "pom version is $pom but tag v$version has base $base"
+    note "release.yml performs this exact comparison, and fails after the tag is pushed"
+    note "fix with: scripts/release.sh prepare $base"
+  fi
+}
+
+check_tag_absent() {
+  local version=$1
+  if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+    fail "tag v$version already exists locally"
+  elif [ -n "$(git ls-remote --tags origin "refs/tags/v$version" 2>/dev/null)" ]; then
+    fail "tag v$version already exists on origin"
+  else
+    pass "tag v$version does not exist yet"
+  fi
+}
+
+check_changelog_closed() {
+  local version=$1
+  if grep -q "^## \[$version\] — " CHANGELOG.md; then
+    pass "CHANGELOG has a [$version] section"
+  else
+    fail "CHANGELOG has no '## [$version] — <date>' section"
+    note "run: scripts/release.sh prepare $version"
+  fi
+
+  if grep -q "^\[$version\]: " CHANGELOG.md; then
+    pass "CHANGELOG has a [$version] compare link"
+  else
+    fail "CHANGELOG has no '[$version]:' compare link at the bottom"
+  fi
+
+  if [ -z "$(unreleased_body)" ]; then
+    pass "CHANGELOG [Unreleased] is empty"
+  else
+    fail "CHANGELOG [Unreleased] still has entries — they would ship unlisted"
+  fi
+}
+
+check_build() {
+  local log
+  if [ "${SKIP_VERIFY:-0}" -eq 1 ]; then
+    warn "skipping mvn verify (--skip-verify)"
+    return
+  fi
+  log=$(mktemp -t jpipe-release-verify)
+  printf '  ..   running mvn verify (this takes a while)\n'
+  if "$MVN" -B verify >"$log" 2>&1; then
+    pass "mvn verify is green"
+    rm -f "$log"
+  else
+    fail "mvn verify failed — full log in $log"
+    tail -20 "$log" | sed 's/^/       /'
+  fi
+}
+
+print_manual_checklist() {
+  head2 "Manual checks — these are required, not optional housekeeping"
+  cat <<'EOF'
+  [ ] Dependency review: `mvn versions:display-dependency-updates` (ADR-0007)
+  [ ] Ubuntu series matrix in .github/workflows/release.yml still matches the
+      policy in ADR-0023 — add a series entering support, drop one past EOL
+  [ ] Windows/Scoop smoke test — CI cannot run it (ADR-0025)
+  [ ] The version number matches what [Unreleased] actually contains (ADR-0001)
+EOF
+}
+
+# ----------------------------------------------------------------------------
+# verbs
+# ----------------------------------------------------------------------------
+
+cmd_preflight() {
+  local version=$1
+  head2 "Preflight for v$version"
+  check_clean_tree
+  check_in_sync
+  check_on_main
+  check_version_matches_pom "$version"
+  check_tag_absent "$version"
+  check_changelog_closed "${version%%-*}"
+  check_build
+  print_manual_checklist
+
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n%s%d check(s) failed.%s Fix them before tagging.\n' "$C_RED" "$FAILURES" "$C_OFF"
+    exit 1
+  fi
+  printf '\n%sReady.%s Next: merge the dev → main PR, then tag on main:\n' "$C_GREEN" "$C_OFF"
+  printf '  git switch main && git pull --ff-only\n'
+  printf '  git tag v%s && git push origin v%s\n' "$version" "$version"
+}
+
+rewrite_changelog() {
+  local version=$1 today=$2 tmp link base prev
+  today=${today:-$(date +%Y-%m-%d)}
+
+  link=$(grep -m1 '^\[Unreleased\]: ' CHANGELOG.md || true)
+  if [ -n "$link" ]; then
+    base=${link#*: }
+    base=${base%/compare/*}
+    prev=${link##*/compare/}
+    prev=${prev%%...*}
+  else
+    base=$REPO_URL_FALLBACK
+    prev=""
+  fi
+
+  tmp=$(mktemp)
+  awk -v ver="$version" -v today="$today" '
+    !swapped && /^## \[Unreleased\]$/ {
+      print "## [Unreleased]"
+      print ""
+      print "---"
+      print ""
+      print "## [" ver "] — " today
+      swapped = 1
+      next
+    }
+    { print }
+  ' CHANGELOG.md >"$tmp"
+
+  if [ -n "$prev" ]; then
+    awk -v ver="$version" -v base="$base" -v prev="$prev" '
+      /^\[Unreleased\]: / {
+        print "[Unreleased]: " base "/compare/v" ver "...HEAD"
+        print "[" ver "]: " base "/compare/" prev "...v" ver
+        next
+      }
+      { print }
+    ' "$tmp" >"$tmp.2" && mv "$tmp.2" "$tmp"
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  %s[dry-run]%s CHANGELOG.md would change:\n' "$C_YELLOW" "$C_OFF"
+    diff -u CHANGELOG.md "$tmp" | sed 's/^/       /' || true
+    rm -f "$tmp"
+  else
+    mv "$tmp" CHANGELOG.md
+    pass "CHANGELOG closed out as [$version] — $today"
+  fi
+}
+
+cmd_prepare() {
+  local version=$1 today
+  today=$(date +%Y-%m-%d)
+
+  case $version in
+    *-*) die "prepare takes a plain X.Y.Z; a pre-release tag (v$version) is cut from an already-prepared version" ;;
+  esac
+
+  head2 "Preparing the $version release"
+  check_clean_tree
+  check_branch_is dev
+  check_in_sync
+  check_tag_absent "$version"
+
+  if [ -z "$(unreleased_body)" ]; then
+    fail "CHANGELOG [Unreleased] is empty — there is nothing to release"
+  else
+    pass "CHANGELOG [Unreleased] has entries"
+  fi
+
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n%s%d check(s) failed.%s Nothing was changed.\n' "$C_RED" "$FAILURES" "$C_OFF"
+    exit 1
+  fi
+
+  head2 "Applying"
+  # The root pom is also the parent of every module, so a plain versions:set
+  # rewrites all six poms; -DprocessAllModules is not needed here.
+  run "$MVN" -B -q versions:set "-DnewVersion=$version-SNAPSHOT" -DgenerateBackupPoms=false
+  [ "$DRY_RUN" -eq 1 ] || pass "pom version set to $version-SNAPSHOT"
+  rewrite_changelog "$version" "$today"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n%sDry run — nothing was written.%s\n' "$C_YELLOW" "$C_OFF"
+    return
+  fi
+
+  check_build
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n%sBuild failed.%s The working tree holds the prepared changes; fix and commit yourself.\n' \
+      "$C_RED" "$C_OFF"
+    exit 1
+  fi
+
+  git add CHANGELOG.md pom.xml ./*/pom.xml
+  git commit -q -m "chore: prepare the $version release"
+  pass "committed: chore: prepare the $version release"
+
+  print_manual_checklist
+  printf '\n%sPrepared.%s Next:\n' "$C_GREEN" "$C_OFF"
+  printf '  git push                                  # straight to dev, no PR needed\n'
+  printf '  scripts/release.sh preflight %s\n' "$version"
+  printf '  then open the dev → main release PR\n'
+}
+
+cmd_post_release() {
+  local next=$1
+  case $next in
+    *-SNAPSHOT) : ;;
+    *) die "post-release takes the next development version, e.g. 2.4.1-SNAPSHOT" ;;
+  esac
+  valid_version "$next" || die "not a valid version: $next"
+
+  head2 "Bumping to $next"
+  check_clean_tree
+  check_branch_is dev
+  check_in_sync
+
+  git fetch --quiet origin main
+  if git merge-base --is-ancestor origin/main HEAD; then
+    pass "main has been merged back into dev"
+  else
+    fail "main is not merged back into dev yet"
+    note "run: git merge origin/main"
+  fi
+
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n%s%d check(s) failed.%s Nothing was changed.\n' "$C_RED" "$FAILURES" "$C_OFF"
+    exit 1
+  fi
+
+  head2 "Applying"
+  run "$MVN" -B -q versions:set "-DnewVersion=$next" -DgenerateBackupPoms=false
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '\n%sDry run — nothing was written.%s\n' "$C_YELLOW" "$C_OFF"
+    return
+  fi
+  pass "pom version set to $next"
+
+  git add pom.xml ./*/pom.xml
+  git commit -q -m "chore: bump to $next"
+  pass "committed: chore: bump to $next"
+  printf '\n%sDone.%s Push straight to dev — no PR needed for a version bump.\n' "$C_GREEN" "$C_OFF"
+}
+
+# ----------------------------------------------------------------------------
+# entry point
+# ----------------------------------------------------------------------------
+
+main() {
+  local verb="" version="" arg
+  SKIP_VERIFY=0
+
+  for arg in "$@"; do
+    case $arg in
+      --dry-run) DRY_RUN=1 ;;
+      --skip-verify) SKIP_VERIFY=1 ;;
+      -h|--help) usage; exit 0 ;;
+      -*) die "unknown option: $arg" ;;
+      *)
+        if [ -z "$verb" ]; then verb=$arg
+        elif [ -z "$version" ]; then version=$arg
+        else die "unexpected argument: $arg"
+        fi
+        ;;
+    esac
+  done
+
+  [ -n "$verb" ] || { usage; exit 1; }
+
+  cd "$(git rev-parse --show-toplevel)" ||
+    die "not inside a git repository"
+  command -v "$MVN" >/dev/null || die "maven not found on PATH"
+
+  version=${version#v}
+  case $verb in
+    preflight|prepare)
+      [ -n "$version" ] || die "$verb needs a version, e.g. scripts/release.sh $verb 2.4.0"
+      valid_version "$version" || die "not a valid version: $version"
+      ;;
+    post-release)
+      [ -n "$version" ] || die "post-release needs the next version, e.g. 2.4.1-SNAPSHOT"
+      ;;
+  esac
+
+  case $verb in
+    preflight) cmd_preflight "$version" ;;
+    prepare) cmd_prepare "$version" ;;
+    post-release) cmd_post_release "$version" ;;
+    *) die "unknown verb: $verb (expected preflight, prepare or post-release)" ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
This pull request updates documentation and configuration to clarify and automate the release workflow, improve CI efficiency, and document new diagnostic reporting features. The most important changes are summarized below.

---

**Release workflow and branching model improvements:**

* Updated `README.md` and `CLAUDE.md` to clarify the branching model: `main` is release-only, `dev` is for integration, and low-risk changes may be pushed directly to `dev` by human authors, while all feature work still branches from `dev`. The release process is now fully documented and automated with `scripts/release.sh`, and only `main` requires a pull request. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R137) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L8-R8) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L24-R36) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L244-R255)
* The release procedure in `README.md` now references the full checklist in `docs/releasing.md`, and describes the new release automation script and pipeline triggers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R137) [[3]](diffhunk://#diff-4c558b33df7ebd1f454cc09262ebb1e1bdc3ef3f217760b29baeeea6048f2a12L98-R112)
* The repository structure is updated to include the new `scripts` directory for maintainer tooling.

**Continuous integration improvements:**

* The GitHub Actions workflow (`.github/workflows/build.yml`) now only triggers on pushes to `main` and `dev` (not all branches), and uses concurrency settings to avoid duplicate builds for pull requests.
* The documentation workflow (`.github/workflows/docs.yml`) now stages the diagnostic report JSON Schema in the published docs, ensuring a single source of truth for consumers.

**Diagnostic reporting enhancements:**

* Added a new `2.4.0` release section to `CHANGELOG.md`, documenting that the `jpipe diagnostic` command now supports JSON output with machine-readable codes, and that a published JSON Schema documents the report structure. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR23-R56) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL294-R329)
* Updated ADR-0016 (`docs/adr/0016-error-management.md`) to specify that diagnostics now carry a machine-readable code as a distinct field, not as a message prefix, for better tool integration and stability. [[1]](diffhunk://#diff-545d2e9061ee735b2195382162065f1b8048bd9e8dddbec8260f33a16bd2ba51L1-R4) [[2]](diffhunk://#diff-545d2e9061ee735b2195382162065f1b8048bd9e8dddbec8260f33a16bd2ba51R19-R22) [[3]](diffhunk://#diff-545d2e9061ee735b2195382162065f1b8048bd9e8dddbec8260f33a16bd2ba51R49-R74) [[4]](diffhunk://#diff-545d2e9061ee735b2195382162065f1b8048bd9e8dddbec8260f33a16bd2ba51R131-R135) [[5]](diffhunk://#diff-545d2e9061ee735b2195382162065f1b8048bd9e8dddbec8260f33a16bd2ba51R148-R153)

**User documentation updates:**

* Improved installation and usage instructions in `README.md`, including new examples for JSON diagnostic output and clearer guidance on verifying installations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R177-R179) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R137)

**Release versioning and changelog links:**

* Updated changelog comparison links to reference the new `2.4.0` release.

---

These changes together improve the clarity, automation, and reliability of the release process, enhance diagnostic tooling support, and streamline CI/CD operations.