### PR TITLE
Fix unification to be independent of source order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
   (e.g. `dot (Graphviz): OK (version 12.2.1)`). Some operating systems ship an
   outdated Graphviz, which is a common explanation for rendering problems.
 
+### Fixed
+- Composition operators are now commutative when unification merges elements
+  of different kinds: a claim that one model argues (a sub-conclusion) and
+  another asserts (an evidence) merges into a sub-conclusion whichever order
+  the sources are listed in. `assemble(a, b)` and `assemble(b, a)` previously
+  produced the same model only by luck, and the unlucky order failed to
+  compile at all (#156).
+- A unification group whose element kinds genuinely cannot be merged (e.g. the
+  assembled conclusion colliding with a source evidence) is now reported as
+  `incompatible-unification`, pointing at the operator call and naming both
+  elements and their shared label, instead of surfacing as an unexplained
+  `invalid-support` further down the build.
+
 ---
 
 ## [2.4.0] — 2026-08-10

--- a/docs/design/model.md
+++ b/docs/design/model.md
@@ -34,6 +34,7 @@ package "model.elements" {
   interface JustificationElement <<sealed>> {
     + id() : String
     + label() : String
+    + kind() : String
     + accept(JustificationVisitor<R>) : R
   }
 

--- a/docs/design/operators.md
+++ b/docs/design/operators.md
@@ -87,6 +87,25 @@ Controlled by two optional operator config parameters:
 | `unifyBy` | `"sameLabel"` | Name of the equivalence relation to use |
 | `unifyExclude` | *(empty)* | Comma-separated result-model element ids to exclude from unification |
 
+**Merging a group that mixes element kinds.** Because the default relation
+compares labels, a group can legitimately hold elements of different kinds:
+one source argued a claim (a sub-conclusion) while another still asserts it
+(an evidence). The merged element is built from the group's *dominant*
+member, not from whichever member appears first in the command list, so the
+result does not depend on the order the sources were listed in:
+
+| Group | Merged element |
+|-------|----------------|
+| sub-conclusion + evidence | **sub-conclusion** — being both `StrategyBacked` and `SupportLeaf`, it supports whatever the evidence supported and can additionally carry the strategy that argues it |
+| any other mix of kinds | rejected with the `incompatible-unification` diagnostic, naming both elements and their shared label |
+
+Among members of the same kind the first one wins, and provides the merged
+element's label and source location. Nothing else is comparable: a
+conclusion is the model's single root, a strategy is the support rather than
+a supporter, and an `@support` placeholder is discharged by an explicit
+override, never by a merge. Use `unifyExclude` to keep colliding elements
+apart.
+
 `UnificationEquivalenceRegistry` maps names to `EquivalenceRelation`
 instances. It is populated at compiler startup in
 `CompilerFactory.builtInUnificationEquivalences()`. `SameShortId` is

--- a/examples/024_assemble_commutativity.jd
+++ b/examples/024_assemble_commutativity.jd
@@ -1,0 +1,49 @@
+/*********************************
+ * jPipe  -  Reference Examples  *
+ * @author   Sebastien Mosser    *
+ * @compiler 2.x                 *
+ *********************************/
+
+// "X" is asserted here, as a plain evidence.
+justification base {
+    conclusion c is "Base holds"
+    strategy   s is "because X"
+    evidence   x is "X"
+    s supports c
+    x supports s
+}
+
+// ... and argued here, as a conclusion in its own right.
+justification detail {
+    conclusion c is "X"
+    strategy   s is "because Y"
+    evidence   y is "Y"
+    s supports c
+    y supports s
+}
+
+// A third brick that still asserts "X".
+justification other {
+    conclusion c is "Other holds"
+    strategy   s is "also because X"
+    evidence   x is "X"
+    s supports c
+    x supports s
+}
+
+// Refining turns "X" into a sub-conclusion inside deep.
+justification deep is refine(base, detail) { hook: "x" }
+
+// Assembling deep with other unifies a sub-conclusion ("X", argued) with an
+// evidence ("X", asserted). Both argument orders must give the same model:
+// the merged element is a sub-conclusion, which the detail's strategy can
+// support and which can itself support the other bricks' strategies.
+justification left is assemble(deep, other) {
+    conclusionLabel: "All"
+    strategyLabel:   "Both"
+}
+
+justification right is assemble(other, deep) {
+    conclusionLabel: "All"
+    strategyLabel:   "Both"
+}

--- a/examples/invalid/024_unifying_incompatible_kinds.jd
+++ b/examples/invalid/024_unifying_incompatible_kinds.jd
@@ -1,0 +1,23 @@
+justification base {
+    conclusion c is "A conclusion"
+    strategy   s is "A strategy"
+    evidence   e is "An evidence"
+    s supports c
+    e supports s
+}
+
+justification other {
+    conclusion c is "Another conclusion"
+    strategy   s is "Another strategy"
+    evidence   e is "Another evidence"
+    s supports c
+    e supports s
+}
+
+// The global conclusion carries the same label as an evidence of a source:
+// unification groups them, but no single element can be both the model's
+// conclusion and a leaf supporting a strategy.
+justification bad is assemble(base, other) {
+    conclusionLabel: "An evidence"
+    strategyLabel:   "An aggregating strategy"
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticCodes.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticCodes.java
@@ -60,6 +60,12 @@ public final class DiagnosticCodes {
 	/** A command references an element ID that does not exist in its model. */
 	public static final String UNKNOWN_ELEMENT = "unknown-element";
 
+	/**
+	 * Unification grouped elements whose kinds cannot be merged into a single
+	 * element, e.g. a strategy and an evidence sharing the same label.
+	 */
+	public static final String INCOMPATIBLE_UNIFICATION = "incompatible-unification";
+
 	// ---- execution ----------------------------------------------------------
 
 	/** A command could not be executed (catch-all for unexpected failures). */

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ExecutionFailureDiagnostics.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ExecutionFailureDiagnostics.java
@@ -9,6 +9,8 @@ import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import ca.mcscert.jpipe.compiler.model.DiagnosticCodes;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.operators.ApplyOperator;
+import ca.mcscert.jpipe.operators.IncompatibleUnificationException;
 import java.util.List;
 
 /**
@@ -57,6 +59,17 @@ final class ExecutionFailureDiagnostics {
 	 */
 	static void diagnoseExecutionFailure(Command cmd, Unit unit,
 			Throwable cause, CompilationContext ctx) {
+		if (cause instanceof IncompatibleUnificationException) {
+			// Raised while expanding an operator call: anchor the diagnostic on
+			// the call site rather than on the command's own text.
+			SourceLocation loc = cmd instanceof ApplyOperator op
+					? op.location()
+					: SourceLocation.UNKNOWN;
+			error(ctx, DiagnosticCodes.INCOMPATIBLE_UNIFICATION, loc,
+					cause.getMessage());
+			ctx.error("model construction failed — see errors above");
+			return;
+		}
 		switch (cmd) {
 			case ImplementsTemplate c -> {
 				SourceLocation loc = c.location();

--- a/jpipe-compiler/src/test/resources/features/operators.feature
+++ b/jpipe-compiler/src/test/resources/features/operators.feature
@@ -87,6 +87,49 @@ Feature: Composition operators
     And the sub-conclusion "hook" supports the strategy "both:second:s"
     And the strategy "refine_1:s" supports the sub-conclusion "hook"
 
+  Scenario: assemble is commutative when a merged group mixes element kinds
+    Given the source file "024_assemble_commutativity.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+    # "X" is argued in deep (a sub-conclusion) and asserted in other (an
+    # evidence). Whichever source comes first, the merged element must be the
+    # sub-conclusion: it carries the strategy that argues it, and supports the
+    # strategies that lean on it.
+    And the unit contains a justification named "left"
+    And it has a conclusion with id "assembleConclusion" and label "All"
+    And it has a strategy with id "assembleStrategy" and label "Both"
+    And it has a sub-conclusion with id "unified_0" and label "X"
+    And it has a sub-conclusion with id "deep:base:c" and label "Base holds"
+    And it has a sub-conclusion with id "other:c" and label "Other holds"
+    And it has evidence with id "deep:detail:y" and label "Y"
+    And the strategy "deep:detail:s" supports the sub-conclusion "unified_0"
+    And the sub-conclusion "unified_0" supports the strategy "deep:base:s"
+    And the sub-conclusion "unified_0" supports the strategy "other:s"
+    And the sub-conclusion "deep:base:c" supports the strategy "assembleStrategy"
+    And the sub-conclusion "other:c" supports the strategy "assembleStrategy"
+    And the strategy "assembleStrategy" supports the conclusion "assembleConclusion"
+    # Same assertions, sources listed the other way round.
+    And the unit contains a justification named "right"
+    And it has a conclusion with id "assembleConclusion" and label "All"
+    And it has a strategy with id "assembleStrategy" and label "Both"
+    And it has a sub-conclusion with id "unified_0" and label "X"
+    And it has a sub-conclusion with id "deep:base:c" and label "Base holds"
+    And it has a sub-conclusion with id "other:c" and label "Other holds"
+    And it has evidence with id "deep:detail:y" and label "Y"
+    And the strategy "deep:detail:s" supports the sub-conclusion "unified_0"
+    And the sub-conclusion "unified_0" supports the strategy "deep:base:s"
+    And the sub-conclusion "unified_0" supports the strategy "other:s"
+    And the sub-conclusion "deep:base:c" supports the strategy "assembleStrategy"
+    And the sub-conclusion "other:c" supports the strategy "assembleStrategy"
+    And the strategy "assembleStrategy" supports the conclusion "assembleConclusion"
+
+  Scenario: unifying incompatible element kinds reports a dedicated error
+    Given the source file "invalid/024_unifying_incompatible_kinds.jd"
+    When I compile it into a unit
+    Then the compilation has validation errors
+    And a validation error is reported for rule "incompatible-unification"
+    And a validation error mentions "cannot unify"
+
   Scenario: unknown unification method reports an execution error
     Given the source file "invalid/015_unknown_unification_method.jd"
     When I compile it into a unit

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateAbstractSupport.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateAbstractSupport.java
@@ -25,8 +25,13 @@ public final class CreateAbstractSupport
 	}
 
 	@Override
+	public AbstractSupport element() {
+		return new AbstractSupport(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.addInto(container, new AbstractSupport(identifier, label));
+		context.addInto(container, element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateConclusion.java
@@ -22,8 +22,13 @@ public final class CreateConclusion extends AbstractElementCreationCommand {
 	}
 
 	@Override
+	public Conclusion element() {
+		return new Conclusion(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.get(container).setConclusion(new Conclusion(identifier, label));
+		context.get(container).setConclusion(element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateEvidence.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateEvidence.java
@@ -22,8 +22,13 @@ public final class CreateEvidence extends AbstractElementCreationCommand {
 	}
 
 	@Override
+	public Evidence element() {
+		return new Evidence(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.addInto(container, new Evidence(identifier, label));
+		context.addInto(container, element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateStrategy.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateStrategy.java
@@ -22,8 +22,13 @@ public final class CreateStrategy extends AbstractElementCreationCommand {
 	}
 
 	@Override
+	public Strategy element() {
+		return new Strategy(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.addInto(container, new Strategy(identifier, label));
+		context.addInto(container, element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateSubConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateSubConclusion.java
@@ -23,8 +23,13 @@ public final class CreateSubConclusion extends AbstractElementCreationCommand {
 	}
 
 	@Override
+	public SubConclusion element() {
+		return new SubConclusion(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.addInto(container, new SubConclusion(identifier, label));
+		context.addInto(container, element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/ElementCreationCommand.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/ElementCreationCommand.java
@@ -3,6 +3,7 @@ package ca.mcscert.jpipe.commands.creation;
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.elements.ElementView;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
 
 /**
  * Sealed interface common to all element-creation commands.
@@ -52,4 +53,19 @@ public sealed interface ElementCreationCommand extends Command, ElementView
 	 * identifier. The container, label, and location are preserved.
 	 */
 	ElementCreationCommand withId(String newId);
+
+	/**
+	 * The element this command creates, built from the command's own id and
+	 * label but not attached to any model.
+	 *
+	 * <p>
+	 * Lets callers reason about the kind of element a command produces using
+	 * the element hierarchy itself (e.g.
+	 * {@link ca.mcscert.jpipe.model.elements.SupportLeaf} and
+	 * {@link ca.mcscert.jpipe.model.elements.StrategyBacked}) instead of
+	 * matching on command types.
+	 *
+	 * @return a fresh element, as {@link #doExecute} would create it.
+	 */
+	JustificationElement element();
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/AbstractSupport.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/AbstractSupport.java
@@ -6,4 +6,9 @@ package ca.mcscert.jpipe.model.elements;
  */
 public record AbstractSupport(String id,
 		String label) implements JustificationElement, SupportLeaf {
+
+	@Override
+	public String kind() {
+		return "abstract-support";
+	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Conclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Conclusion.java
@@ -9,4 +9,9 @@ public final class Conclusion extends AbstractSupportedElement
 	public Conclusion(String id, String label) {
 		super(id, label);
 	}
+
+	@Override
+	public String kind() {
+		return "conclusion";
+	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Evidence.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Evidence.java
@@ -3,4 +3,9 @@ package ca.mcscert.jpipe.model.elements;
 /** A leaf evidence element supporting a strategy. */
 public record Evidence(String id,
 		String label) implements CommonElement, SupportLeaf {
+
+	@Override
+	public String kind() {
+		return "evidence";
+	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/JustificationElement.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/JustificationElement.java
@@ -10,6 +10,15 @@ import ca.mcscert.jpipe.visitor.JustificationVisitor;
 public sealed interface JustificationElement extends ElementView
 		permits CommonElement, AbstractSupport {
 
+	/**
+	 * The kebab-case name of this element's kind, as used in user-facing
+	 * output: {@code conclusion}, {@code sub-conclusion}, {@code strategy},
+	 * {@code evidence}, {@code abstract-support}.
+	 *
+	 * @return the kind name of this element.
+	 */
+	String kind();
+
 	default <R> R accept(JustificationVisitor<R> visitor) {
 		return switch (this) {
 			case Conclusion c -> visitor.visit(c);

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
@@ -26,6 +26,11 @@ public final class Strategy implements CommonElement {
 		return label;
 	}
 
+	@Override
+	public String kind() {
+		return "strategy";
+	}
+
 	/**
 	 * Adds {@code supporter} to this strategy. A strategy can never
 	 * legitimately be supported twice by the same element id, so the call is

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/SubConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/SubConclusion.java
@@ -10,4 +10,9 @@ public final class SubConclusion extends AbstractSupportedElement
 	public SubConclusion(String id, String label) {
 		super(id, label);
 	}
+
+	@Override
+	public String kind() {
+		return "sub-conclusion";
+	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
@@ -152,9 +152,8 @@ public class PythonExporter extends AbstractModelExporter {
 		builder.append("@jpipe(").append(decoratorArgs).append(")\n");
 		builder.append("def ").append(name).append("(").append(params)
 				.append(") -> bool:\n");
-		builder.append("    \"\"\"[").append(elementTypeName(element))
-				.append("] ").append(escapeDocstring(element.label()))
-				.append("\"\"\"\n");
+		builder.append("    \"\"\"[").append(element.kind()).append("] ")
+				.append(escapeDocstring(element.label())).append("\"\"\"\n");
 		if (element instanceof AbstractSupport) {
 			builder.append("    raise NotImplementedError(\"").append(qid)
 					.append(" is abstract and must be"
@@ -162,16 +161,6 @@ public class PythonExporter extends AbstractModelExporter {
 		} else {
 			builder.append("    pass\n\n\n");
 		}
-	}
-
-	private static String elementTypeName(JustificationElement element) {
-		return switch (element) {
-			case Conclusion _ -> "conclusion";
-			case SubConclusion _ -> "sub-conclusion";
-			case Strategy _ -> "strategy";
-			case Evidence _ -> "evidence";
-			case AbstractSupport _ -> "abstract-support";
-		};
 	}
 
 	private static String jpipeDecoratorArgs(JustificationElement element) {

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/elements/JustificationElementTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/elements/JustificationElementTest.java
@@ -7,8 +7,12 @@ import ca.mcscert.jpipe.visitor.JustificationVisitor;
 import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class JustificationElementTest {
 
@@ -54,6 +58,21 @@ class JustificationElementTest {
 	}
 
 	private final RecordingVisitor visitor = new RecordingVisitor();
+
+	static Stream<Arguments> elementKinds() {
+		return Stream.of(Arguments.of(new Conclusion("c", "l"), "conclusion"),
+				Arguments.of(new SubConclusion("sc", "l"), "sub-conclusion"),
+				Arguments.of(new Strategy("s", "l"), "strategy"),
+				Arguments.of(new Evidence("e", "l"), "evidence"), Arguments.of(
+						new AbstractSupport("as", "l"), "abstract-support"));
+	}
+
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("elementKinds")
+	void eachElementNamesItsOwnKind(JustificationElement element,
+			String expected) {
+		assertThat(element.kind()).isEqualTo(expected);
+	}
 
 	@Nested
 	class ConclusionTest {

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/IncompatibleUnificationException.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/IncompatibleUnificationException.java
@@ -1,0 +1,17 @@
+package ca.mcscert.jpipe.operators;
+
+/**
+ * Raised when unification groups elements whose kinds cannot be merged into a
+ * single element, e.g. a strategy and an evidence sharing the same label.
+ *
+ * <p>
+ * Reported independently of the order in which the source models were listed:
+ * the operator is commutative, so the same group is rejected, with the same
+ * message, whichever way its members were written.
+ */
+public final class IncompatibleUnificationException extends RuntimeException {
+
+	public IncompatibleUnificationException(String message) {
+		super(message);
+	}
+}

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
@@ -198,19 +198,22 @@ public final class Unifier {
 	 */
 	private static ElementCreationCommand dominant(String resultName,
 			List<ElementCreationCommand> group) {
-		ElementCreationCommand best = group.get(0);
-		for (ElementCreationCommand candidate : group) {
+		List<JustificationElement> elements = group.stream()
+				.map(ElementCreationCommand::element).toList();
+		int best = 0;
+		for (int i = 1; i < elements.size(); i++) {
 			// Strict upgrade only: among equals, the first member wins.
-			if (!subsumes(best.element(), candidate.element())) {
-				best = candidate;
+			if (!subsumes(elements.get(best), elements.get(i))) {
+				best = i;
 			}
 		}
-		for (ElementCreationCommand member : group) {
-			if (!subsumes(best.element(), member.element())) {
+		JustificationElement winner = elements.get(best);
+		for (JustificationElement element : elements) {
+			if (!subsumes(winner, element)) {
 				throw incompatible(resultName, group);
 			}
 		}
-		return best;
+		return group.get(best);
 	}
 
 	/**

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
@@ -4,7 +4,14 @@ import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.creation.ElementCreationCommand;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
 import ca.mcscert.jpipe.commands.linking.RegisterAlias;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -25,6 +32,23 @@ import java.util.stream.Collectors;
  * original member ids are aliased to the new id via {@link RegisterAlias}
  * commands, and {@link AddSupport} commands referencing removed ids are
  * rewritten accordingly.
+ *
+ * <p>
+ * A group may legitimately mix element kinds — one source argued a claim while
+ * another still asserts it — so the merged element is built from the group's
+ * <em>dominant</em> member rather than from whichever member happens to come
+ * first: a sub-conclusion subsumes an evidence, and among members of the same
+ * kind the first one wins (it also provides the merged element's label and
+ * source location). A group whose kinds are incomparable cannot be merged and
+ * raises an {@link IncompatibleUnificationException}. This makes composition
+ * operators commutative: the result no longer depends on the order the source
+ * models were listed in.
+ *
+ * <p>
+ * Note that for an equivalence relation that does not compare labels, the
+ * merged element's <em>label</em> is still the dominant member's, hence still
+ * order-dependent among members of the same kind. The only registered relation,
+ * {@code sameLabel}, cannot exhibit that.
  *
  * <p>
  * Controlled by two optional config parameters:
@@ -95,12 +119,15 @@ public final class Unifier {
 		List<List<ElementCreationCommand>> groups = Partitions
 				.partitionBy(candidates, equiv);
 
-		// Build phase4Aliases: oldId → unified_N for every group with >1 member
+		// For every group with more than one member: alias each member id to
+		// unified_N, and elect the command the merged element is built from.
 		Map<String, String> phase4Aliases = new LinkedHashMap<>();
+		Map<String, ElementCreationCommand> prototypes = new LinkedHashMap<>();
 		int counter = 0;
 		for (List<ElementCreationCommand> group : groups) {
 			if (group.size() > 1) {
 				String unifiedId = UNIFIED_PREFIX + counter++;
+				prototypes.put(unifiedId, dominant(resultName, group));
 				for (ElementCreationCommand ecc : group) {
 					phase4Aliases.put(ecc.identifier(), unifiedId);
 				}
@@ -112,7 +139,7 @@ public final class Unifier {
 		}
 
 		List<Command> result = rebuildCommands(resultName, commands,
-				phase4Aliases);
+				phase4Aliases, prototypes);
 		phase4Aliases.forEach((oldId, newId) -> result
 				.add(new RegisterAlias(resultName, oldId, newId)));
 		return List.copyOf(result);
@@ -122,13 +149,15 @@ public final class Unifier {
 	// ─────────────────────────────────────────────────────────────────
 
 	private static List<Command> rebuildCommands(String resultName,
-			List<Command> commands, Map<String, String> phase4Aliases) {
+			List<Command> commands, Map<String, String> phase4Aliases,
+			Map<String, ElementCreationCommand> prototypes) {
 		List<Command> result = new ArrayList<>();
 		Set<String> insertedUnified = new LinkedHashSet<>();
 		Set<String> seenEdges = new LinkedHashSet<>();
 		for (Command cmd : commands) {
 			if (isElement(cmd)) {
-				appendElement(result, cmd, phase4Aliases, insertedUnified);
+				appendElement(result, cmd, phase4Aliases, prototypes,
+						insertedUnified);
 			} else if (cmd instanceof AddSupport as) {
 				appendEdge(result, resultName, as, phase4Aliases, seenEdges);
 			} else {
@@ -139,16 +168,106 @@ public final class Unifier {
 	}
 
 	private static void appendElement(List<Command> result, Command cmd,
-			Map<String, String> phase4Aliases, Set<String> insertedUnified) {
+			Map<String, String> phase4Aliases,
+			Map<String, ElementCreationCommand> prototypes,
+			Set<String> insertedUnified) {
 		String id = idOf(cmd);
 		if (phase4Aliases.containsKey(id)) {
 			String unifiedId = phase4Aliases.get(id);
+			// The merged element takes the position of the first member met,
+			// but is built from the group's dominant one.
 			if (insertedUnified.add(unifiedId)) {
-				result.add(synthesized(cmd, unifiedId));
+				result.add(prototypes.get(unifiedId).withId(unifiedId));
 			}
 		} else {
 			result.add(cmd);
 		}
+	}
+
+	/**
+	 * Elects the command a merged group is synthesized from.
+	 *
+	 * <p>
+	 * The elected command is the first member whose kind subsumes every other
+	 * kind in the group; its label and location are the ones the merged element
+	 * carries. A group whose kinds are incomparable cannot be merged into a
+	 * single element and is rejected.
+	 *
+	 * @throws IncompatibleUnificationException
+	 *             if no member subsumes all the others.
+	 */
+	private static ElementCreationCommand dominant(String resultName,
+			List<ElementCreationCommand> group) {
+		ElementCreationCommand best = group.get(0);
+		for (ElementCreationCommand candidate : group) {
+			// Strict upgrade only: among equals, the first member wins.
+			if (!subsumes(best.element(), candidate.element())) {
+				best = candidate;
+			}
+		}
+		for (ElementCreationCommand member : group) {
+			if (!subsumes(best.element(), member.element())) {
+				throw incompatible(resultName, group);
+			}
+		}
+		return best;
+	}
+
+	/**
+	 * Tells whether an element of {@code winner}'s kind can stand for one of
+	 * {@code other}'s kind in a merged group.
+	 *
+	 * <p>
+	 * A {@link SubConclusion} subsumes an {@link Evidence}: being both
+	 * {@link ca.mcscert.jpipe.model.elements.StrategyBacked} and
+	 * {@link ca.mcscert.jpipe.model.elements.SupportLeaf}, it supports whatever
+	 * the evidence supported and can additionally carry the strategy that
+	 * argues it. No other pair of distinct kinds is comparable: a conclusion is
+	 * the model's single root, a strategy is the support rather than a
+	 * supporter, and an {@link AbstractSupport} placeholder is discharged by an
+	 * explicit override, never by a merge.
+	 */
+	private static boolean subsumes(JustificationElement winner,
+			JustificationElement other) {
+		return switch (winner) {
+			case SubConclusion _ ->
+				other instanceof SubConclusion || other instanceof Evidence;
+			case Conclusion _ -> other instanceof Conclusion;
+			case Strategy _ -> other instanceof Strategy;
+			case Evidence _ -> other instanceof Evidence;
+			case AbstractSupport _ -> other instanceof AbstractSupport;
+		};
+	}
+
+	/**
+	 * Builds the rejection for a group that mixes incomparable kinds, naming
+	 * the first incomparable pair in a canonical order so that the message does
+	 * not depend on the order the source models were listed in.
+	 */
+	private static IncompatibleUnificationException incompatible(
+			String resultName, List<ElementCreationCommand> group) {
+		List<ElementCreationCommand> sorted = group.stream()
+				.sorted(Comparator.comparing(
+						(ElementCreationCommand c) -> c.element().kind())
+						.thenComparing(ElementCreationCommand::identifier))
+				.toList();
+		ElementCreationCommand first = sorted.get(0);
+		ElementCreationCommand clashing = sorted.stream()
+				.filter(c -> !subsumes(first.element(), c.element())
+						&& !subsumes(c.element(), first.element()))
+				.findFirst().orElse(sorted.get(sorted.size() - 1));
+		return new IncompatibleUnificationException("cannot unify "
+				+ describe(first) + " with " + describe(clashing)
+				+ " in model '" + resultName
+				+ "': these element kinds are incompatible."
+				+ " Rename one of the labels, or keep the elements apart with "
+				+ UNIFY_EXCLUDE_KEY + ".");
+	}
+
+	/** Renders an element command as {@code 'id' (kind, "label")}. */
+	private static String describe(ElementCreationCommand cmd) {
+		return "'" + cmd.identifier() + "' (" + cmd.element().kind() + ", \""
+				+ cmd.label() + "\")";
 	}
 
 	private static void appendEdge(List<Command> result, String resultName,
@@ -187,14 +306,6 @@ public final class Unifier {
 	/** Extracts the label from an element-creation command. */
 	static String labelOf(Command cmd) {
 		return ((ElementCreationCommand) cmd).label();
-	}
-
-	/**
-	 * Returns a copy of {@code original} with {@code newId} as the element
-	 * identifier, preserving the command type, container, label, and location.
-	 */
-	private static Command synthesized(Command original, String newId) {
-		return ((ElementCreationCommand) original).withId(newId);
 	}
 
 	private static String resolve(String id, Map<String, String> aliases) {

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/UnifierTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/UnifierTest.java
@@ -6,10 +6,12 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.ExecutionEngine;
+import ca.mcscert.jpipe.commands.creation.CreateAbstractSupport;
 import ca.mcscert.jpipe.commands.creation.CreateConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateEvidence;
 import ca.mcscert.jpipe.commands.creation.CreateJustification;
 import ca.mcscert.jpipe.commands.creation.CreateStrategy;
+import ca.mcscert.jpipe.commands.creation.CreateSubConclusion;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
 import ca.mcscert.jpipe.commands.linking.RegisterAlias;
 import ca.mcscert.jpipe.model.Justification;
@@ -17,14 +19,26 @@ import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.Evidence;
 import ca.mcscert.jpipe.model.elements.JustificationElement;
 import ca.mcscert.jpipe.operators.equivalences.SameLabel;
+import ca.mcscert.jpipe.operators.equivalences.SameShortId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class UnifierTest {
+
+	/** Label shared by the members of a merged group. */
+	private static final String SHARED = "A shared claim";
+
+	/** Name of the model under test; {@link #model()} for instance contexts. */
+	private static final String MODEL = "m";
 
 	private Unifier unifier;
 	private ExecutionEngine engine;
@@ -254,6 +268,151 @@ class UnifierTest {
 		}
 	}
 
+	// ── groups mixing element kinds
+	// ───────────────────────────────────────────────
+
+	@Nested
+	class MixedKinds {
+
+		/**
+		 * A group mixing a sub-conclusion and an evidence carrying the same
+		 * claim: one source argued it, the other still asserts it.
+		 */
+		private List<Command> argued(boolean subConclusionFirst) {
+			List<Command> elements = subConclusionFirst
+					? List.of(new CreateSubConclusion(model(), "sc", SHARED),
+							new CreateEvidence(model(), "e", SHARED))
+					: List.of(new CreateEvidence(model(), "e", SHARED),
+							new CreateSubConclusion(model(), "sc", SHARED));
+			List<Command> cmds = new ArrayList<>(
+					List.of(new CreateJustification(model())));
+			cmds.addAll(elements);
+			return cmds;
+		}
+
+		@ParameterizedTest(name = "sub-conclusion listed first: {0}")
+		@ValueSource(booleans = {true, false})
+		void subConclusionWinsWhateverTheOrder(boolean subConclusionFirst) {
+			List<Command> result = unifier.unify(model(),
+					argued(subConclusionFirst), Map.of());
+
+			assertThat(result).filteredOn(Unifier::isElement)
+					.filteredOn(cmd -> "unified_0".equals(Unifier.idOf(cmd)))
+					.singleElement().isInstanceOf(CreateSubConclusion.class)
+					.extracting(Unifier::labelOf).isEqualTo(SHARED);
+		}
+
+		@Test
+		void mergedElementKeepsThePositionOfItsFirstMember() {
+			// The evidence is listed first, so unified_0 takes its slot even
+			// though the sub-conclusion is the one it is built from.
+			List<Command> cmds = argued(false);
+			cmds.add(new CreateEvidence(model(), "last", "Something else"));
+
+			List<Command> result = unifier.unify(model(), cmds, Map.of());
+
+			assertThat(result).filteredOn(Unifier::isElement)
+					.extracting(Unifier::idOf)
+					.containsExactly("unified_0", "last");
+		}
+
+		@Test
+		void mergedSubConclusionCanCarryAStrategyAndSupportAnother() {
+			// The reason sub-conclusion must win: it is both supported by the
+			// strategy that argues it, and a supporter of the strategy that
+			// used to lean on the evidence.
+			List<Command> cmds = argued(false);
+			cmds.addAll(List.of(new CreateStrategy(model(), "arguing", "why"),
+					new CreateStrategy(model(), "leaning", "because"),
+					new AddSupport(model(), "sc", "arguing"),
+					new AddSupport(model(), "leaning", "e")));
+
+			Unit unit = engine.spawn("test",
+					unifier.unify(model(), cmds, Map.of()));
+			Justification result = (Justification) unit.get(model());
+
+			assertThat(result.subConclusions()).singleElement()
+					.satisfies(sc -> assertThat(sc.id()).isEqualTo("unified_0"))
+					.satisfies(sc -> assertThat(sc.getSupport()).get()
+							.extracting(JustificationElement::id)
+							.isEqualTo("arguing"));
+		}
+
+		static Stream<Arguments> incomparablePairs() {
+			return Stream.of(
+					Arguments.of("strategy and evidence",
+							new CreateStrategy(MODEL, "s", SHARED),
+							new CreateEvidence(MODEL, "e", SHARED)),
+					Arguments.of("conclusion and evidence",
+							new CreateConclusion(MODEL, "c", SHARED),
+							new CreateEvidence(MODEL, "e", SHARED)),
+					Arguments.of("conclusion and sub-conclusion",
+							new CreateConclusion(MODEL, "c", SHARED),
+							new CreateSubConclusion(MODEL, "sc", SHARED)),
+					Arguments.of("evidence and abstract support",
+							new CreateEvidence(MODEL, "e", SHARED),
+							new CreateAbstractSupport(MODEL, "as", SHARED)),
+					Arguments.of("sub-conclusion and abstract support",
+							new CreateSubConclusion(MODEL, "sc", SHARED),
+							new CreateAbstractSupport(MODEL, "as", SHARED)));
+		}
+
+		@ParameterizedTest(name = "{0}")
+		@MethodSource("incomparablePairs")
+		void incomparableKindsAreRejected(String label, Command first,
+				Command second) {
+			List<Command> cmds = List.of(new CreateJustification(model()),
+					first, second);
+			assertThatThrownBy(() -> unifier.unify(model(), cmds, Map.of()))
+					.isInstanceOf(IncompatibleUnificationException.class)
+					.hasMessageContaining("cannot unify")
+					.hasMessageContaining(SHARED)
+					.hasMessageContaining("element kinds are incompatible")
+					.hasMessageContaining(Unifier.UNIFY_EXCLUDE_KEY);
+		}
+
+		@Test
+		void theRejectionMessageIsTheSameWhateverTheOrder() {
+			Command strategy = new CreateStrategy(model(), "s", SHARED);
+			Command evidence = new CreateEvidence(model(), "e", SHARED);
+			List<Command> oneWay = List.of(new CreateJustification(model()),
+					strategy, evidence);
+			List<Command> theOther = List.of(new CreateJustification(model()),
+					evidence, strategy);
+
+			String first = messageOf(oneWay);
+			String second = messageOf(theOther);
+
+			assertThat(first).isEqualTo(second);
+		}
+
+		private String messageOf(List<Command> cmds) {
+			try {
+				unifier.unify(model(), cmds, Map.of());
+				throw new AssertionError("expected the group to be rejected");
+			} catch (IncompatibleUnificationException e) {
+				return e.getMessage();
+			}
+		}
+
+		@Test
+		void homogeneousGroupStillTakesTheFirstMembersLabel() {
+			// sameShortId ignores labels, so a group can hold two evidence
+			// elements with different labels: the first one still wins.
+			UnificationEquivalenceRegistry registry = new UnificationEquivalenceRegistry();
+			registry.register("sameShortId", new SameShortId());
+			List<Command> cmds = List.of(new CreateJustification(model()),
+					new CreateEvidence(model(), "a:e", "first label"),
+					new CreateEvidence(model(), "b:e", "second label"));
+
+			List<Command> result = new Unifier(registry).unify(model(), cmds,
+					Map.of("unifyBy", "sameShortId"));
+
+			assertThat(result).filteredOn(Unifier::isElement).singleElement()
+					.extracting(Unifier::labelOf).isEqualTo("first label");
+		}
+	}
+
 	// ── unknown unifyBy
 	// ───────────────────────────────────────────────────────────────
 
@@ -271,6 +430,6 @@ class UnifierTest {
 	}
 
 	private static String model() {
-		return "m";
+		return MODEL;
 	}
 }

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/UnifierTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/UnifierTest.java
@@ -363,7 +363,8 @@ class UnifierTest {
 				Command second) {
 			List<Command> cmds = List.of(new CreateJustification(model()),
 					first, second);
-			assertThatThrownBy(() -> unifier.unify(model(), cmds, Map.of()))
+			Map<String, String> args = Map.of();
+			assertThatThrownBy(() -> unifier.unify(MODEL, cmds, args))
 					.isInstanceOf(IncompatibleUnificationException.class)
 					.hasMessageContaining("cannot unify")
 					.hasMessageContaining(SHARED)

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/builtin/AssembleOperatorTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/builtin/AssembleOperatorTest.java
@@ -9,6 +9,7 @@ import ca.mcscert.jpipe.commands.creation.CreateConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateEvidence;
 import ca.mcscert.jpipe.commands.creation.CreateJustification;
 import ca.mcscert.jpipe.commands.creation.CreateStrategy;
+import ca.mcscert.jpipe.commands.creation.CreateSubConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateTemplate;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
 import ca.mcscert.jpipe.model.Justification;
@@ -16,13 +17,21 @@ import ca.mcscert.jpipe.model.JustificationModel;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
 import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
+import ca.mcscert.jpipe.operators.IncompatibleUnificationException;
 import ca.mcscert.jpipe.operators.InvalidOperatorCallException;
 import ca.mcscert.jpipe.operators.ModelKind;
+import ca.mcscert.jpipe.operators.UnificationEquivalenceRegistry;
+import ca.mcscert.jpipe.operators.Unifier;
+import ca.mcscert.jpipe.operators.equivalences.SameLabel;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -31,11 +40,15 @@ class AssembleOperatorTest {
 
 	private ExecutionEngine engine;
 	private AssembleOperator assemble;
+	private Unifier unifier;
 
 	@BeforeEach
 	void setUp() {
 		engine = new ExecutionEngine();
 		assemble = new AssembleOperator();
+		UnificationEquivalenceRegistry registry = new UnificationEquivalenceRegistry();
+		registry.register("sameLabel", new SameLabel());
+		unifier = new Unifier(registry);
 	}
 
 	private static final Map<String, String> ARGS = Map.of("conclusionLabel",
@@ -247,6 +260,112 @@ class AssembleOperatorTest {
 					.filter(s -> s.id().equals(AssembleOperator.STRATEGY_ID))
 					.findFirst().orElseThrow();
 			assertThat(assembleS.getSupports()).hasSize(3);
+		}
+	}
+
+	// ── Commutativity ────────────────────────────────────────────────────────
+
+	/**
+	 * Assembling the same bricks in either order must give the same model, even
+	 * when unification merges a group that mixes element kinds: one source
+	 * argues the claim (sub-conclusion), the other still asserts it (evidence).
+	 * See issue #156.
+	 */
+	@Nested
+	class Commutativity {
+
+		private static final String SHARED = "A shared claim";
+
+		/** A brick whose shared claim is argued: a sub-conclusion. */
+		private Justification arguing(String name) {
+			List<Command> cmds = new ArrayList<>();
+			cmds.add(new CreateJustification(name));
+			cmds.add(new CreateConclusion(name, "c", "Argued holds"));
+			cmds.add(new CreateStrategy(name, "s", "because the claim"));
+			cmds.add(new CreateSubConclusion(name, "sc", SHARED));
+			cmds.add(new CreateStrategy(name, "deeper", "because of details"));
+			cmds.add(new CreateEvidence(name, "e", "Some detail"));
+			cmds.add(new AddSupport(name, "c", "s"));
+			cmds.add(new AddSupport(name, "s", "sc"));
+			cmds.add(new AddSupport(name, "sc", "deeper"));
+			cmds.add(new AddSupport(name, "deeper", "e"));
+			return (Justification) engine.spawn("src", cmds).get(name);
+		}
+
+		/** A brick whose shared claim is asserted: a plain evidence. */
+		private Justification asserting(String name) {
+			return buildJustification(name, "Asserted holds", "also because it",
+					SHARED);
+		}
+
+		private Justification assembled(String name,
+				List<JustificationModel<?>> sources) {
+			List<Command> cmds = unifier.unify(name,
+					assemble.apply(name, sources, ARGS), ARGS);
+			return (Justification) engine.spawn("out", cmds).get(name);
+		}
+
+		@Test
+		void assemblingThePlainSourceFirstStillBuilds() {
+			// The regression: with the evidence met first, the merged element
+			// used to be created as an evidence, which the arguing strategy
+			// could not support.
+			Justification result = assembled("right",
+					List.of(asserting("other"), arguing("deep")));
+
+			assertThat(result.subConclusions()).extracting(SubConclusion::id)
+					.contains("unified_0");
+		}
+
+		@Test
+		void bothArgumentOrdersProduceTheSameModel() {
+			// Labels are pairwise distinct in these fixtures, so (kind, label)
+			// identifies an element and comparing the two sets below is an
+			// exact isomorphism check. Ids cannot be compared directly: the
+			// unified_N counter follows group-discovery order.
+			Justification left = assembled("left",
+					List.of(arguing("deep"), asserting("other")));
+			Justification right = assembled("right",
+					List.of(asserting("other"), arguing("deep")));
+
+			assertThat(nodes(left)).isEqualTo(nodes(right));
+			assertThat(edges(left)).isEqualTo(edges(right));
+		}
+
+		@Test
+		void mergingTheGlobalConclusionWithASourceElementIsRejected() {
+			List<JustificationModel<?>> sources = List.of(arguing("deep"),
+					asserting("other"));
+			Map<String, String> clashing = Map.of("conclusionLabel", SHARED,
+					"strategyLabel", "An aggregating strategy");
+			List<Command> composed = assemble.apply("clash", sources, clashing);
+
+			assertThatThrownBy(() -> unifier.unify("clash", composed, clashing))
+					.isInstanceOf(IncompatibleUnificationException.class)
+					.hasMessageContaining("cannot unify")
+					.hasMessageContaining(SHARED);
+		}
+
+		private Set<String> nodes(JustificationModel<?> model) {
+			Set<String> nodes = model.getElements().stream()
+					.map(e -> e.kind() + "|" + e.label())
+					.collect(Collectors.toCollection(HashSet::new));
+			model.conclusion()
+					.ifPresent(c -> nodes.add(c.kind() + "|" + c.label()));
+			return nodes;
+		}
+
+		private Set<String> edges(JustificationModel<?> model) {
+			Set<String> edges = new HashSet<>();
+			model.strategies().forEach(s -> s.getSupports().forEach(
+					leaf -> edges.add(((JustificationElement) leaf).label()
+							+ " -> " + s.label())));
+			model.subConclusions().forEach(sc -> sc.getSupport().ifPresent(
+					s -> edges.add(s.label() + " -> " + sc.label())));
+			model.conclusion().flatMap(Conclusion::getSupport)
+					.ifPresent(s -> edges.add(s.label() + " -> "
+							+ model.conclusion().orElseThrow().label()));
+			return edges;
 		}
 	}
 


### PR DESCRIPTION
This pull request improves the commutativity and error handling of composition operators in the model assembly process. It ensures that merging elements of different kinds (like sub-conclusions and evidences with the same label) produces consistent results regardless of order, and introduces a dedicated error for truly incompatible unifications. The changes also add an explicit `kind()` method to all justification elements, making element type handling more robust and user-friendly.

**Composition operator improvements:**
- Composition operators (`assemble`) are now commutative when unification merges elements of different kinds (e.g., a sub-conclusion and an evidence with the same label), always producing a sub-conclusion regardless of order. Previously, the result could vary or fail to compile depending on argument order. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR26-R38) [[2]](diffhunk://#diff-34c85dda5b4fe4c6099a6df12e9bc099f117ce0269c9adaf99f3f66e4fe4ca01R90-R108) [[3]](diffhunk://#diff-41b91f52dbd8f9010696c6737e4da5d924c51950bd569f3fb188cf1f38a29c49R90-R132) [[4]](diffhunk://#diff-0151637e02c65d0152ec90ff5a1795df09bfe8f37dd180ff6a924ac0b6271fc1R1-R49)
- When unification groups contain element kinds that cannot be merged (e.g., a conclusion and an evidence with the same label), a dedicated `incompatible-unification` diagnostic is reported, pointing to the operator call and naming both elements and their shared label. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR26-R38) [[2]](diffhunk://#diff-34c85dda5b4fe4c6099a6df12e9bc099f117ce0269c9adaf99f3f66e4fe4ca01R90-R108) [[3]](diffhunk://#diff-41b91f52dbd8f9010696c6737e4da5d924c51950bd569f3fb188cf1f38a29c49R90-R132) [[4]](diffhunk://#diff-eac7fd1c464ea79ba64d67e10a3d76aa6e657c1df8ff841ea7e49d123a229abcR1-R23) [[5]](diffhunk://#diff-20923a50cfe1d492416199e183f42de0b1838b865f90deead606ef19a1f3f7ddR63-R68) [[6]](diffhunk://#diff-40d2e549ccd3f1e9077a9bbda27c973466afed79594d291ce322ed42ec52f5a3R62-R72)

**Model and API enhancements:**
- Added a `kind()` method to the `JustificationElement` interface and all its implementations, returning a kebab-case string for the element type (e.g., `conclusion`, `evidence`, etc.), to simplify reasoning about element types in code and user-facing output. [[1]](diffhunk://#diff-84d828e82fe5deab9d44b504da986940e185f5cd88a8913adf3b2895ea07b134R37) [[2]](diffhunk://#diff-c70d185515dee0d92226c83d52808d24b3af69018f68da7ac581cc072981c3e7R13-R21) [[3]](diffhunk://#diff-447f352d9098745cbaffd96b8c6708bdcd59a2ecb889b390c0309bc3abb0f04bR9-R13) [[4]](diffhunk://#diff-ea7d5616d531543fbb4d4299b0bad351b6bc008b1a97d7fe017bc56576f7f67cR12-R16) [[5]](diffhunk://#diff-404ade3cd4c504ced4e73d9ed12bb5c441cc48213525572471ec458a6dc38ad7R6-R10) [[6]](diffhunk://#diff-5629d1a07af52b08963b796c3d3dcd1cf16b60370f74ace6b4eeef716daf089cR29-R33) [[7]](diffhunk://#diff-fc9ed0858983cf66c4957a9e45787e928d700b2f119918087ac36c70d4bc0f3aR13-R17)
- The `ElementCreationCommand` interface now exposes an `element()` method, letting callers obtain the element that would be created, aiding in type-safe handling of element creation logic. [[1]](diffhunk://#diff-2a1f5fdb43ae95dec8ef8987638564a82993d971b340f035a2382319a82e9879R6) [[2]](diffhunk://#diff-2a1f5fdb43ae95dec8ef8987638564a82993d971b340f035a2382319a82e9879R56-R70) [[3]](diffhunk://#diff-5d2b516ecb3c8bc20b5144bc5a35e9fe25645e92a9acce2c0dfb67369ff35570R27-R34) [[4]](diffhunk://#diff-fa98c7ac744f4b0acf0239c8205afd96c93ed75bbc4c191b24df5db9a41e0f8dR24-R31) [[5]](diffhunk://#diff-fca96ddde1256e0317ad2c2f7c2bc869d130c7fd9e9b81a1e44c5efc560ec030R24-R31) [[6]](diffhunk://#diff-83168e60d68a641e9a2cc6d38975d656c63ec9b15b835b1b58ac32324f775a70R24-R31) [[7]](diffhunk://#diff-82fc7e64e6445debf15f17a45958cc874a9caa9703c368e632cbe025c76c6a1bR25-R32)

**Diagnostics and testing:**
- Introduced a new diagnostic code `incompatible-unification` and updated error reporting logic to anchor errors on the operator call site for easier debugging. [[1]](diffhunk://#diff-20923a50cfe1d492416199e183f42de0b1838b865f90deead606ef19a1f3f7ddR63-R68) [[2]](diffhunk://#diff-40d2e549ccd3f1e9077a9bbda27c973466afed79594d291ce322ed42ec52f5a3R12-R13) [[3]](diffhunk://#diff-40d2e549ccd3f1e9077a9bbda27c973466afed79594d291ce322ed42ec52f5a3R62-R72)
- Added reference and invalid example files, as well as comprehensive feature tests, to verify commutativity and error reporting for unification of different and incompatible element kinds. [[1]](diffhunk://#diff-0151637e02c65d0152ec90ff5a1795df09bfe8f37dd180ff6a924ac0b6271fc1R1-R49) [[2]](diffhunk://#diff-eac7fd1c464ea79ba64d67e10a3d76aa6e657c1df8ff841ea7e49d123a229abcR1-R23) [[3]](diffhunk://#diff-41b91f52dbd8f9010696c6737e4da5d924c51950bd569f3fb188cf1f38a29c49R90-R132)