### PR TITLE
Display Graphviz version in `jpipe doctor` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- `jpipe doctor` now reports the version of each external tool it finds
+  (e.g. `dot (Graphviz): OK (version 12.2.1)`). Some operating systems ship an
+  outdated Graphviz, which is a common explanation for rendering problems.
+
 ---
 
 ## [2.4.0] — 2026-08-10

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -46,7 +46,9 @@ package "cli" {
   }
 
   class Doctor <<utility>> {
-    + {static} run() : boolean
+    + {static} run(PrintStream) : boolean
+    ~ {static} probe(String[]) : Optional<String>
+    ~ {static} statusLine(String, Optional<String>) : String
     ~ {static} describe(String) : String
   }
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -47,6 +47,7 @@ package "cli" {
 
   class Doctor <<utility>> {
     + {static} run() : boolean
+    ~ {static} describe(String) : String
   }
 
   class Logo <<utility>> {
@@ -194,9 +195,17 @@ prints a status line for each. Also prints the jPipe version number.
 jpipe doctor
 ```
 
+```
+  dot (Graphviz): OK (version 12.2.1)
+```
+
 Currently checks: `dot` (Graphviz). A tool is considered available if the OS
-can launch the executable; the exit code of the probe is ignored. Returns exit
-code `0` if all tools are found, `1` otherwise.
+can launch the executable; the exit code of the probe is ignored. The probe
+output is scanned for a version number, which is reported next to the status —
+several operating systems ship an outdated Graphviz, and that shows up as
+rendering bugs. When no version can be read out of the banner, the status line
+reads `OK (version unknown)`. Returns exit code `0` if all tools are found, `1`
+otherwise.
 
 ## Shared infrastructure
 

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
@@ -43,17 +43,23 @@ final class Doctor {
 	 *         missing.
 	 */
 	static boolean run() {
+		return run(TOOLS);
+	}
+
+	/**
+	 * Probes the given tools and prints a status line for each.
+	 *
+	 * @param tools
+	 *            the tools to probe, mapping a name to its probe command.
+	 * @return {@code true} if every tool is available, {@code false} if any is
+	 *         missing.
+	 */
+	static boolean run(Map<String, String[]> tools) {
 		boolean allOk = true;
-		for (Map.Entry<String, String[]> entry : TOOLS.entrySet()) {
-			String name = entry.getKey();
+		for (Map.Entry<String, String[]> entry : tools.entrySet()) {
 			Optional<String> banner = probe(entry.getValue());
-			if (banner.isPresent()) {
-				System.out.println(
-						"  " + name + ": OK (" + describe(banner.get()) + ")");
-			} else {
-				System.out.println("  " + name + ": NOT FOUND");
-				allOk = false;
-			}
+			System.out.println(statusLine(entry.getKey(), banner));
+			allOk = allOk && banner.isPresent();
 		}
 		return allOk;
 	}
@@ -61,27 +67,41 @@ final class Doctor {
 	/**
 	 * Runs a probe command and captures what it printed.
 	 *
+	 * <p>
+	 * The probe output is read to end-of-file, which the tool reaches when it
+	 * terminates; its exit code is deliberately ignored.
+	 *
 	 * @param command
 	 *            the command to run.
 	 * @return the (possibly empty) probe output, or {@link Optional#empty()} if
 	 *         the executable could not be launched.
 	 */
-	private static Optional<String> probe(String[] command) {
+	static Optional<String> probe(String[] command) {
 		try {
 			Process p = new ProcessBuilder(command).redirectErrorStream(true)
 					.start();
-			String output;
 			try (InputStream in = p.getInputStream()) {
-				output = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+				return Optional.of(
+						new String(in.readAllBytes(), StandardCharsets.UTF_8));
 			}
-			p.waitFor();
-			return Optional.of(output);
-		} catch (InterruptedException _) {
-			Thread.currentThread().interrupt();
-			return Optional.empty();
 		} catch (IOException _) {
 			return Optional.empty();
 		}
+	}
+
+	/**
+	 * Builds the status line reported for a tool.
+	 *
+	 * @param name
+	 *            the human-readable tool name.
+	 * @param banner
+	 *            the probe output, empty if the tool could not be launched.
+	 * @return the line to print for that tool.
+	 */
+	static String statusLine(String name, Optional<String> banner) {
+		String status = banner.map(b -> "OK (" + describe(b) + ")")
+				.orElse("NOT FOUND");
+		return "  " + name + ": " + status;
 	}
 
 	/**

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
@@ -2,6 +2,7 @@ package ca.mcscert.jpipe.cli;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -11,7 +12,7 @@ import java.util.regex.Pattern;
 
 /**
  * Checks that external tools required by jPipe are available on {@code PATH}
- * and reports their status to standard output.
+ * and reports their status to a given stream.
  *
  * <p>
  * Each tool is probed by attempting to start a process. A tool is considered
@@ -37,28 +38,32 @@ final class Doctor {
 	}
 
 	/**
-	 * Probes all required external tools and prints a status line for each.
+	 * Probes all required external tools and reports a status line for each.
 	 *
+	 * @param out
+	 *            where the status lines are written.
 	 * @return {@code true} if every tool is available, {@code false} if any is
 	 *         missing.
 	 */
-	static boolean run() {
-		return run(TOOLS);
+	static boolean run(PrintStream out) {
+		return run(TOOLS, out);
 	}
 
 	/**
-	 * Probes the given tools and prints a status line for each.
+	 * Probes the given tools and reports a status line for each.
 	 *
 	 * @param tools
 	 *            the tools to probe, mapping a name to its probe command.
+	 * @param out
+	 *            where the status lines are written.
 	 * @return {@code true} if every tool is available, {@code false} if any is
 	 *         missing.
 	 */
-	static boolean run(Map<String, String[]> tools) {
+	static boolean run(Map<String, String[]> tools, PrintStream out) {
 		boolean allOk = true;
 		for (Map.Entry<String, String[]> entry : tools.entrySet()) {
 			Optional<String> banner = probe(entry.getValue());
-			System.out.println(statusLine(entry.getKey(), banner));
+			out.println(statusLine(entry.getKey(), banner));
 			allOk = allOk && banner.isPresent();
 		}
 		return allOk;
@@ -69,7 +74,9 @@ final class Doctor {
 	 *
 	 * <p>
 	 * The probe output is read to end-of-file, which the tool reaches when it
-	 * terminates; its exit code is deliberately ignored.
+	 * terminates; its exit code is deliberately ignored. A tool that starts but
+	 * whose output cannot be read is still reported as available, with an empty
+	 * banner.
 	 *
 	 * @param command
 	 *            the command to run.
@@ -77,15 +84,19 @@ final class Doctor {
 	 *         the executable could not be launched.
 	 */
 	static Optional<String> probe(String[] command) {
+		Process process;
 		try {
-			Process p = new ProcessBuilder(command).redirectErrorStream(true)
+			process = new ProcessBuilder(command).redirectErrorStream(true)
 					.start();
-			try (InputStream in = p.getInputStream()) {
-				return Optional.of(
-						new String(in.readAllBytes(), StandardCharsets.UTF_8));
-			}
 		} catch (IOException _) {
 			return Optional.empty();
+		}
+		try (InputStream in = process.getInputStream()) {
+			return Optional
+					.of(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+		} catch (IOException _) {
+			process.destroy();
+			return Optional.of("");
 		}
 	}
 

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
@@ -1,9 +1,13 @@
 package ca.mcscert.jpipe.cli;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Checks that external tools required by jPipe are available on {@code PATH}
@@ -12,12 +16,18 @@ import java.util.Map;
  * <p>
  * Each tool is probed by attempting to start a process. A tool is considered
  * available if the OS can locate and launch the executable, regardless of its
- * exit code.
+ * exit code. When the probe output advertises a version number, it is reported
+ * alongside the status: some operating systems ship outdated versions, which is
+ * a common source of rendering issues.
  */
 final class Doctor {
 
 	/** Maps a human-readable tool name to the command used to probe it. */
 	private static final Map<String, String[]> TOOLS = new LinkedHashMap<>();
+
+	/** Extracts a version number out of a {@code --version} style banner. */
+	private static final Pattern VERSION = Pattern
+			.compile("version\\s+v?(\\d[\\w.+-]*)", Pattern.CASE_INSENSITIVE);
 
 	static {
 		TOOLS.put("dot (Graphviz)", new String[]{"dot", "-V"});
@@ -36,9 +46,10 @@ final class Doctor {
 		boolean allOk = true;
 		for (Map.Entry<String, String[]> entry : TOOLS.entrySet()) {
 			String name = entry.getKey();
-			String[] command = entry.getValue();
-			if (isAvailable(command)) {
-				System.out.println("  " + name + ": OK");
+			Optional<String> banner = probe(entry.getValue());
+			if (banner.isPresent()) {
+				System.out.println(
+						"  " + name + ": OK (" + describe(banner.get()) + ")");
 			} else {
 				System.out.println("  " + name + ": NOT FOUND");
 				allOk = false;
@@ -47,18 +58,45 @@ final class Doctor {
 		return allOk;
 	}
 
-	private static boolean isAvailable(String[] command) {
+	/**
+	 * Runs a probe command and captures what it printed.
+	 *
+	 * @param command
+	 *            the command to run.
+	 * @return the (possibly empty) probe output, or {@link Optional#empty()} if
+	 *         the executable could not be launched.
+	 */
+	private static Optional<String> probe(String[] command) {
 		try {
 			Process p = new ProcessBuilder(command).redirectErrorStream(true)
 					.start();
-			p.getInputStream().transferTo(OutputStream.nullOutputStream());
+			String output;
+			try (InputStream in = p.getInputStream()) {
+				output = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+			}
 			p.waitFor();
-			return true;
+			return Optional.of(output);
 		} catch (InterruptedException _) {
 			Thread.currentThread().interrupt();
-			return false;
+			return Optional.empty();
 		} catch (IOException _) {
-			return false;
+			return Optional.empty();
 		}
+	}
+
+	/**
+	 * Turns a probe banner into a human-readable version description.
+	 *
+	 * @param banner
+	 *            the raw output captured from the probe command.
+	 * @return {@code "version X.Y.Z"}, or {@code "version unknown"} when the
+	 *         banner does not advertise one.
+	 */
+	static String describe(String banner) {
+		Matcher matcher = VERSION.matcher(banner);
+		if (matcher.find()) {
+			return "version " + matcher.group(1);
+		}
+		return "version unknown";
 	}
 }

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/DoctorCommand.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/DoctorCommand.java
@@ -26,6 +26,6 @@ class DoctorCommand implements Callable<Integer> {
 		}
 		System.out.println(spec.root().version()[0]);
 		System.out.println("Checking external tools:");
-		return Doctor.run() ? Main.EXIT_OK : Main.EXIT_JPIPE_ERROR;
+		return Doctor.run(System.out) ? Main.EXIT_OK : Main.EXIT_JPIPE_ERROR;
 	}
 }

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
@@ -3,14 +3,40 @@ package ca.mcscert.jpipe.cli;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class DoctorTest {
+
+	/** A name no executable on PATH is expected to have. */
+	private static final String MISSING_TOOL = "jpipe-no-such-tool-42";
+
+	/** The executable of the JVM running the tests: always available. */
+	private static String javaBinary() {
+		return System.getProperty("java.home") + File.separator + "bin"
+				+ File.separator + "java";
+	}
+
+	/** Runs the doctor on the given tools, capturing what it prints. */
+	private static String capturedRun(Map<String, String[]> tools) {
+		PrintStream original = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+		try {
+			Doctor.run(tools);
+		} finally {
+			System.setOut(original);
+		}
+		return captured.toString(StandardCharsets.UTF_8);
+	}
 
 	@Test
 	void run_returns_boolean() {
@@ -20,17 +46,62 @@ class DoctorTest {
 
 	@Test
 	void run_reports_a_status_line_per_tool() {
-		PrintStream original = System.out;
-		ByteArrayOutputStream captured = new ByteArrayOutputStream();
-		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
-		try {
-			Doctor.run();
-		} finally {
-			System.setOut(original);
-		}
-		assertThat(captured.toString(StandardCharsets.UTF_8))
-				.startsWith("  dot (Graphviz): ").containsPattern(
-						"dot \\(Graphviz\\): (OK \\(version .+\\)|NOT FOUND)");
+		String output = capturedRun(
+				Map.of("dot (Graphviz)", new String[]{"dot", "-V"}));
+		assertThat(output).startsWith("  dot (Graphviz): ").containsPattern(
+				"dot \\(Graphviz\\): (OK \\(version .+\\)|NOT FOUND)");
+	}
+
+	// The runtime tools are not guaranteed to be installed where the tests run,
+	// so the probe is exercised against the running JVM, which always is.
+
+	@Test
+	void run_reports_every_tool_and_fails_on_a_missing_one() {
+		Map<String, String[]> tools = new LinkedHashMap<>();
+		tools.put("java (JVM)", new String[]{javaBinary(), "-version"});
+		tools.put("ghost", new String[]{MISSING_TOOL});
+		String output = capturedRun(tools);
+		assertThat(output).contains("  java (JVM): OK (version ")
+				.contains("  ghost: NOT FOUND");
+	}
+
+	@Test
+	void run_succeeds_when_every_tool_is_available() {
+		boolean allOk = Doctor.run(
+				Map.of("java (JVM)", new String[]{javaBinary(), "-version"}));
+		assertThat(allOk).isTrue();
+	}
+
+	@Test
+	void run_fails_when_a_tool_is_missing() {
+		boolean allOk = Doctor.run(Map.of("ghost", new String[]{MISSING_TOOL}));
+		assertThat(allOk).isFalse();
+	}
+
+	@Test
+	void probe_captures_the_output_of_an_existing_tool() {
+		Optional<String> banner = Doctor
+				.probe(new String[]{javaBinary(), "-version"});
+		assertThat(banner).hasValueSatisfying(
+				b -> assertThat(b).containsIgnoringCase("version"));
+	}
+
+	@Test
+	void probe_is_empty_when_the_tool_cannot_be_launched() {
+		assertThat(Doctor.probe(new String[]{MISSING_TOOL})).isEmpty();
+	}
+
+	@Test
+	void statusLine_reports_the_version_of_an_available_tool() {
+		assertThat(Doctor.statusLine("dot (Graphviz)",
+				Optional.of("dot - graphviz version 12.2.1 (20241206.2353)")))
+				.isEqualTo("  dot (Graphviz): OK (version 12.2.1)");
+	}
+
+	@Test
+	void statusLine_reports_a_missing_tool() {
+		assertThat(Doctor.statusLine("dot (Graphviz)", Optional.empty()))
+				.isEqualTo("  dot (Graphviz): NOT FOUND");
 	}
 
 	@ParameterizedTest(name = "extracts {1} out of \"{0}\"")

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
@@ -2,7 +2,13 @@ package ca.mcscert.jpipe.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class DoctorTest {
 
@@ -10,5 +16,36 @@ class DoctorTest {
 	void run_returns_boolean() {
 		boolean result = Doctor.run();
 		assertThat(result).isIn(true, false);
+	}
+
+	@Test
+	void run_reports_a_status_line_per_tool() {
+		PrintStream original = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+		try {
+			Doctor.run();
+		} finally {
+			System.setOut(original);
+		}
+		assertThat(captured.toString(StandardCharsets.UTF_8))
+				.startsWith("  dot (Graphviz): ").containsPattern(
+						"dot \\(Graphviz\\): (OK \\(version .+\\)|NOT FOUND)");
+	}
+
+	@ParameterizedTest(name = "extracts {1} out of \"{0}\"")
+	@CsvSource({"dot - graphviz version 12.2.1 (20241206.2353), version 12.2.1",
+			"dot - graphviz version 2.43.0 (0), version 2.43.0",
+			"Graphviz VERSION v1.2.3-beta, version 1.2.3-beta"})
+	void describe_extracts_the_advertised_version(String banner,
+			String expected) {
+		assertThat(Doctor.describe(banner)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest(name = "falls back to unknown for \"{0}\"")
+	@ValueSource(strings = {"", "some tool with no version banner",
+			"version without a number"})
+	void describe_falls_back_when_no_version_is_advertised(String banner) {
+		assertThat(Doctor.describe(banner)).isEqualTo("version unknown");
 	}
 }

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -25,22 +26,31 @@ class DoctorTest {
 				+ File.separator + "java";
 	}
 
-	/** Runs the doctor on the given tools, capturing what it prints. */
+	/** Runs the doctor on the given tools, capturing what it reports. */
 	private static String capturedRun(Map<String, String[]> tools) {
-		PrintStream original = System.out;
 		ByteArrayOutputStream captured = new ByteArrayOutputStream();
-		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
-		try {
-			Doctor.run(tools);
-		} finally {
-			System.setOut(original);
+		try (PrintStream out = new PrintStream(captured, true,
+				StandardCharsets.UTF_8)) {
+			Doctor.run(tools, out);
 		}
 		return captured.toString(StandardCharsets.UTF_8);
 	}
 
+	/** Runs the doctor on the given tools, discarding what it reports. */
+	private static boolean silentRun(Map<String, String[]> tools) {
+		try (PrintStream out = new PrintStream(OutputStream.nullOutputStream(),
+				true, StandardCharsets.UTF_8)) {
+			return Doctor.run(tools, out);
+		}
+	}
+
 	@Test
 	void run_returns_boolean() {
-		boolean result = Doctor.run();
+		boolean result;
+		try (PrintStream out = new PrintStream(OutputStream.nullOutputStream(),
+				true, StandardCharsets.UTF_8)) {
+			result = Doctor.run(out);
+		}
 		assertThat(result).isIn(true, false);
 	}
 
@@ -67,14 +77,14 @@ class DoctorTest {
 
 	@Test
 	void run_succeeds_when_every_tool_is_available() {
-		boolean allOk = Doctor.run(
+		boolean allOk = silentRun(
 				Map.of("java (JVM)", new String[]{javaBinary(), "-version"}));
 		assertThat(allOk).isTrue();
 	}
 
 	@Test
 	void run_fails_when_a_tool_is_missing() {
-		boolean allOk = Doctor.run(Map.of("ghost", new String[]{MISSING_TOOL}));
+		boolean allOk = silentRun(Map.of("ghost", new String[]{MISSING_TOOL}));
 		assertThat(allOk).isFalse();
 	}
 


### PR DESCRIPTION
This pull request enhances the `jpipe doctor` command to report the version of each external tool it detects, improving diagnostics for users who may encounter issues due to outdated dependencies. It also refactors the underlying implementation to extract and display version information, and expands test coverage for these new behaviors.

**Enhancements to `jpipe doctor` reporting:**

* The `jpipe doctor` command now prints the version of each external tool it finds (e.g., `dot (Graphviz): OK (version 12.2.1)`), helping users identify outdated dependencies that may cause rendering issues. If the version cannot be determined, it reports `version unknown`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R25) [[2]](diffhunk://#diff-070c8bd29587a5ed7f11c2ce0e8453a6ae96dce536fa44a959fc2ae4f80cd670R198-R208)

**Implementation changes:**

* The `Doctor` class now probes each tool, captures its output, and extracts version information using a regular expression. The new `describe` method formats the version for display. [[1]](diffhunk://#diff-7f0c8f5015de1264d59421dab4624ccba83c3cb62e41d596f93e42a03b5ff821L15-R31) [[2]](diffhunk://#diff-7f0c8f5015de1264d59421dab4624ccba83c3cb62e41d596f93e42a03b5ff821L39-R52) [[3]](diffhunk://#diff-7f0c8f5015de1264d59421dab4624ccba83c3cb62e41d596f93e42a03b5ff821L50-R100)
* The CLI design documentation (`cli.md`) is updated to reflect the new status line format and version-reporting behavior. [[1]](diffhunk://#diff-070c8bd29587a5ed7f11c2ce0e8453a6ae96dce536fa44a959fc2ae4f80cd670R50) [[2]](diffhunk://#diff-070c8bd29587a5ed7f11c2ce0e8453a6ae96dce536fa44a959fc2ae4f80cd670R198-R208)

**Testing improvements:**

* Unit tests for the `Doctor` class now verify that the status line includes version information, and parameterized tests ensure correct extraction and fallback behavior for version banners. [[1]](diffhunk://#diff-3d24191d508d00678241346e0fa6fc6c47a564b2b622b664dca9761b216035efR5-R11) [[2]](diffhunk://#diff-3d24191d508d00678241346e0fa6fc6c47a564b2b622b664dca9761b216035efR20-R50)