### PR TITLE
Skip docs deploy for non-affecting changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,28 @@ on:
   push:
     branches:
       - dev
+    # The site is generated from more than docs/: the API reference comes from
+    # every module's main sources, the railroad diagrams from the grammar, and
+    # the schema page from a compiler resource. So this is a deny list, not an
+    # allow list — anything not named here still deploys. Listing what the site
+    # is built from instead would publish a stale site the day someone adds a
+    # new input and forgets this file.
+    paths-ignore:
+      - '**/src/test/**'
+      - 'examples/**'
+      - 'scripts/**'
+      - 'debian/**'
+      - 'bin/**'
+      - 'config/**'
+      - '.github/workflows/build.yml'
+      - '.github/workflows/sonar.yml'
+      - '.github/workflows/release.yml'
+      - '.gitignore'
+      - 'CHANGELOG.md'
+      - 'CLAUDE.md'
+      - 'CITATION.cff'
+      - 'LICENSE'
+      - 'code-of-conduct.md'
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request updates the documentation deployment workflow configuration to avoid unnecessary deployments when non-essential files are changed. The main improvement is the addition of a `paths-ignore` section to the `.github/workflows/docs.yml` file, which prevents the workflow from running when changes are made only to certain files or directories that do not affect the documentation site.

Workflow configuration improvements:

* Added a `paths-ignore` list to `.github/workflows/docs.yml` to prevent documentation deployments when changes are made only to files or directories unrelated to the site build, such as tests, examples, scripts, and configuration files. This helps avoid publishing a stale or unnecessary documentation site.