### PR TITLE
Add smoke tests for shaded JAR to verify CLI functionality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,11 @@ jobs:
           [ -n "$VERSION" ] || { echo "ERROR: could not extract project version"; exit 1; }
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      # `verify`, not `package`: the shaded-JAR smoke tests (jpipe-cli's *IT)
+      # run after packaging, and only this phase reaches them. It also brings
+      # spotless, checkstyle and coverage into this job.
       - name: Build and test
-        run: mvn -B package
+        run: mvn -B verify
 
       # Locate the shaded fat JAR (exclude the *-original.jar that Shade leaves behind)
       - name: Locate fat JAR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ mvn test                                 # run all tests
 mvn test -pl jpipe-model                 # single module
 mvn test -pl jpipe-compiler              # E2E (Cucumber) tests
 mvn test -pl jpipe-compiler -Dtest=Foo   # single test class
-mvn verify                               # includes checkstyle and coverage
+mvn verify                               # + checkstyle, coverage, fat-JAR smoke tests
 mvn spotless:apply                       # auto-format (required before commit)
 mvn spotless:check                       # check formatting without applying
 ```
@@ -219,7 +219,10 @@ Architecture decisions live in `docs/adr/`. Notable ones:
   `ca.mcscert.jpipe.compiler.steps`.
 - **Testing:** New features must include Cucumber scenarios in
   `jpipe-compiler/src/test/resources/features` and JUnit Jupiter unit tests in
-  the relevant module.
+  the relevant module. Anything that only shows up once the fat JAR is
+  assembled — a dependency scope, a shade transformer, a packaged resource —
+  belongs in `jpipe-cli`'s `*IT` smoke tests, which run the built JAR itself;
+  unit tests resolve the module classpath and cannot see those failures.
 - **Logging:** Log4j 2; follow ADR-0006 conventions.
 - **Changelog:** Every user-facing change must be recorded in
   [`CHANGELOG.md`](CHANGELOG.md) under `## [Unreleased]` — see

--- a/jpipe-cli/README.md
+++ b/jpipe-cli/README.md
@@ -28,7 +28,12 @@ mvn package -pl jpipe-cli --also-make
 
 # Run
 java -jar target/jpipe-cli-*.jar --help
+
+# Build it and smoke-test the JAR itself
+mvn verify -pl jpipe-cli --also-make
 ```
 
 The fat JAR is the only distributable artefact; all other modules are
-internal.
+internal. Because it is assembled after the tests run, packaging mistakes are
+invisible to them: `ShadedJarIT` therefore runs the built JAR through each
+output path, and is what `verify` adds over `package`.

--- a/jpipe-cli/pom.xml
+++ b/jpipe-cli/pom.xml
@@ -100,6 +100,32 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Runs the *IT smoke tests after `package`, so they exercise the
+                 shaded JAR that users actually run. Unit tests cannot: surefire
+                 resolves the module's own classpath, where a dependency the
+                 shade plugin dropped is still present (see issue #153). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Shade replaces the main artifact, so this is the fat
+                             JAR; the pre-shade one is original-*.jar. -->
+                        <shaded.jar>${project.build.directory}/${project.build.finalName}.jar</shaded.jar>
+                        <examples.dir>${maven.multiModuleProjectDirectory}/examples</examples.dir>
+                        <project.version>${project.version}</project.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
@@ -1,0 +1,197 @@
+package ca.mcscert.jpipe.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarFile;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Smoke tests running the shaded JAR as a user would: {@code java -jar}.
+ *
+ * <p>
+ * The unit and Cucumber suites run against each module's own classpath, so a
+ * packaging mistake — a dependency the shade plugin dropped, a clobbered
+ * {@code META-INF} service file, a resource left out of the JAR — passes them
+ * all while the shipped CLI is broken. These tests exercise the artifact
+ * itself, once per output path, asserting exit codes and output shape rather
+ * than exact bytes.
+ *
+ * <p>
+ * Named {@code *IT} so failsafe runs them after {@code package}, when the JAR
+ * exists. They are part of {@code mvn verify}.
+ */
+class ShadedJarIT {
+
+	private static final String MINIMAL = example("000_minimal.jd");
+
+	/** Outcome of one CLI invocation. */
+	private record Execution(int exitCode, String out, String err) {
+	}
+
+	// ── the JAR loads and each output path runs ──────────────────────────────
+
+	@ParameterizedTest(name = "{0} exits 0 and writes {1}")
+	@CsvSource({"diagnostic, === Diagnostics ===", "process, digraph"})
+	void everyOutputPathRuns(String subcommand, String expected)
+			throws IOException {
+		Execution run = subcommand.equals("diagnostic")
+				? jpipe("--headless", "diagnostic", "-i", MINIMAL)
+				: jpipe("--headless", "process", "-i", MINIMAL, "-m", "minimal",
+						"-f", "dot");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(run.out()).contains(expected);
+	}
+
+	@Test
+	void theDiagnosticReportIsParseableJson() throws IOException {
+		// org.json is a transitive dependency: it went missing from the JAR
+		// once, and every unit test stayed green (#153).
+		Execution run = jpipe("--headless", "diagnostic", "-i", MINIMAL, "-f",
+				"json");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(new JSONObject(run.out()).getInt("schemaVersion"))
+				.isEqualTo(1);
+	}
+
+	@Test
+	void theExportedModelIsParseableJson() throws IOException {
+		Execution run = jpipe("--headless", "process", "-i", MINIMAL, "-m",
+				"minimal", "-f", "json");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(new JSONObject(run.out()).getString("name"))
+				.isEqualTo("minimal");
+	}
+
+	// ── the contract tools rely on ───────────────────────────────────────────
+
+	@Test
+	void theJsonReportStaysParseableWithoutHeadless() throws IOException {
+		// The logo must step aside on its own when the report goes to stdout,
+		// or every IDE integration would have to strip it.
+		Execution run = jpipe("diagnostic", "-i", MINIMAL, "-f", "json");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(new JSONObject(run.out()).getInt("schemaVersion"))
+				.isEqualTo(1);
+	}
+
+	@Test
+	void aFileWithValidationErrorsStillReportsAndExitsOne() throws IOException {
+		Execution run = jpipe("--headless", "diagnostic", "-i",
+				example("invalid/001_no_conclusion.jd"), "-f", "json");
+
+		assertThat(run.exitCode()).isEqualTo(1);
+		assertThat(new JSONObject(run.out()).getJSONArray("diagnostics"))
+				.isNotEmpty();
+	}
+
+	// ── packaging-sensitive plumbing ─────────────────────────────────────────
+
+	@Test
+	void theManifestCarriesTheProjectVersion() throws IOException {
+		// Proves the ManifestResourceTransformer kept Main-Class (the JAR ran
+		// at all) and Implementation-Version.
+		Execution run = jpipe("--version");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(run.out()).contains(System.getProperty("project.version"));
+	}
+
+	@Test
+	void loggingSurvivesShading() throws IOException {
+		// Log4j2's plugin registry is merged across JARs by a shade
+		// transformer;
+		// without it logging silently degrades to nothing.
+		Execution run = jpipe("--headless", "--log-level=INFO", "diagnostic",
+				"-i", MINIMAL);
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(run.err()).contains("ChainCompiler");
+	}
+
+	@Test
+	void doctorReportsOnTheToolsItProbes() throws IOException {
+		// Exit code depends on whether Graphviz is installed on the machine
+		// running the build, so only the report itself is asserted.
+		Execution run = jpipe("--headless", "doctor");
+
+		assertThat(run.exitCode()).isIn(Main.EXIT_OK, Main.EXIT_JPIPE_ERROR);
+		assertThat(run.out()).contains("dot (Graphviz):");
+	}
+
+	@Test
+	void theDiagnosticSchemaIsPackaged() throws IOException {
+		// Served from the site at the $id URL the JSON report declares, so its
+		// loss would break consumers without breaking any command.
+		try (JarFile jar = new JarFile(new File(jarPath()))) {
+			assertThat(jar.getEntry("schema/diagnostic-report-v1.schema.json"))
+					.isNotNull();
+		}
+	}
+
+	// ── helpers ──────────────────────────────────────────────────────────────
+
+	/** Runs the shaded JAR with {@code args}, and captures what it produced. */
+	private static Execution jpipe(String... args) throws IOException {
+		List<String> command = new ArrayList<>(
+				List.of(javaBinary(), "-jar", jarPath()));
+		command.addAll(List.of(args));
+		Process process = new ProcessBuilder(command).start();
+		String out = read(process.getInputStream());
+		String err = read(process.getErrorStream());
+		return new Execution(waitFor(process), out, err);
+	}
+
+	private static int waitFor(Process process) {
+		try {
+			return process.waitFor();
+		} catch (InterruptedException _) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(
+					"interrupted while running the JAR");
+		}
+	}
+
+	private static String read(InputStream stream) throws IOException {
+		try (stream) {
+			return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+	}
+
+	/** The executable of the JVM running the build: always available. */
+	private static String javaBinary() {
+		return System.getProperty("java.home") + File.separator + "bin"
+				+ File.separator + "java";
+	}
+
+	private static String jarPath() {
+		return required("shaded.jar");
+	}
+
+	private static String example(String name) {
+		return Path.of(required("examples.dir"), name).toString();
+	}
+
+	/** Reads a system property failsafe is expected to have set. */
+	private static String required(String key) {
+		String value = System.getProperty(key);
+		if (value == null) {
+			throw new IllegalStateException("'" + key
+					+ "' is not set: run these tests through `mvn verify`");
+		}
+		return value;
+	}
+}

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarFile;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -150,9 +151,23 @@ class ShadedJarIT {
 				List.of(javaBinary(), "-jar", jarPath()));
 		command.addAll(List.of(args));
 		Process process = new ProcessBuilder(command).start();
+
+		// Drain stderr in a virtual thread, as RenderWithDot does: reading the
+		// two streams one after the other lets a chatty stderr fill its pipe
+		// buffer and block the process before it can close stdout.
+		AtomicReference<String> stderr = new AtomicReference<>("");
+		Thread drain = Thread.ofVirtual().start(() -> {
+			try {
+				stderr.set(read(process.getErrorStream()));
+			} catch (IOException _) {
+				// Process died before stderr was fully read; safe to ignore.
+			}
+		});
+
 		String out = read(process.getInputStream());
-		String err = read(process.getErrorStream());
-		return new Execution(waitFor(process), out, err);
+		int exitCode = waitFor(process);
+		join(drain);
+		return new Execution(exitCode, out, stderr.get());
 	}
 
 	private static int waitFor(Process process) {
@@ -162,6 +177,15 @@ class ShadedJarIT {
 			Thread.currentThread().interrupt();
 			throw new IllegalStateException(
 					"interrupted while running the JAR");
+		}
+	}
+
+	private static void join(Thread thread) {
+		try {
+			thread.join();
+		} catch (InterruptedException _) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("interrupted while reading stderr");
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <log4j-transform.version>0.1.0</log4j-transform.version>
         <spotless-plugin.version>3.9.0</spotless-plugin.version>
@@ -241,6 +242,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
This pull request enhances the project's build and testing process by adding integration ("smoke") tests that run against the final shaded JAR, ensuring that the distributable artifact works as expected and catches packaging issues that unit tests cannot. It introduces the Maven Failsafe plugin to run these tests during the `verify` phase, updates documentation to reflect the new testing strategy, and adds comprehensive smoke tests for the CLI JAR.

**Build and Test Process Improvements**
- Switched the main CI build step from `mvn package` to `mvn verify` to ensure that integration tests (which run the shaded JAR) and additional checks (spotless, checkstyle, coverage) are executed during CI.
- Added and configured the Maven Failsafe plugin in both the root and `jpipe-cli` POMs to run `*IT` integration tests after the JAR is packaged. This ensures the final distributable artifact is tested, not just module classpaths. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R89) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R247-R252) [[3]](diffhunk://#diff-70e0ecf70d842804a690af37666f356433d1c9bcb4b80df625ee541367cd7d3dR103-R128)

**Testing Enhancements**
- Added `ShadedJarIT` integration tests to `jpipe-cli`, which run the shaded JAR as a user would (`java -jar ...`) and verify that critical commands, resource packaging, logging, and versioning work as intended. These tests catch errors missed by unit tests, such as missing dependencies or resources in the final JAR.

**Documentation Updates**
- Updated `CLAUDE.md` and `jpipe-cli/README.md` to explain the new role of `verify`, the purpose of the smoke tests, and why certain tests must be integration tests rather than unit tests. This helps contributors understand the improved testing strategy and its rationale. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L86-R86) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L222-R225) [[3]](diffhunk://#diff-b7ff26599943afff083e14b72306572dcee3ee24303ad355f0a9f69c6d78962bR31-R39)