### PR TITLE
Report compilation aborts with detailed diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
   outdated Graphviz, which is a common explanation for rendering problems.
 
 ### Fixed
+- `jpipe diagnostic` now writes a report even when compilation fails fatally —
+  a syntax error or an unresolvable `load` — in both `text` and `json`. The
+  report carries a diagnostic with `severity: "fatal"` and an empty `models`
+  list, and the exit code stays 1, so tooling no longer has to parse stderr for
+  the most common failure of a file being edited (#154).
 - Composition operators are now commutative when unification merges elements
   of different kinds: a claim that one model argues (a sub-conclusion) and
   another asserts (an evidence) merges into a sub-conclusion whichever order

--- a/docs/adr/0016-error-management.md
+++ b/docs/adr/0016-error-management.md
@@ -69,8 +69,9 @@ renderer chooses its own presentation.
 
 Codes are optional by design. Summary diagnostics such as `"model construction
 failed — see errors above"` name no specific rule, and none is invented for
-them. `FATAL` diagnostics carry no code: a fatal aborts the pipeline before any
-report is rendered, so nothing consumes one.
+them. `FATAL` diagnostics carry no code either: a fatal names a
+compilation-level failure — the pipeline cannot continue — rather than a rule
+that was broken.
 
 ### HaltAndCatchFire is placed exclusively after parsing
 
@@ -102,6 +103,23 @@ points to inspect the outcome without access to `CompilationContext`.
 `ChainCompiler` returns `ctx.hasErrors()` after the pipeline completes. If the
 pipeline throws (e.g. due to a `FATAL`), the exception propagates naturally and the
 return value is never reached — the CLI catch blocks handle that path.
+
+### Reporting on a compilation that aborted
+
+The pipeline invariant above is absolute: no step runs after a `FATAL`. That
+makes a report assembled as the last steps of a pipeline unable to describe the
+very failures that stopped it — which is what the `diagnostic` command exists to
+do.
+
+The command therefore has its own `DiagnosticCompiler`, which runs the analysis
+as a pipeline and then writes the report whether that pipeline completed or
+aborted; when it aborted, on the empty unit it never got to build. Rendering is
+reachable outside `fire()` for that reason (`CollectDiagnostics.snapshot` and
+`DiagnosticRenderer.render`). The exit code is unchanged: `hasErrors()` counts a
+`FATAL`, so the command still exits 1.
+
+`process` keeps the original behaviour, because its output stream carries a
+model export and a report written into it would corrupt the artefact.
 
 ### CLI exit codes
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -183,10 +183,19 @@ The ASCII logo is suppressed automatically when the JSON report goes to
 standard output, so `jpipe diagnostic -f json | jq .` works without
 `--headless`. Writing to a file with `-o` keeps the banner on stdout.
 
-**Limitation.** A *fatal* error (a syntax error, an unresolvable `load`) aborts
-the pipeline before any report is produced, in either format: nothing is
-written to the output stream, the message goes to standard error, and the exit
-code is 1. Tools must handle that case separately.
+**Reporting on a compilation that aborted.** A *fatal* error — a syntax error,
+an unresolvable `load` — stops the pipeline, but the report is still written in
+both formats: the diagnostics describe the failure, `models` is empty and the
+symbol table reads `(empty)`, because nothing could be built. The exit code is
+1. Consumers detect the case by finding a diagnostic with `severity: "fatal"`,
+and need no separate path for it.
+
+This is why `diagnostic` has its own compiler rather than assembling the report
+as the tail of the analysis chain — a report produced as a pipeline step could
+never describe the failures that stopped that pipeline. `process` deliberately
+keeps the old behaviour: its output stream carries a model export, so a report
+poured into it would corrupt the artefact. A fatal there still reaches standard
+error with exit code 1 and no output.
 
 ### `doctor`
 

--- a/docs/design/compiler.md
+++ b/docs/design/compiler.md
@@ -18,6 +18,12 @@ the only type that callers outside the module need to reference.
 `compiler.model`. It is not instantiated directly — `ChainBuilder.andThen(Sink)`
 produces it as the final step of pipeline construction.
 
+`DiagnosticCompiler` backs the `diagnostic` command. It runs the analysis as a
+pipeline but writes its report whether that pipeline completed or aborted, so a
+syntax error or an unresolvable `load` is reported rather than swallowed
+(ADR-0016). A report assembled as the tail of the chain could not do that: a
+fatal stops the chain before those steps run.
+
 ```plantuml
 @startuml compiler
 
@@ -38,7 +44,16 @@ package "compiler" {
     + compile(String, String) : boolean
   }
 
+  class DiagnosticCompiler {
+    - source : Source<InputStream>
+    - analysis : Transformation<InputStream, Unit>
+    - renderer : DiagnosticRenderer
+    - sink : Sink<String>
+    + compile(String, String) : boolean
+  }
+
   Compiler <|.. ChainCompiler
+  Compiler <|.. DiagnosticCompiler
 }
 
 @enduml

--- a/docs/design/diagnostic-schema.md
+++ b/docs/design/diagnostic-schema.md
@@ -100,16 +100,22 @@ report.
 
 Instead `JsonDiagnosticReportSchemaTest` validates against the schema every
 report produced from the unit fixtures **and from every file in `examples/`**,
-so code and schema cannot drift apart without CI noticing. The same test also
+compiled through the same wiring the CLI uses — including the sources that
+abort, which are also asserted to carry their fatal — so code and schema cannot
+drift apart without CI noticing. The same test also
 asserts that the schema rejects malformed documents, so it cannot quietly decay
 into one that accepts anything.
 
 ## Note on fatal errors
 
-A *fatal* error — a syntax error, an unresolvable `load` — aborts the pipeline
-before any report is rendered. **Nothing is written to the output stream**, the
-message goes to standard error, and the exit code is 1. Consumers must handle
-that case outside the schema. `severity: "fatal"` is reserved in the schema but
-does not currently appear in any document.
+A *fatal* error — a syntax error, an unresolvable `load` — aborts the
+compilation, and the report describes exactly that: one or more diagnostics
+with `severity: "fatal"`, `status: "errors"`, an empty `models` array and zeroed
+statistics, because nothing could be built. The exit code is 1.
+
+Consumers therefore need no separate path for it: the document has the same
+shape as any other, and an aborted compilation is recognised by the severity.
+That matters most for editor integrations, since a file being edited is
+syntactically broken most of the time.
 
 See [`cli.md`](cli.md#diagnostic) for the command itself.

--- a/docs/design/steps.md
+++ b/docs/design/steps.md
@@ -290,9 +290,13 @@ only step that walks the `Unit` for reporting purposes; the renderers below
 consume the snapshot and never touch the model, which is what keeps the two
 report formats describing the same compilation.
 
+Also callable directly as `snapshot(Unit, CompilationContext)`. `DiagnosticCompiler`
+uses that entry point, with an empty `Unit`, to report on a compilation that
+aborted — a fatal stops the pipeline before this step would otherwise run.
+
 #### `DiagnosticReport`
 
-**Type:** `Transformation<DiagnosticSnapshot, String>`  
+**Type:** `DiagnosticRenderer` (a `Transformation<DiagnosticSnapshot, String>`)  
 **Package:** `compiler.steps.transformations`
 
 Renders the snapshot as the human-readable report printed by the `diagnostic`
@@ -303,13 +307,17 @@ operators), and Executed Actions. Sections whose data is absent are omitted.
 
 #### `JsonDiagnosticReport`
 
-**Type:** `Transformation<DiagnosticSnapshot, String>`  
+**Type:** `DiagnosticRenderer` (a `Transformation<DiagnosticSnapshot, String>`)  
 **Package:** `compiler.steps.transformations`
 
 Renders the same snapshot as JSON for tooling — selected by `diagnostic -f
 json`. Uses `org.json` internally as a builder for correct escaping while the
 pipeline type stays `String` (ADR-0013). The document declares a
 `schemaVersion`; see [`cli.md`](cli.md) for its shape.
+
+Both renderers extend `DiagnosticRenderer`, whose `render(DiagnosticSnapshot)`
+is reachable outside `fire()` for the same reason as `CollectDiagnostics.snapshot`
+above.
 
 ---
 

--- a/examples/invalid/025_syntax_error.jd
+++ b/examples/invalid/025_syntax_error.jd
@@ -1,0 +1,16 @@
+/*********************************
+ * jPipe  -  Reference Examples  *
+ * @author   Sebastien Mosser    *
+ * @compiler 2.x                 *
+ *********************************/
+
+// The parser reports each syntax error, then HaltAndCatchFire promotes them
+// into a fatal that aborts the pipeline. The diagnostic command still reports
+// on the aborted compilation: this is the state a file spends most of its time
+// in while being edited.
+justification broken {
+    conclusion c is "A conclusion"
+    strategy   s is
+    this is not valid jd syntax %%%
+    s supports c
+}

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DiagnosticCommandTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DiagnosticCommandTest.java
@@ -1,14 +1,14 @@
 package ca.mcscert.jpipe.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ca.mcscert.jpipe.compiler.CompilationConfig;
 import ca.mcscert.jpipe.compiler.DiagnosticFormat;
-import ca.mcscert.jpipe.compiler.model.CompilationException;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -26,14 +26,44 @@ class DiagnosticCommandTest {
 	}
 
 	@Test
-	void doCall_invalid_syntax_throws_compilation_exception() {
+	void doCall_invalid_syntax_still_writes_a_report() throws Exception {
+		// A file being edited is broken most of the time: that is exactly when
+		// a tool needs a report rather than an empty stream (#154).
 		DiagnosticCommand cmd = new DiagnosticCommand();
 		cmd.input = resourcePath("test_invalid.jd");
 		cmd.output = CompilationConfig.STDOUT;
-
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		assertThatThrownBy(() -> cmd.doCall(out))
-				.isInstanceOf(CompilationException.class);
+
+		Integer result = cmd.doCall(out);
+
+		assertThat(result).isEqualTo(Main.EXIT_JPIPE_ERROR);
+		assertThat(out.toString(StandardCharsets.UTF_8))
+				.contains("=== Diagnostics ===").contains("[FATAL]");
+	}
+
+	@Test
+	void doCall_invalid_syntax_writes_a_parseable_json_report()
+			throws Exception {
+		DiagnosticCommand cmd = new DiagnosticCommand();
+		cmd.input = resourcePath("test_invalid.jd");
+		cmd.output = CompilationConfig.STDOUT;
+		cmd.format = DiagnosticFormat.JSON;
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		Integer result = cmd.doCall(out);
+
+		JSONObject report = new JSONObject(
+				out.toString(StandardCharsets.UTF_8));
+		assertThat(result).isEqualTo(Main.EXIT_JPIPE_ERROR);
+		assertThat(report.getString("status")).isEqualTo("errors");
+		assertThat(report.getJSONArray("models")).isEmpty();
+		assertThat(severities(report)).contains("fatal");
+	}
+
+	/** The severity of every diagnostic in a JSON report. */
+	private static List<String> severities(JSONObject report) {
+		return report.getJSONArray("diagnostics").toList().stream()
+				.map(d -> (String) ((Map<?, ?>) d).get("severity")).toList();
 	}
 
 	@Test

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
@@ -99,6 +99,20 @@ class ShadedJarIT {
 				.isNotEmpty();
 	}
 
+	@Test
+	void aFileThatFailsFatallyStillReportsAndExitsOne() throws IOException {
+		// The issue's own repro: an unresolvable load used to leave stdout
+		// empty, which is the case a tool most needs to read (#154).
+		Execution run = jpipe("--headless", "diagnostic", "-i",
+				example("invalid/021_load_glob_invalid.jd"), "-f", "json");
+
+		JSONObject report = new JSONObject(run.out());
+		assertThat(run.exitCode()).isEqualTo(1);
+		assertThat(report.getString("status")).isEqualTo("errors");
+		assertThat(report.getJSONArray("diagnostics").getJSONObject(0)
+				.getString("severity")).isEqualTo("fatal");
+	}
+
 	// ── packaging-sensitive plumbing ─────────────────────────────────────────
 
 	@Test
@@ -120,7 +134,7 @@ class ShadedJarIT {
 				"-i", MINIMAL);
 
 		assertThat(run.exitCode()).isZero();
-		assertThat(run.err()).contains("ChainCompiler");
+		assertThat(run.err()).contains("Compiling [");
 	}
 
 	@Test

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
@@ -2,7 +2,6 @@ package ca.mcscert.jpipe.compiler;
 
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.compiler.model.ChainBuilder;
-import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
 import ca.mcscert.jpipe.operators.OperatorRegistry;
 import ca.mcscert.jpipe.operators.UnificationEquivalenceRegistry;
 import ca.mcscert.jpipe.operators.equivalences.SameLabel;
@@ -18,6 +17,7 @@ import ca.mcscert.jpipe.compiler.steps.transformations.ActionListProvider;
 import ca.mcscert.jpipe.compiler.steps.transformations.LoadResolver;
 import ca.mcscert.jpipe.compiler.steps.transformations.CharStreamProvider;
 import ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics;
+import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticRenderer;
 import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
 import ca.mcscert.jpipe.compiler.steps.transformations.ExportToDot;
 import ca.mcscert.jpipe.compiler.steps.transformations.ExportToJson;
@@ -114,6 +114,11 @@ public final class CompilerFactory {
 	 * Both formats share the {@link CollectDiagnostics} step and differ only in
 	 * their renderer, so they always describe the same compilation.
 	 *
+	 * <p>
+	 * The report is written by a {@link DiagnosticCompiler} rather than
+	 * assembled as the tail of the analysis chain, so that a compilation which
+	 * aborts on a fatal diagnostic is still reported on.
+	 *
 	 * @param format
 	 *            how to render the report.
 	 * @param stdout
@@ -123,13 +128,13 @@ public final class CompilerFactory {
 	 */
 	public static Compiler buildDiagnosticCompiler(DiagnosticFormat format,
 			OutputStream stdout) {
-		Transformation<DiagnosticSnapshot, String> renderer = switch (format) {
+		DiagnosticRenderer renderer = switch (format) {
 			case TEXT -> new DiagnosticReport();
 			case JSON -> new JsonDiagnosticReport();
 		};
-		return parsingChain().andThen(unitBuilder())
-				.andThen(new CollectDiagnostics()).andThen(renderer)
-				.andThen(new StringSink(stdout));
+		return new DiagnosticCompiler(new FileSource(),
+				parsingChain().andThen(unitBuilder()).asTransformation(),
+				renderer, new StringSink(stdout));
 	}
 
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticCompiler.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticCompiler.java
@@ -1,0 +1,72 @@
+package ca.mcscert.jpipe.compiler;
+
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.CompilationException;
+import ca.mcscert.jpipe.compiler.model.Sink;
+import ca.mcscert.jpipe.compiler.model.Source;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+import ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics;
+import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticRenderer;
+import ca.mcscert.jpipe.model.Unit;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The compiler behind the {@code diagnostic} command: it reports on a
+ * compilation rather than producing an artefact from it.
+ *
+ * <p>
+ * That distinction is why this is not a {@link ChainCompiler
+ * ca.mcscert.jpipe.compiler.model.ChainCompiler}. A fatal diagnostic aborts the
+ * pipeline at the next {@code fire()} boundary (ADR-0016), so a report
+ * assembled as the last steps of that same pipeline could never describe a
+ * syntax error or an unresolvable {@code load} — precisely the failures a tool
+ * most needs to read. Here the analysis runs as a pipeline, and the report is
+ * written whether it completed or aborted; when it aborted, on the empty unit
+ * it never got to build.
+ *
+ * <p>
+ * The pipeline invariant is untouched: no step runs after a fatal, and
+ * {@code process} still fails without writing anything, since a report poured
+ * into an export stream would corrupt the artefact.
+ */
+final class DiagnosticCompiler implements Compiler {
+
+	private static final Logger logger = LogManager.getLogger();
+
+	private final Source<InputStream> source;
+	private final Transformation<InputStream, Unit> analysis;
+	private final DiagnosticRenderer renderer;
+	private final Sink<String> sink;
+
+	DiagnosticCompiler(Source<InputStream> source,
+			Transformation<InputStream, Unit> analysis,
+			DiagnosticRenderer renderer, Sink<String> sink) {
+		this.source = source;
+		this.analysis = analysis;
+		this.renderer = renderer;
+		this.sink = sink;
+	}
+
+	@Override
+	public boolean compile(String sourceFile, String sinkFile)
+			throws IOException {
+		logger.info("Compiling [{}]", sourceFile);
+		CompilationContext ctx = new CompilationContext(sourceFile);
+		InputStream input = source.provideFrom(sourceFile);
+		Unit unit;
+		try {
+			unit = analysis.fire(input, ctx);
+		} catch (CompilationException _) {
+			// The abort is the subject of the report, not a reason to skip it.
+			// Only a fatal is caught here: a bug in a step still propagates.
+			unit = new Unit(sourceFile);
+		}
+		sink.pourInto(
+				renderer.render(new CollectDiagnostics().snapshot(unit, ctx)));
+		logger.info("Compilation finished [{}]", sourceFile);
+		return ctx.hasErrors();
+	}
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/ChainCompiler.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/ChainCompiler.java
@@ -39,9 +39,7 @@ public final class ChainCompiler<I, O> implements Compiler {
 			O output = chain.fire(input, ctx);
 			sink.pourInto(output);
 		} finally {
-			if (!ctx.diagnosticsRendered()) {
-				printDiagnostics(ctx);
-			}
+			printDiagnostics(ctx);
 		}
 		logger.info("Compilation finished [{}]", sourceFile);
 		return ctx.hasErrors();

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/CompilationContext.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/CompilationContext.java
@@ -35,7 +35,6 @@ public final class CompilationContext {
 	private final List<Diagnostic> diagnostics = new ArrayList<>();
 	private final Map<String, Long> stats = new LinkedHashMap<>();
 	private List<ExecutedAction> executedActions = List.of();
-	private boolean diagnosticsRendered = false;
 
 	public CompilationContext(String sourcePath) {
 		this.sourcePath = sourcePath;
@@ -137,21 +136,6 @@ public final class CompilationContext {
 	/** Ordered list of actions that occurred during interpretation. */
 	public List<ExecutedAction> executedActions() {
 		return executedActions;
-	}
-
-	/**
-	 * Signal that a pipeline step has already rendered the diagnostics (e.g.
-	 * {@code DiagnosticReport}), so
-	 * {@link ca.mcscert.jpipe.compiler.model.ChainCompiler} should not print
-	 * them a second time.
-	 */
-	public void markDiagnosticsRendered() {
-		this.diagnosticsRendered = true;
-	}
-
-	/** True when a step has already rendered the diagnostics. */
-	public boolean diagnosticsRendered() {
-		return diagnosticsRendered;
 	}
 
 }

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnostics.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnostics.java
@@ -43,6 +43,25 @@ public final class CollectDiagnostics
 
 	@Override
 	protected DiagnosticSnapshot run(Unit input, CompilationContext ctx) {
+		return snapshot(input, ctx);
+	}
+
+	/**
+	 * Describes what a compilation produced and reported.
+	 *
+	 * <p>
+	 * Callable directly, and not only as a pipeline step, so that a compilation
+	 * which aborted on a fatal diagnostic can still be reported on — pass an
+	 * empty {@link Unit} for the models it never got to build.
+	 *
+	 * @param input
+	 *            the compiled unit; empty, never {@code null}, when the
+	 *            pipeline aborted.
+	 * @param ctx
+	 *            the context carrying diagnostics, statistics and actions.
+	 * @return the render-agnostic report payload.
+	 */
+	public DiagnosticSnapshot snapshot(Unit input, CompilationContext ctx) {
 		Map<String, List<ImplementorInfo>> implementors = implementorsOf(input);
 		Map<String, Map<String, String>> aliases = groupAliasesByModel(input);
 		List<ModelInfo> models = new ArrayList<>();

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticRenderer.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticRenderer.java
@@ -1,0 +1,39 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+
+/**
+ * Common base of the {@code diagnostic} command's renderers.
+ *
+ * <p>
+ * Rendering is exposed as {@link #render(DiagnosticSnapshot)}, callable
+ * directly and not only as a pipeline step. That is what lets a compilation
+ * which aborted still be reported on: a fatal diagnostic stops the pipeline at
+ * the next {@link Transformation#fire} boundary (ADR-0016), so a report that
+ * could only be produced as a step could never describe the very failures it
+ * exists to report.
+ *
+ * @see DiagnosticReport
+ * @see JsonDiagnosticReport
+ */
+public abstract class DiagnosticRenderer
+		extends
+			Transformation<DiagnosticSnapshot, String> {
+
+	/**
+	 * Renders a snapshot into the report text.
+	 *
+	 * @param snapshot
+	 *            what the compilation produced and reported.
+	 * @return the rendered report.
+	 */
+	public abstract String render(DiagnosticSnapshot snapshot);
+
+	@Override
+	protected final String run(DiagnosticSnapshot input,
+			CompilationContext ctx) {
+		return render(input);
+	}
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReport.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReport.java
@@ -1,6 +1,5 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
-import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_DEFERRALS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_MACROS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
@@ -11,7 +10,6 @@ import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.AliasInfo;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ElementCounts;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ModelInfo;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.SymbolInfo;
-import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.model.SourceLocation;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,9 +37,7 @@ import java.util.stream.Collectors;
  * @see CollectDiagnostics
  * @see JsonDiagnosticReport
  */
-public final class DiagnosticReport
-		extends
-			Transformation<DiagnosticSnapshot, String> {
+public final class DiagnosticReport extends DiagnosticRenderer {
 
 	private static final String HDR_DIAGNOSTICS = "=== Diagnostics ===\n";
 	private static final String HDR_ACTION_STATS = "\n=== Action Statistics ===\n";
@@ -52,14 +48,13 @@ public final class DiagnosticReport
 	private static final String ARROW = "\u2192";
 
 	@Override
-	protected String run(DiagnosticSnapshot input, CompilationContext ctx) {
+	public String render(DiagnosticSnapshot input) {
 		StringBuilder sb = new StringBuilder();
 		appendDiagnostics(sb, input);
 		appendActionStats(sb, input);
 		appendModelSummary(sb, input);
 		appendSymbolTable(sb, input);
 		appendActionList(sb, input);
-		ctx.markDiagnosticsRendered();
 		return sb.toString();
 	}
 

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReport.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReport.java
@@ -1,6 +1,5 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
-import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_DEFERRALS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_MACROS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
@@ -12,7 +11,6 @@ import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ElementCounts;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ImplementorInfo;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ModelInfo;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.SymbolInfo;
-import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.model.SourceLocation;
 import java.util.Map;
 import java.util.Optional;
@@ -59,9 +57,7 @@ import org.json.JSONObject;
  * @see CollectDiagnostics
  * @see DiagnosticReport
  */
-public final class JsonDiagnosticReport
-		extends
-			Transformation<DiagnosticSnapshot, String> {
+public final class JsonDiagnosticReport extends DiagnosticRenderer {
 
 	/** Version of the emitted document shape. */
 	public static final int SCHEMA_VERSION = 1;
@@ -74,7 +70,7 @@ public final class JsonDiagnosticReport
 	private static final String KEY_LOCATION = "location";
 
 	@Override
-	protected String run(DiagnosticSnapshot input, CompilationContext ctx) {
+	public String render(DiagnosticSnapshot input) {
 		JSONObject result = new JSONObject();
 		result.put("schemaVersion", SCHEMA_VERSION);
 		result.put(KEY_SOURCE, input.source());
@@ -83,7 +79,6 @@ public final class JsonDiagnosticReport
 		result.put("stats", stats(input.stats()));
 		result.put("models", models(input));
 		result.put("actions", actions(input));
-		ctx.markDiagnosticsRendered();
 		return result.toString(INDENT);
 	}
 

--- a/jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json
+++ b/jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json
@@ -74,7 +74,7 @@
       "required": ["severity", "source", "message"],
       "properties": {
         "severity": {
-          "description": "'error' accumulates and sets the exit code (ADR-0016). 'fatal' is reserved: a fatal aborts the pipeline before any report is rendered, so it does not currently appear in a document — consumers should still handle it.",
+          "description": "'error' accumulates and sets the exit code (ADR-0016). 'fatal' aborts the compilation: the report still describes it, with an empty 'models' array, since nothing could be built.",
           "enum": ["error", "fatal"]
         },
         "code": { "$ref": "#/$defs/code" },

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/DiagnosticCompilerTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/DiagnosticCompilerTest.java
@@ -1,0 +1,105 @@
+package ca.mcscert.jpipe.compiler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.Sink;
+import ca.mcscert.jpipe.compiler.model.Source;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
+import ca.mcscert.jpipe.model.Unit;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class DiagnosticCompilerTest {
+
+	private final StringBuilder poured = new StringBuilder();
+
+	// ── stubs ────────────────────────────────────────────────────────────────
+
+	/** A source that never touches the filesystem. */
+	private static Source<InputStream> source() {
+		return new Source<>() {
+			@Override
+			public InputStream provideFrom(String path) {
+				return new ByteArrayInputStream(
+						"ignored".getBytes(StandardCharsets.UTF_8));
+			}
+		};
+	}
+
+	/** An analysis step that reports {@code diagnostic} and returns a unit. */
+	private static Transformation<InputStream, Unit> analysis(
+			java.util.function.Consumer<CompilationContext> diagnostic) {
+		return new Transformation<>() {
+			@Override
+			protected Unit run(InputStream in, CompilationContext ctx) {
+				diagnostic.accept(ctx);
+				return new Unit(ctx.sourcePath());
+			}
+		};
+	}
+
+	private Sink<String> sink() {
+		return poured::append;
+	}
+
+	private DiagnosticCompiler compiler(
+			Transformation<InputStream, Unit> analysis) {
+		return new DiagnosticCompiler(source(), analysis,
+				new DiagnosticReport(), sink());
+	}
+
+	// ── tests ────────────────────────────────────────────────────────────────
+
+	@Test
+	void aCleanCompilationIsReportedAndSucceeds() throws IOException {
+		boolean hasErrors = compiler(analysis(ctx -> {
+			// intentionally quiet: nothing to report
+		})).compile("clean.jd", "<stdout>");
+
+		assertThat(hasErrors).isFalse();
+		assertThat(poured).contains("=== Diagnostics ===").contains("(none)");
+	}
+
+	@Test
+	void anAbortedCompilationIsStillReported() throws IOException {
+		// The fatal makes the *next* fire() boundary throw, which is exactly
+		// the case that used to produce no report at all (#154).
+		boolean hasErrors = compiler(analysis(ctx -> ctx.fatal("unrecoverable"))
+				.andThen(passThrough())).compile("broken.jd", "<stdout>");
+
+		assertThat(hasErrors).isTrue();
+		assertThat(poured).contains("[FATAL]").contains("unrecoverable")
+				.contains("(empty)");
+	}
+
+	@Test
+	void aBugInAStepIsNotSwallowed() {
+		Transformation<InputStream, Unit> exploding = new Transformation<>() {
+			@Override
+			protected Unit run(InputStream in, CompilationContext ctx) {
+				throw new IllegalStateException("a bug, not a diagnostic");
+			}
+		};
+		DiagnosticCompiler compiler = compiler(exploding);
+
+		assertThatThrownBy(() -> compiler.compile("any.jd", "<stdout>"))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("a bug");
+	}
+
+	/** A step that only exists to give the fatal a boundary to abort at. */
+	private static Transformation<Unit, Unit> passThrough() {
+		return new Transformation<>() {
+			@Override
+			protected Unit run(Unit in, CompilationContext ctx) {
+				return in;
+			}
+		};
+	}
+}

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
@@ -3,7 +3,9 @@ package ca.mcscert.jpipe.compiler.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
+import ca.mcscert.jpipe.compiler.CompilationConfig;
 import ca.mcscert.jpipe.compiler.CompilerFactory;
+import ca.mcscert.jpipe.compiler.DiagnosticFormat;
 import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import ca.mcscert.jpipe.compiler.model.CompilationException;
 import ca.mcscert.jpipe.compiler.model.Diagnostic;
@@ -25,10 +27,14 @@ import io.cucumber.java.en.When;
 import ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics;
 import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
 import ca.mcscert.jpipe.compiler.steps.transformations.JsonDiagnosticReport;
+import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -45,6 +51,7 @@ public class CompilationSteps {
 	private String dotOutput;
 	private String pythonOutput;
 	private String jsonOutput;
+	private boolean reportedErrors;
 	private String textReport;
 	private JSONObject jsonReport;
 
@@ -209,6 +216,42 @@ public class CompilationSteps {
 				.andThen(new JsonDiagnosticReport()).fire(unit, ctx));
 	}
 
+	/**
+	 * Runs the {@code diagnostic} command's own compiler, which reports on a
+	 * compilation whether it completed or aborted — unlike the steps above,
+	 * which need a unit and so cannot describe a fatal (#154).
+	 */
+	@When("I run the diagnostic compiler with format {string}")
+	public void iRunTheDiagnosticCompilerWithFormat(String format)
+			throws IOException {
+		DiagnosticFormat target = DiagnosticFormat
+				.valueOf(format.toUpperCase(Locale.ROOT));
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		reportedErrors = CompilerFactory.buildDiagnosticCompiler(target, out)
+				.compile(sourcePath, CompilationConfig.STDOUT);
+		String rendered = out.toString(StandardCharsets.UTF_8);
+		if (target == DiagnosticFormat.JSON) {
+			jsonReport = new JSONObject(rendered);
+		} else {
+			textReport = rendered;
+		}
+	}
+
+	@Then("the report signals errors")
+	public void theReportSignalsErrors() {
+		assertThat(reportedErrors).isTrue();
+	}
+
+	@Then("the JSON report has a diagnostic with severity {string}")
+	public void theJsonReportHasADiagnosticWithSeverity(String severity) {
+		assertThat(severitiesIn(jsonReport)).contains(severity);
+	}
+
+	@Then("the JSON report describes no model")
+	public void theJsonReportDescribesNoModel() {
+		assertThat(jsonReport.getJSONArray("models")).isEmpty();
+	}
+
 	@Then("the text report contains {string}")
 	public void theTextReportContains(String fragment) {
 		assertThat(textReport).contains(fragment);
@@ -257,6 +300,15 @@ public class CompilationSteps {
 	public void bothReportsAgreeOnTheNumberOfDiagnostics() {
 		assertThat(jsonReport.getJSONArray("diagnostics").length())
 				.isEqualTo(ctx.diagnostics().size());
+	}
+
+	private static List<String> severitiesIn(JSONObject report) {
+		JSONArray diagnostics = report.getJSONArray("diagnostics");
+		List<String> severities = new ArrayList<>();
+		for (int i = 0; i < diagnostics.length(); i++) {
+			severities.add(diagnostics.getJSONObject(i).getString("severity"));
+		}
+		return severities;
 	}
 
 	private static List<String> codesIn(JSONObject report) {

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
@@ -121,16 +121,6 @@ class CollectDiagnosticsTest {
 				.isInstanceOf(UnsupportedOperationException.class);
 	}
 
-	@Test
-	void collectingDoesNotMarkDiagnosticsRendered() {
-		collect();
-
-		// Only a renderer may claim the diagnostics were shown to the user;
-		// otherwise a failure between collect and render would silently
-		// swallow ChainCompiler's fallback dump.
-		assertThat(ctx.diagnosticsRendered()).isFalse();
-	}
-
 	// -------------------------------------------------------------------------
 	// Models
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReportTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReportTest.java
@@ -122,11 +122,6 @@ class DiagnosticReportTest {
 			assertThat(report).contains("5:10").contains("bad token");
 		}
 
-		@Test
-		void markDiagnosticsRendered_is_called_after_run() {
-			report();
-			assertThat(ctx.diagnosticsRendered()).isTrue();
-		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportSchemaTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportSchemaTest.java
@@ -1,13 +1,12 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ca.mcscert.jpipe.compiler.CompilationConfig;
 import ca.mcscert.jpipe.compiler.CompilerFactory;
+import ca.mcscert.jpipe.compiler.DiagnosticFormat;
 import ca.mcscert.jpipe.compiler.model.CompilationContext;
-import ca.mcscert.jpipe.compiler.model.CompilationException;
 import ca.mcscert.jpipe.compiler.model.DiagnosticCodes;
-import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Template;
@@ -22,14 +21,19 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
-import java.io.FileInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -107,19 +111,20 @@ class JsonDiagnosticReportSchemaTest {
 	}
 
 	/**
-	 * No fatal fixture exists above because one cannot: {@code fire()}
-	 * fast-fails on a fatal, so a report is never produced for a compilation
-	 * that has one. The schema still admits the value — see
-	 * {@link #schemaAdmitsFatalSeverityForFutureUse()}.
+	 * A compilation that aborted is reported on like any other, describing the
+	 * empty unit it never got to build (#154). Rendered directly rather than
+	 * through {@code fire()}, which still fast-fails on a fatal by design.
 	 */
 	@Test
-	void aFatalPreventsAnyReportFromBeingProduced() {
+	void aFatalStillProducesAConformingReport() {
 		CompilationContext ctx = new CompilationContext("test.jd");
 		ctx.fatal("unrecoverable");
-		Unit unit = new Unit("test.jd");
 
-		assertThatThrownBy(() -> reportOf(unit, ctx))
-				.isInstanceOf(CompilationException.class);
+		String report = renderedReportOf(new Unit("test.jd"), ctx);
+
+		assertConforms(report);
+		assertThat(new JSONObject(report).getJSONArray("diagnostics")
+				.getJSONObject(0).getString("severity")).isEqualTo("fatal");
 	}
 
 	@Test
@@ -143,25 +148,27 @@ class JsonDiagnosticReportSchemaTest {
 	}
 
 	/**
-	 * The whole example corpus, compiled for real. Sources that fail fatally
-	 * produce no report at all (documented behaviour), so they are skipped
-	 * rather than asserted on.
+	 * The whole example corpus, compiled through the production wiring — every
+	 * file, including the ones that abort on a fatal (#154).
 	 */
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("exampleSources")
 	void everyExampleConformsToTheSchema(Path source) throws IOException {
-		Transformation<InputStream, Unit> pipeline = CompilerFactory
-				.parsingChain().andThen(CompilerFactory.unitBuilder())
-				.asTransformation();
-		CompilationContext ctx = new CompilationContext(source.toString());
-		Unit unit;
-		try (FileInputStream stream = new FileInputStream(source.toFile())) {
-			unit = pipeline.fire(stream, ctx);
-		} catch (CompilationException _) {
-			return; // fatal: no report is produced, in either format
-		}
+		assertConforms(compileToJsonReport(source));
+	}
 
-		assertConforms(reportOf(unit, ctx));
+	/**
+	 * Sources that abort still describe the failure: conformance alone would
+	 * pass on an empty document, which is the bug this guards against.
+	 */
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("fatalExampleSources")
+	void everyFatalExampleReportsItsFatal(Path source) throws IOException {
+		JSONObject report = new JSONObject(compileToJsonReport(source));
+
+		assertThat(report.getString("status")).isEqualTo("errors");
+		assertThat(report.getJSONArray("models")).isEmpty();
+		assertThat(severitiesOf(report)).contains("fatal");
 	}
 
 	static Stream<Path> exampleSources() throws IOException {
@@ -170,6 +177,36 @@ class JsonDiagnosticReportSchemaTest {
 			return paths.filter(p -> p.toString().endsWith(".jd"))
 					.sorted(Comparator.naturalOrder()).toList().stream();
 		}
+	}
+
+	/** The examples that abort: a syntax error, and the unresolvable loads. */
+	static Stream<Path> fatalExampleSources() throws IOException {
+		return exampleSources().filter(JsonDiagnosticReportSchemaTest::isFatal);
+	}
+
+	private static boolean isFatal(Path source) {
+		try {
+			return new JSONObject(compileToJsonReport(source))
+					.getJSONArray("diagnostics").toList().stream()
+					.anyMatch(d -> "fatal"
+							.equals(((Map<?, ?>) d).get("severity")));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	/** Compiles a source through the production diagnostic wiring. */
+	private static String compileToJsonReport(Path source) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		CompilerFactory.buildDiagnosticCompiler(DiagnosticFormat.JSON, out)
+				.compile(source.toString(), CompilationConfig.STDOUT);
+		return out.toString(StandardCharsets.UTF_8);
+	}
+
+	/** The severity of every diagnostic in a report. */
+	private static List<String> severitiesOf(JSONObject report) {
+		return report.getJSONArray("diagnostics").toList().stream()
+				.map(d -> (String) ((Map<?, ?>) d).get("severity")).toList();
 	}
 
 	// -------------------------------------------------------------------------
@@ -202,16 +239,22 @@ class JsonDiagnosticReportSchemaTest {
 	}
 
 	/**
-	 * The value is reserved rather than reachable today: a fatal aborts before
-	 * any report is rendered. Pinned so the schema stays ready if that
-	 * limitation is lifted.
+	 * A fatal carries no code and usually no location, both of which the schema
+	 * allows. Rendered from a real fatal rather than synthesised, so the schema
+	 * is held to what the emitter actually produces.
 	 */
 	@Test
-	void schemaAdmitsFatalSeverityForFutureUse() throws IOException {
-		JsonNode report = MAPPER.readTree(reportWithCode("unknown-model"));
-		((ObjectNode) report.at("/diagnostics/0")).put("severity", "fatal");
+	void schemaAcceptsARealFatalDiagnostic() throws IOException {
+		CompilationContext ctx = new CompilationContext("t.jd");
+		ctx.fatal("unrecoverable");
+
+		JsonNode report = MAPPER
+				.readTree(renderedReportOf(new Unit("t.jd"), ctx));
 
 		assertThat(SCHEMA.validate(report)).isEmpty();
+		assertThat(report.at("/diagnostics/0/severity").asText())
+				.isEqualTo("fatal");
+		assertThat(report.at("/diagnostics/0").has("code")).isFalse();
 	}
 
 	@Test
@@ -261,6 +304,15 @@ class JsonDiagnosticReportSchemaTest {
 	private static String reportOf(Unit unit, CompilationContext ctx) {
 		return new CollectDiagnostics().andThen(new JsonDiagnosticReport())
 				.fire(unit, ctx);
+	}
+
+	/**
+	 * Renders without going through {@code fire()}, the way the diagnostic
+	 * compiler does when a compilation aborted.
+	 */
+	private static String renderedReportOf(Unit unit, CompilationContext ctx) {
+		return new JsonDiagnosticReport()
+				.render(new CollectDiagnostics().snapshot(unit, ctx));
 	}
 
 	private static String reportWithCode(String code) {

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportTest.java
@@ -82,11 +82,6 @@ class JsonDiagnosticReportTest {
 			assertThat(report().getString("status")).isEqualTo("errors");
 		}
 
-		@Test
-		void markDiagnosticsRenderedIsCalled() {
-			report();
-			assertThat(ctx.diagnosticsRendered()).isTrue();
-		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/resources/features/diagnostic.feature
+++ b/jpipe-compiler/src/test/resources/features/diagnostic.feature
@@ -60,3 +60,29 @@ Feature: Reporting on a compilation unit
     When I produce a JSON diagnostic report
     Then the JSON report describes a "template" named "t"
       And the JSON report status is "ok"
+
+  # A file being edited is syntactically broken most of the time, which is
+  # exactly when a tool needs something machine-readable back (#154).
+  Scenario: A syntax error is reported in JSON rather than aborting silently
+    Given the source file "invalid/025_syntax_error.jd"
+    When I run the diagnostic compiler with format "json"
+    Then the report signals errors
+      And the JSON report status is "errors"
+      And the JSON report declares a schema version
+      And the JSON report has a diagnostic with severity "fatal"
+      And the JSON report describes no model
+
+  Scenario: An unresolvable load is reported in JSON
+    Given the source file "invalid/011_missing_load.jd"
+    When I run the diagnostic compiler with format "json"
+    Then the report signals errors
+      And the JSON report has a diagnostic with severity "fatal"
+      And the JSON report describes no model
+
+  Scenario: An aborted compilation still renders the text report
+    Given the source file "invalid/025_syntax_error.jd"
+    When I run the diagnostic compiler with format "text"
+    Then the report signals errors
+      And the text report contains "[FATAL]"
+      And the text report contains "=== Symbol Table ==="
+      And the text report contains "(empty)"


### PR DESCRIPTION
This pull request significantly improves how the `jpipe diagnostic` command handles fatal compilation failures, such as syntax errors or unresolvable `load` statements. Previously, these failures would abort the pipeline without producing a diagnostic report, forcing tooling to parse stderr for errors. Now, even if compilation fails fatally, a complete diagnostic report is always written in both text and JSON formats, clearly describing the failure. This change is well-documented, covered by new and updated tests, and includes a new `DiagnosticCompiler` to support the revised behavior.

The most important changes are:

**New Diagnostic Reporting for Fatal Errors**
* Introduced the `DiagnosticCompiler` class, which ensures that a diagnostic report is always generated, even when the compilation aborts due to a fatal error (e.g., syntax errors, unresolvable loads). The report includes a diagnostic with `severity: "fatal"`, an empty `models` list, and the correct exit code. [[1]](diffhunk://#diff-2044b88203e00487ba9cde0c289a6ed3619cf63cba2d383a137ae62babd94f1dR1-R72) [[2]](diffhunk://#diff-b9215bb22db8de9dbe589ffa778c89253287d92ab7f0913cc3c4e3208f8cca93L126-R137)
* Updated the `CompilerFactory` to use `DiagnosticCompiler` for the `diagnostic` command, ensuring the new reporting behavior is consistently applied. [[1]](diffhunk://#diff-b9215bb22db8de9dbe589ffa778c89253287d92ab7f0913cc3c4e3208f8cca93L126-R137) [[2]](diffhunk://#diff-b9215bb22db8de9dbe589ffa778c89253287d92ab7f0913cc3c4e3208f8cca93R117-R121)

**Documentation Updates**
* Updated multiple documentation files (`cli.md`, `compiler.md`, `diagnostic-schema.md`, `steps.md`, ADR 16) to explain the new behavior, rationale, and pipeline invariants. These changes clarify that fatal errors now produce reports and describe how consumers can reliably detect and handle them. [[1]](diffhunk://#diff-070c8bd29587a5ed7f11c2ce0e8453a6ae96dce536fa44a959fc2ae4f80cd670L186-R198) [[2]](diffhunk://#diff-19974e9b576f58b5ea26f6e53dc8237efca41b9d038be7f5c13faef80f5b556fR21-R26) [[3]](diffhunk://#diff-19974e9b576f58b5ea26f6e53dc8237efca41b9d038be7f5c13faef80f5b556fR47-R56) [[4]](diffhunk://#diff-b4f2166f6e6433f4f4df7e5b8882d619a88946e1d58b6d860fff3822da1c5968L103-R119) [[5]](diffhunk://#diff-545d2e9061ee735b2195382162065f1b8048bd9e8dddbec8260f33a16bd2ba51L72-R74) [[6]](diffhunk://#diff-545d2e9061ee735b2195382162065f1b8048bd9e8dddbec8260f33a16bd2ba51R107-R123) [[7]](diffhunk://#diff-b27206f7bb411dac51596bac9d7d9c98856e4e355e66240973f9cddabd6b284fR293-R299) [[8]](diffhunk://#diff-b27206f7bb411dac51596bac9d7d9c98856e4e355e66240973f9cddabd6b284fL306-R321)

**Test Coverage**
* Added and updated tests in `DiagnosticCommandTest` and `ShadedJarIT` to verify that diagnostic reports are produced for fatal errors, both in text and JSON formats, and that the exit code is correct. [[1]](diffhunk://#diff-e49e7e2082e0068bebd3bea833901fdf104fce1157be0491145ad5401c235a19L29-R66) [[2]](diffhunk://#diff-65191ff5945abf1ac03adfa7c88df96a0b81c87baa0b79d11b7e6087c2454bbeR102-R115)

**Examples**
* Added a new example file with an intentional syntax error to demonstrate and test the diagnostic reporting of fatal errors.

**Minor Cleanups**
* Removed unused imports and obsolete fields related to the old diagnostics rendering path. [[1]](diffhunk://#diff-b9215bb22db8de9dbe589ffa778c89253287d92ab7f0913cc3c4e3208f8cca93L5) [[2]](diffhunk://#diff-b9215bb22db8de9dbe589ffa778c89253287d92ab7f0913cc3c4e3208f8cca93R20) [[3]](diffhunk://#diff-3530392fdd5499b46f4033e303d16a27d34da30cd71a61ab1a26ef8163888584L38) [[4]](diffhunk://#diff-d14e66dc8ea6a06be5e2b2ff3f95daf0fb1fc72b3fb80ed56d473617fc15465cL42-L45)

These changes make the diagnostic system more robust and tooling-friendly, especially for editor integrations and CI tools.