### PR TITLE
Enhance Python exporter to use authored IDs and group functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,63 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- Python export now leaves out the conclusion entirely and emits sub-conclusions
+  commented out, with a line saying why. The runner requires only evidence and
+  strategies to be bound: it never executes a conclusion, so there was nothing to
+  implement there, and it passes an unbound sub-conclusion through. Commenting
+  the sub-conclusions keeps the shape of the argument visible and lets you turn
+  one into a real check by deleting the `# ` prefixes. Both remain in the JSON
+  and DOT exports, which describe the model rather than its execution.
+- Python export now groups functions by namespace, each section opening with a
+  banner comment naming it, so a module assembled from several sources reads as
+  the parts it was built from rather than one flat list. Sections are ordered
+  alphabetically; elements a composition created or merged carry no source
+  prefix and are grouped under the composed model itself. Within a section
+  elements run bottom-up (evidence, then strategies, then sub-conclusions), so
+  the file reads from the steps you implement toward the claim they support.
+
+  ```python
+  ###       ###
+  ## a_claim ##
+  ###       ###
+  ```
+- Python export now guarantees that every `@jpipe_link` in a generated module
+  names a distinct identifier, and refuses to write the module otherwise
+  rather than emitting one that cannot load. A runner keys its binding registry
+  by the link id, so the same id on two functions leaves it with two candidate
+  implementations and no way to choose.
+- New `unique-identifiers` consistency rule: compilation now fails if any
+  identifier an exported model can be referenced by would designate two
+  different elements. Element ids were already checked; this extends the
+  guarantee to the aliases a merge leaves behind, because an alias colliding
+  with another element's id makes a reference ambiguous. Consumers index ids
+  and aliases into one namespace and cannot resolve such a clash —
+  `jpipe-runner` discards the entire model rather than guess — so the compiler
+  now reports it as an error, with the source location, instead of emitting a
+  model that silently fails to load.
+
 ### Changed
 - `jpipe doctor` now reports the version of each external tool it finds
   (e.g. `dot (Graphviz): OK (version 12.2.1)`). Some operating systems ship an
   outdated Graphviz, which is a common explanation for rendering problems.
 
 ### Fixed
+- **Python export:** `@jpipe_link` now names elements the way you wrote them.
+  An element produced by a merge is linked by the ids it was merged from
+  instead of by the internal id unification minted for it (`unified_0`), and a
+  composition of a composition resolves all the way back to the ids in the
+  original source models. Links are also shortened — `@jpipe_link("a_claim:s1")`
+  rather than `@jpipe_link("assembled_2:a_claim:s1")` — but never below
+  `justification:id`, since a bare `s1` would leave a reader of the generated
+  module unable to tell what it refers to, and they lengthen again wherever a
+  shorter form would be ambiguous. Elements a composition operator creates in
+  its own right, such as `assembleConclusion`, keep their id: it is the only
+  name they have, and their label comes from the operator call.
+- **JSON export:** the per-element `aliases` array now lists every pre-merge id
+  rather than only the most recent one. Composing the result of a composition
+  records a chain of merges, and the earlier ids in that chain were dropped,
+  leaving elements that `jpipe-runner` could not bind by their original names.
 - `jpipe diagnostic` now reports an unreadable input file as a fatal diagnostic
   and exits 1, instead of exiting 42 with only a message on standard error.
   `jpipe process` is unchanged: a missing file there is still a system error.

--- a/docs/adr/0015-consistency-and-completeness-validation.md
+++ b/docs/adr/0015-consistency-and-completeness-validation.md
@@ -105,6 +105,7 @@ misleading completeness results.
 | Rule | Description |
 |------|-------------|
 | `no-duplicate-ids` | All element IDs within a model are unique, including the conclusion's ID. |
+| `unique-identifiers` | No identifier an exported model can be addressed by designates two different elements. Beyond the element IDs this covers the merge aliases, since every ID merged into an element addresses that element too: an alias colliding with another element's ID would make a reference ambiguous. Consumers index IDs and aliases into a single namespace, so the ambiguity has no safe resolution — `jpipe-runner` discards the whole model rather than guess. |
 | `acyclic-support` | The support graph is acyclic. A cycle is detected when following support edges from any node visits a node already on the current traversal path. |
 
 Note: type constraints (Conclusion ← Strategy ← SupportLeaf only) are enforced by

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
@@ -360,6 +360,31 @@ public class CompilationSteps {
 				.doesNotContain("# @jpipe_link(\"" + qualifiedId + "\")");
 	}
 
+	@Then("the Python output has @jpipe_link for id {string} commented out")
+	public void thePythonOutputHasJpipeLinkCommentedOut(String qualifiedId) {
+		assertThat(pythonOutput)
+				.contains("# @jpipe_link(\"" + qualifiedId + "\")");
+	}
+
+	@Then("the Python output declares {string} before {string}")
+	public void thePythonOutputDeclaresBefore(String first, String second) {
+		assertThat(pythonOutput).containsSubsequence("def " + first + "(",
+				"def " + second + "(");
+	}
+
+	@Then("the Python output has a namespace section for {string}")
+	public void thePythonOutputHasANamespaceSectionFor(String namespace) {
+		String edge = "###" + " ".repeat(namespace.length()) + "###";
+		assertThat(pythonOutput)
+				.contains(edge + "\n## " + namespace + " ##\n" + edge + "\n");
+	}
+
+	@Then("the Python output has no @jpipe_link for id {string}")
+	public void thePythonOutputHasNoJpipeLinkFor(String qualifiedId) {
+		assertThat(pythonOutput)
+				.doesNotContain("@jpipe_link(\"" + qualifiedId + "\")");
+	}
+
 	@Then("the compilation has validation errors")
 	public void theCompilationHasValidationErrors() {
 		assertThat(ctx.hasErrors()).isTrue();

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/checkers/ConsistencyCheckerTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/checkers/ConsistencyCheckerTest.java
@@ -48,6 +48,36 @@ class ConsistencyCheckerTest {
 		assertThat(ctx.hasFatalErrors()).isFalse();
 	}
 
+	@Test
+	void ambiguous_identifier_produces_error_diagnostic() {
+		Unit unit = new Unit("src");
+		Justification j = new Justification("j");
+		j.setConclusion(new Conclusion("c", "C"));
+		j.addElement(new Strategy("s", "S"));
+		j.addElement(new Evidence("e", "E"));
+		// "e" would designate the evidence and, through the alias, the strategy
+		j.recordAlias("e", "s");
+		unit.add(j);
+
+		new ConsistencyChecker().fire(unit, ctx);
+
+		assertThat(ctx.hasErrors()).isTrue();
+		assertThat(ctx.hasFatalErrors()).isFalse();
+	}
+
+	@Test
+	void merge_aliases_produce_no_diagnostics() {
+		Unit unit = validUnit();
+		unit.getModels().forEach(m -> {
+			m.recordAlias("a:s", "s");
+			m.recordAlias("b:s", "s");
+		});
+
+		new ConsistencyChecker().fire(unit, ctx);
+
+		assertThat(ctx.hasErrors()).isFalse();
+	}
+
 	// -------------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/resources/features/exports.feature
+++ b/jpipe-compiler/src/test/resources/features/exports.feature
@@ -14,10 +14,18 @@ Feature: Exporting compiled models to various formats
     When I compile it into a unit
     Then the unit contains a justification named "minimal"
     When I export the current model to Python format
-    Then the Python output contains a method named "a_conclusion"
-      And the Python output contains a method named "a_strategy"
+    Then the Python output contains a method named "a_strategy"
       And the Python output contains a method named "an_evidence"
-      And the Python output has @jpipe_link for id "minimal:c" active
+      And the Python output has @jpipe_link for id "minimal:s" active
+      And the Python output has @jpipe_link for id "minimal:e" active
+      And the Python output has no @jpipe_link for id "c"
+
+  Scenario: Python export leaves out the conclusion the runner never executes
+    Given the source file "000_minimal.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "minimal"
+    When I export the current model to Python format
+    Then the Python output has no @jpipe_link for id "minimal:c"
       And the Python output has @jpipe_link for id "minimal:s" active
       And the Python output has @jpipe_link for id "minimal:e" active
 
@@ -31,11 +39,43 @@ Feature: Exporting compiled models to various formats
       And the JSON output contains "assembled_2:a_claim:s1"
       And the JSON output contains "assembled_2:another_claim:s2"
 
-  Scenario: Python export links the merged element by every original id
+  Scenario: Python export names the merged element by its original ids only
     Given the source file "011_unifying_while_compising.jd"
     When I compile it into a unit
     Then the unit contains a justification named "assembled_2"
     When I export the current model to Python format
-    Then the Python output has @jpipe_link for id "assembled_2:unified_0" active
-      And the Python output has @jpipe_link for id "assembled_2:a_claim:s1" active
-      And the Python output has @jpipe_link for id "assembled_2:another_claim:s2" active
+    Then the Python output has @jpipe_link for id "a_claim:s1" active
+      And the Python output has @jpipe_link for id "another_claim:s2" active
+      And the Python output has no @jpipe_link for id "s1"
+      And the Python output has no @jpipe_link for id "assembled_2:unified_0"
+      And the Python output has no @jpipe_link for id "unified_0"
+
+  Scenario: Python export groups elements under a banner per namespace
+    Given the source file "011_unifying_while_compising.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "assembled_2"
+    When I export the current model to Python format
+    Then the Python output has a namespace section for "a_claim"
+      And the Python output has a namespace section for "another_claim"
+      And the Python output has a namespace section for "assembled_2"
+
+  Scenario: Python export orders a namespace bottom-up, evidence first
+    Given the source file "011_unifying_while_compising.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "assembled_2"
+    When I export the current model to Python format
+    Then the Python output declares "an_evidence" before "a_strategy"
+      And the Python output declares "a_strategy" before "a_conclusion"
+      And the Python output declares "a_shared_evidence" before "an_aggregating_strategy"
+
+  Scenario: Python export resolves a composition of a composition to the authored ids
+    Given the source file "012_chaining_operators.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "with_refine_1"
+    When I export the current model to Python format
+    # The refine hook merges the base's evidence with the refinement's
+    # conclusion into a sub-conclusion, so it is emitted commented out.
+    Then the Python output has @jpipe_link for id "first:e" commented out
+      And the Python output has @jpipe_link for id "second:e" commented out
+      And the Python output has @jpipe_link for id "refine_1:c" commented out
+      And the Python output has no @jpipe_link for id "unified_0"

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/MarkUnified.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/MarkUnified.java
@@ -1,0 +1,39 @@
+package ca.mcscert.jpipe.commands.linking;
+
+import ca.mcscert.jpipe.commands.RegularCommand;
+import ca.mcscert.jpipe.model.Unit;
+
+/**
+ * Records that {@code id} inside a result model was minted by unification to
+ * stand for a group of merged elements. Persisted to {@link Unit} so that
+ * exporters can tell an id the compiler invented from one an author wrote; see
+ * {@link ca.mcscert.jpipe.model.JustificationModel#recordUnifiedId(String)}.
+ */
+public final class MarkUnified extends RegularCommand {
+
+	private final String container;
+	private final String id;
+
+	public MarkUnified(String container, String id) {
+		this.container = container;
+		this.id = id;
+	}
+
+	public String container() {
+		return container;
+	}
+
+	public String id() {
+		return id;
+	}
+
+	@Override
+	public void doExecute(Unit context) {
+		context.recordUnifiedId(container, id);
+	}
+
+	@Override
+	public String toString() {
+		return "markUnified('" + container + "', '" + id + "').";
+	}
+}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
@@ -13,9 +13,11 @@ import ca.mcscert.jpipe.visitor.JustificationVisitor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Abstract base for all named justification models. Sealed to exactly two
@@ -49,6 +51,7 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 	private Template parent = null;
 	private final List<E> elements = new ArrayList<>();
 	private final Map<String, String> aliases = new LinkedHashMap<>();
+	private final Set<String> unifiedIds = new LinkedHashSet<>();
 
 	protected JustificationModel(String name) {
 		this.name = name;
@@ -94,6 +97,29 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 	 */
 	public void recordAlias(String oldId, String newId) {
 		aliases.put(oldId, newId);
+	}
+
+	/**
+	 * Records that {@code id} was minted by unification to stand for a group of
+	 * merged elements, rather than written in a source file.
+	 *
+	 * <p>
+	 * Unification names a merged group after a counter ({@code unified_0}), so
+	 * the id carries no meaning outside the compiler and cannot be traced back
+	 * to anything the author wrote. Exporters that address an audience, such as
+	 * the Python module a developer implements against, use this to name the
+	 * element by the ids it was merged from instead. Contrast the elements a
+	 * composition operator synthesises ({@code assembleConclusion}), which are
+	 * genuine elements of the composed model carrying labels the author
+	 * supplied in the operator call, and are <em>not</em> recorded here.
+	 */
+	public void recordUnifiedId(String id) {
+		unifiedIds.add(id);
+	}
+
+	/** Unmodifiable view of the ids unification minted within this model. */
+	public Set<String> unifiedIds() {
+		return Collections.unmodifiableSet(unifiedIds);
 	}
 
 	/**

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/Unit.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/Unit.java
@@ -135,6 +135,14 @@ public final class Unit {
 	}
 
 	/**
+	 * Records that {@code id} in model {@code modelName} was minted by
+	 * unification. See {@link JustificationModel#recordUnifiedId(String)}.
+	 */
+	public void recordUnifiedId(String modelName, String id) {
+		findModel(modelName).ifPresent(m -> m.recordUnifiedId(id));
+	}
+
+	/**
 	 * Returns the id that {@code id} resolves to in {@code modelName}, or
 	 * {@code id} itself if no alias was registered.
 	 */

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/validation/ConsistencyValidator.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/validation/ConsistencyValidator.java
@@ -20,6 +20,10 @@ import java.util.function.Function;
  * Rules:
  * <ul>
  * <li>{@code no-duplicate-ids} — all element IDs within a model are unique.
+ * <li>{@code unique-identifiers}: no identifier an exported model can be
+ * addressed by designates two different elements. This covers the merge aliases
+ * as well as the ids: an alias that collides with another element's id would
+ * make a reference ambiguous.
  * <li>{@code acyclic-support} — the support graph contains no cycles (it must
  * be a DAG).
  * <li>{@code acyclic-implements} — the implements chain between models contains
@@ -49,6 +53,7 @@ public final class ConsistencyValidator {
 		List<Violation> violations = new ArrayList<>();
 		for (JustificationModel<?> model : unit.getModels()) {
 			violations.addAll(checkNoDuplicateIds(model, ctx));
+			violations.addAll(checkUniqueIdentifiers(model, ctx));
 			violations.addAll(checkAcyclicSupport(model, ctx));
 		}
 		violations.addAll(checkAcyclicImplements(unit, ctx));
@@ -63,6 +68,7 @@ public final class ConsistencyValidator {
 		ValidationContext ctx = ValidationContext.STANDALONE;
 		List<Violation> violations = new ArrayList<>();
 		violations.addAll(checkNoDuplicateIds(model, ctx));
+		violations.addAll(checkUniqueIdentifiers(model, ctx));
 		violations.addAll(checkAcyclicSupport(model, ctx));
 		violations.addAll(checkAcyclicImplements(model));
 		return violations;
@@ -91,6 +97,72 @@ public final class ConsistencyValidator {
 			}
 		});
 		return violations;
+	}
+
+	/**
+	 * Checks that no identifier designates two different elements.
+	 *
+	 * <p>
+	 * An exported model can be addressed by more than an element's own id:
+	 * every id merged into an element addresses it too, so that a reference
+	 * written before a composition keeps working afterwards. Consumers
+	 * therefore index ids and merge aliases into one namespace, and a key
+	 * landing on two elements leaves them no way to choose. jpipe-runner
+	 * rejects the whole model rather than guess. Element ids alone are covered
+	 * by {@code no-duplicate-ids}; what this adds is the aliases.
+	 */
+	private List<Violation> checkUniqueIdentifiers(JustificationModel<?> model,
+			ValidationContext ctx) {
+		Set<String> elementIds = elementIdsOf(model);
+		Map<String, String> designated = new HashMap<>();
+		elementIds.forEach(id -> designated.put(id, id));
+
+		List<Violation> violations = new ArrayList<>();
+		model.aliases().forEach((alias, target) -> {
+			String canonical = elementDesignatedBy(model, elementIds, target);
+			if (canonical == null) {
+				// The chain leads to no element of this model, so the alias is
+				// never exported and can collide with nothing.
+				return;
+			}
+			String existing = designated.putIfAbsent(alias, canonical);
+			if (existing != null && !existing.equals(canonical)) {
+				violations.add(new Violation("unique-identifiers",
+						"Identifier '" + alias + IN_MODEL + model.getName()
+								+ "' designates both element '" + existing
+								+ "' and element '" + canonical + "'",
+						ctx.locationOf(model.getName(), alias)));
+			}
+		});
+		return violations;
+	}
+
+	/** Element ids of {@code model}, conclusion included. */
+	private static Set<String> elementIdsOf(JustificationModel<?> model) {
+		Set<String> ids = new HashSet<>();
+		model.conclusion().ifPresent(c -> ids.add(c.id()));
+		model.getElements().forEach(element -> ids.add(element.id()));
+		return ids;
+	}
+
+	/**
+	 * Follows {@code id} through the alias map until it reaches an element of
+	 * {@code model}, or {@code null} if it reaches none or loops.
+	 */
+	private static String elementDesignatedBy(JustificationModel<?> model,
+			Set<String> elementIds, String id) {
+		Set<String> visited = new HashSet<>();
+		String current = id;
+		while (visited.add(current)) {
+			if (elementIds.contains(current)) {
+				return current;
+			}
+			current = model.aliases().get(current);
+			if (current == null) {
+				return null;
+			}
+		}
+		return null;
 	}
 
 	private List<Violation> checkAcyclicSupport(JustificationModel<?> model,

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/AbstractModelExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/AbstractModelExporter.java
@@ -4,10 +4,16 @@ import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.JustificationModel;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Abstract base for exporters that serialise a single
@@ -37,6 +43,13 @@ public abstract class AbstractModelExporter
 		implements
 			JustificationVisitor<Void> {
 
+	/**
+	 * Fewest colon-separated segments a shortened identifier may keep, so that
+	 * it always reads as {@code container:id}. See
+	 * {@link #minimalLink(String)}.
+	 */
+	private static final int MIN_SEGMENTS = 2;
+
 	/** Accumulates the serialised output. Reset at the start of each export. */
 	protected final StringBuilder builder = new StringBuilder();
 
@@ -55,6 +68,23 @@ public abstract class AbstractModelExporter
 	private final Map<String, List<String>> aliasesByTarget = new HashMap<>();
 
 	/**
+	 * The identifiers a consumer of the exported model may use to designate an
+	 * element: every element's qualified id, plus every qualified id it was
+	 * merged from. Maps each such key to the plain id of the element it
+	 * designates. Populated by {@link #initAliases(JustificationModel)} and
+	 * used by {@link #minimalLink(String)} to decide how far a link can be
+	 * shortened.
+	 */
+	private final Map<String, String> linkIndex = new LinkedHashMap<>();
+
+	/**
+	 * Ids unification minted within the model being exported. Populated by
+	 * {@link #initAliases(JustificationModel)}; see
+	 * {@link JustificationModel#recordUnifiedId(String)}.
+	 */
+	private Set<String> unifiedIds = Set.of();
+
+	/**
 	 * Qualifies {@code elementId} with the current model name:
 	 * {@code "currentModelName:elementId"}.
 	 */
@@ -63,8 +93,8 @@ public abstract class AbstractModelExporter
 	}
 
 	/**
-	 * Builds the inverted alias lookup for {@code model}. Subclasses that
-	 * surface aliases must call this at the start of
+	 * Builds the inverted alias lookup and the link index for {@code model}.
+	 * Subclasses that surface aliases must call this at the start of
 	 * {@link #exportModel(JustificationModel)}, after setting
 	 * {@link #currentModelName}.
 	 */
@@ -72,6 +102,17 @@ public abstract class AbstractModelExporter
 		aliasesByTarget.clear();
 		model.aliases().forEach((oldId, newId) -> aliasesByTarget
 				.computeIfAbsent(newId, _ -> new ArrayList<>()).add(oldId));
+		unifiedIds = model.unifiedIds();
+		linkIndex.clear();
+		model.conclusion().ifPresent(this::indexElement);
+		model.getElements().forEach(this::indexElement);
+	}
+
+	private void indexElement(JustificationElement element) {
+		linkIndex.put(qualify(element.id()), element.id());
+		for (String original : qualifiedOriginalsOf(element.id())) {
+			linkIndex.put(original, element.id());
+		}
 	}
 
 	/**
@@ -86,6 +127,143 @@ public abstract class AbstractModelExporter
 			return List.of();
 		}
 		return originals.stream().map(this::qualify).toList();
+	}
+
+	/**
+	 * Returns every qualified id {@code plainElementId} was merged from,
+	 * following alias chains transitively.
+	 *
+	 * <p>
+	 * A composition applied to the result of another composition records a
+	 * chain ({@code a -> merged -> unified_0}) rather than a flat mapping, so a
+	 * one-hop lookup ({@link #qualifiedAliasesOf(String)}) stops at the
+	 * intermediate and loses the id the user actually wrote. The returned list
+	 * holds both the intermediates and the leaves, nearest first.
+	 */
+	protected final List<String> qualifiedOriginalsOf(String plainElementId) {
+		return collectOriginals(plainElementId, false);
+	}
+
+	/**
+	 * Returns the qualified ids {@code plainElementId} was merged from that an
+	 * author actually wrote: the ids as they stood in the source models. Empty
+	 * when the element is not a merge product.
+	 *
+	 * <p>
+	 * Two kinds of id are passed over. One that was merged from further ids is
+	 * skipped in favour of those, which stand closer to the source. One that
+	 * unification minted ({@code unified_0}) is skipped outright: it names a
+	 * merged group by a counter and appears in no source file. The latter is
+	 * not always the former, since composing the result of a composition can
+	 * leave a minted id recorded as a sibling of the ids it stood for rather
+	 * than as their parent, so being childless does not make an id authored.
+	 */
+	protected final List<String> qualifiedAuthoredOriginalsOf(
+			String plainElementId) {
+		return collectOriginals(plainElementId, true);
+	}
+
+	private List<String> collectOriginals(String plainElementId,
+			boolean authoredOnly) {
+		if (!aliasesByTarget.containsKey(plainElementId)) {
+			return List.of();
+		}
+		Set<String> found = new LinkedHashSet<>();
+		Set<String> visited = new HashSet<>();
+		visited.add(plainElementId);
+		collectFrom(plainElementId, authoredOnly, visited, found);
+		return found.stream().map(this::qualify).toList();
+	}
+
+	private void collectFrom(String id, boolean authoredOnly,
+			Set<String> visited, Set<String> found) {
+		for (String original : aliasesByTarget.getOrDefault(id, List.of())) {
+			if (!visited.add(original)) {
+				continue;
+			}
+			if (!authoredOnly || isAuthored(original)) {
+				found.add(original);
+			}
+			collectFrom(original, authoredOnly, visited, found);
+		}
+	}
+
+	private boolean isAuthored(String plainId) {
+		return !aliasesByTarget.containsKey(plainId)
+				&& !unifiedIds.contains(plainId);
+	}
+
+	/**
+	 * Shortens {@code qualifiedKey} to the shortest trailing run of
+	 * colon-separated segments that still designates the same element, never
+	 * going below {@code container:id}.
+	 *
+	 * <p>
+	 * Consumers resolve a link by exact match against the link index first,
+	 * then by strict segment-suffix match; a suffix designating two different
+	 * elements is ambiguous and is not a valid link. Candidates are therefore
+	 * checked against the very index a consumer builds from the exported model,
+	 * shortest first, and {@code qualifiedKey} itself is returned when no
+	 * shorter form is unambiguous, because a full id always resolves exactly.
+	 *
+	 * <p>
+	 * The {@value #MIN_SEGMENTS}-segment floor is a readability requirement
+	 * rather than a resolution one: a bare {@code id} would often resolve, but
+	 * a reader of the exported artefact has no way to tell what it belongs to.
+	 * Keeping the owning model or source justification in front of it, as
+	 * {@code a_claim:s1} rather than {@code s1}, makes the reference legible on
+	 * its own. Every key starts qualified with the model name, so the floor is
+	 * always reachable.
+	 */
+	protected final String minimalLink(String qualifiedKey) {
+		String canonical = linkIndex.get(qualifiedKey);
+		if (canonical == null) {
+			return qualifiedKey;
+		}
+		String[] segments = qualifiedKey.split(":");
+		for (int length = MIN_SEGMENTS; length < segments.length; length++) {
+			String candidate = String.join(":", Arrays.copyOfRange(segments,
+					segments.length - length, segments.length));
+			if (canonical.equals(designatedBy(candidate))) {
+				return candidate;
+			}
+		}
+		return qualifiedKey;
+	}
+
+	/**
+	 * Returns the plain id of the single element {@code candidate} designates,
+	 * or {@code null} when it designates none or more than one.
+	 */
+	private String designatedBy(String candidate) {
+		String exact = linkIndex.get(candidate);
+		if (exact != null) {
+			return exact;
+		}
+		String[] wanted = candidate.split(":");
+		String found = null;
+		for (Map.Entry<String, String> entry : linkIndex.entrySet()) {
+			String[] segments = entry.getKey().split(":");
+			if (!isStrictSuffix(wanted, segments)) {
+				continue;
+			}
+			if (found != null && !found.equals(entry.getValue())) {
+				return null;
+			}
+			found = entry.getValue();
+		}
+		return found;
+	}
+
+	/**
+	 * Tells whether {@code wanted} is a strictly shorter tail of {@code of}.
+	 */
+	private static boolean isStrictSuffix(String[] wanted, String[] of) {
+		if (wanted.length >= of.length) {
+			return false;
+		}
+		return Arrays.equals(of, of.length - wanted.length, of.length, wanted,
+				0, wanted.length);
 	}
 
 	/**

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/JsonExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/JsonExporter.java
@@ -37,7 +37,10 @@ import org.json.JSONObject;
  * <p>
  * The optional per-element {@code "aliases"} array lists the qualified original
  * ids that were merged into the element during composition/unification; it is
- * omitted for elements that are not the target of any alias.
+ * omitted for elements that are not the target of any alias. Merges compose, so
+ * the array is transitive: composing the result of a composition records a
+ * chain, and the array lists every id along it, down to those written in the
+ * original source models.
  */
 public class JsonExporter extends AbstractModelExporter {
 
@@ -139,7 +142,7 @@ public class JsonExporter extends AbstractModelExporter {
 		obj.put("id", qualify(element.id()));
 		obj.put("label", element.label());
 		obj.put("escaped", LabelEscaper.toMethodName(element.label()));
-		List<String> aliases = qualifiedAliasesOf(element.id());
+		List<String> aliases = qualifiedOriginalsOf(element.id());
 		if (!aliases.isEmpty()) {
 			obj.put("aliases", new JSONArray(aliases));
 		}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
@@ -9,19 +9,29 @@ import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
 import ca.mcscert.jpipe.util.LabelEscaper;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Serialises a single {@link JustificationModel} to a Python module: each
  * element becomes a decorated function named after the element's label
- * (snake_case via {@link LabelEscaper}). Two decorators are emitted per
- * function:
+ * (snake_case via {@link LabelEscaper}), carrying:
  *
  * <ul>
- * <li>{@code @jpipe_link("<modelName:elementId>")} — links the function back to
- * the originating jPipe element. When the element resulted from a
- * composition/unification merge, one additional {@code @jpipe_link} is emitted
- * per original (pre-merge) id, so the function can be resolved by any of
- * them.</li>
+ * <li>one or more {@code @jpipe_link("<id>")}, linking the function back to the
+ * originating jPipe element. An element that resulted from a merge is linked by
+ * the ids it was merged from rather than by its own, transitively, so a
+ * composition of a composition still names the ids as the original source
+ * models had them; ids unification minted along the way ({@code unified_0}) are
+ * left out, having been written in no source file. Every id is then shortened
+ * to the least qualified form that still designates the element unambiguously,
+ * but never past {@code container:id}, because a bare id would leave a reader
+ * of the generated module unable to tell what it refers to; see
+ * {@link AbstractModelExporter#minimalLink(String)}.</li>
  * <li>{@code @jpipe(produce=[], consume=[])} — placeholder decorators to be
  * filled in by the developer.</li>
  * </ul>
@@ -36,6 +46,17 @@ import java.time.Instant;
  * invoking this exporter.
  */
 public class PythonExporter extends AbstractModelExporter {
+
+	/** Prefix that comments out a line of generated Python. */
+	private static final String COMMENT = "# ";
+
+	/**
+	 * Link id &rarr; the function it has already been emitted on, for the
+	 * module being written. Consumers key their registry by the link id, so the
+	 * same id on two functions has no resolution; see
+	 * {@link #claim(String, String)}.
+	 */
+	private final Map<String, String> boundTo = new LinkedHashMap<>();
 
 	/**
 	 * Serialise {@code model} to Python source text without a file header.
@@ -73,9 +94,14 @@ public class PythonExporter extends AbstractModelExporter {
 	// Element visit methods
 	// -------------------------------------------------------------------------
 
+	/**
+	 * Emits nothing. The runner never executes a conclusion: it concludes one
+	 * from whatever supports it, so a function here could never run and there
+	 * is nothing for a developer to implement. The conclusion remains in the
+	 * JSON and DOT exports, which describe the model rather than its execution.
+	 */
 	@Override
 	public Void visit(Conclusion conclusion) {
-		appendMethod(conclusion);
 		return null;
 	}
 
@@ -111,13 +137,84 @@ public class PythonExporter extends AbstractModelExporter {
 	protected void exportModel(JustificationModel<?> model) {
 		currentModelName = model.getName();
 		initAliases(model);
-		model.conclusion().ifPresent(c -> c.accept(this));
-		model.getElements().forEach(e -> e.accept(this));
+		boundTo.clear();
+
+		// The conclusion is deliberately absent: it is never executed, so it
+		// would open a section holding nothing a developer can implement.
+		Map<String, List<JustificationElement>> byNamespace = new TreeMap<>();
+		model.getElements()
+				.forEach(e -> group(byNamespace, e, currentModelName));
+
+		byNamespace.forEach((namespace, elements) -> {
+			appendNamespaceBanner(namespace);
+			elements.stream()
+					.sorted(Comparator
+							.comparingInt(PythonExporter::supportRank))
+					.forEach(e -> e.accept(this));
+		});
 	}
 
 	// -------------------------------------------------------------------------
 	// Private helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Orders elements within a namespace bottom-up, so a section reads from the
+	 * evidence a developer has to implement toward the claim it ends up
+	 * supporting, rather than asking them to start at the conclusion and work
+	 * backwards. Ties keep the order the model holds them in.
+	 *
+	 * <p>
+	 * An {@link AbstractSupport} ranks with the evidence: it is a
+	 * {@link ca.mcscert.jpipe.model.elements.SupportLeaf} standing where one
+	 * will go, and it is the other thing in a module still awaiting an
+	 * implementation.
+	 */
+	private static int supportRank(JustificationElement element) {
+		return switch (element) {
+			case Evidence _ -> 0;
+			case AbstractSupport _ -> 1;
+			case Strategy _ -> 2;
+			case SubConclusion _ -> 3;
+			case Conclusion _ -> 4;
+		};
+	}
+
+	private static void group(
+			Map<String, List<JustificationElement>> byNamespace,
+			JustificationElement element, String modelName) {
+		byNamespace.computeIfAbsent(namespaceOf(element.id(), modelName),
+				_ -> new ArrayList<>()).add(element);
+	}
+
+	/**
+	 * The namespace an element belongs to: the part of its id in front of the
+	 * last segment, or the model itself when the id carries no prefix.
+	 *
+	 * <p>
+	 * An element copied in from a source model or expanded from a template
+	 * keeps that origin as its prefix ({@code a_claim:c}, {@code root:abs1}),
+	 * so this groups the module the way the author thinks of it. An element the
+	 * composition created or merged has no prefix, and belongs to the composed
+	 * model itself, being owned by no single source.
+	 */
+	private static String namespaceOf(String plainElementId, String modelName) {
+		int lastSeparator = plainElementId.lastIndexOf(':');
+		return lastSeparator < 0
+				? modelName
+				: plainElementId.substring(0, lastSeparator);
+	}
+
+	/**
+	 * Opens a namespace section with a banner comment, so the reader can find
+	 * where one origin's steps end and the next begins.
+	 */
+	private void appendNamespaceBanner(String namespace) {
+		String edge = "###" + " ".repeat(namespace.length()) + "###";
+		builder.append(edge).append("\n");
+		builder.append("## ").append(namespace).append(" ##\n");
+		builder.append(edge).append("\n\n");
+	}
 
 	private void appendHeader(String sourcePath) {
 		builder.append("# Generated by jPipe\n");
@@ -138,28 +235,109 @@ public class PythonExporter extends AbstractModelExporter {
 	}
 
 	private void appendMethod(JustificationElement element) {
-		String qid = qualify(element.id());
+		List<String> links = linksFor(element);
 		String name = LabelEscaper.toMethodName(element.label());
 		String params = element instanceof Conclusion
 				? ""
 				: "produce: JpipeProduce";
-		String decoratorArgs = jpipeDecoratorArgs(element);
 
-		builder.append("@jpipe_link(\"").append(qid).append("\")\n");
-		for (String alias : qualifiedAliasesOf(element.id())) {
-			builder.append("@jpipe_link(\"").append(alias).append("\")\n");
+		StringBuilder block = new StringBuilder();
+		for (String link : links) {
+			claim(link, name);
+			block.append("@jpipe_link(\"").append(link).append("\")\n");
 		}
-		builder.append("@jpipe(").append(decoratorArgs).append(")\n");
-		builder.append("def ").append(name).append("(").append(params)
+		block.append("@jpipe(").append(jpipeDecoratorArgs(element))
+				.append(")\n");
+		block.append("def ").append(name).append("(").append(params)
 				.append(") -> bool:\n");
-		builder.append("    \"\"\"[").append(element.kind()).append("] ")
+		block.append("    \"\"\"[").append(element.kind()).append("] ")
 				.append(escapeDocstring(element.label())).append("\"\"\"\n");
 		if (element instanceof AbstractSupport) {
-			builder.append("    raise NotImplementedError(\"").append(qid)
-					.append(" is abstract and must be"
-							+ " overridden before execution\")\n\n\n");
+			block.append("    raise NotImplementedError(\"")
+					.append(links.get(0)).append(" is abstract and must be"
+							+ " overridden before execution\")\n");
 		} else {
-			builder.append("    pass\n\n\n");
+			block.append("    pass\n");
+		}
+
+		appendBlock(block.toString(), element);
+		builder.append("\n\n");
+	}
+
+	/**
+	 * Writes a function, commenting it out when the runner does not need it
+	 * implemented.
+	 *
+	 * <p>
+	 * Only evidence and strategies must be bound to run. A sub-conclusion
+	 * executes solely when it happens to be bound, so leaving it live would add
+	 * a function that never runs, while leaving it out would drop the claim it
+	 * states from the module. Emitting it commented keeps the shape of the
+	 * argument visible and lets a developer turn the check on by deleting the
+	 * prefixes.
+	 */
+	private void appendBlock(String block, JustificationElement element) {
+		if (!(element instanceof SubConclusion)) {
+			builder.append(block);
+			return;
+		}
+		builder.append(COMMENT).append("The runner passes this claim through"
+				+ " unless it is bound. Uncomment to check it.\n");
+		block.lines().forEach(
+				line -> builder.append(COMMENT).append(line).append("\n"));
+	}
+
+	/**
+	 * The ids this element should be linkable by: the ids it was merged from
+	 * when it is a merge product, its own id otherwise, each shortened to the
+	 * least qualified form that still designates it.
+	 *
+	 * <p>
+	 * A merge product is named by what it was merged from rather than by its
+	 * own id, which the operator chose ({@code hook}) or unification minted
+	 * ({@code unified_0}). That own id stays the fallback for when no authored
+	 * original can be resolved, so every function carries at least one link.
+	 *
+	 * <p>
+	 * Two originals that shorten to the same form are emitted once, since the
+	 * second decorator would say nothing the first does not. Source models that
+	 * named an element identically do not collide this way: the shortened form
+	 * keeps the model in front of the id, so {@code a:s} and {@code b:s} stay
+	 * apart. The unshortened ids remain in the JSON export either way.
+	 */
+	private List<String> linksFor(JustificationElement element) {
+		List<String> originals = qualifiedAuthoredOriginalsOf(element.id());
+		List<String> keys = originals.isEmpty()
+				? List.of(qualify(element.id()))
+				: originals;
+		return keys.stream().map(this::minimalLink).distinct().toList();
+	}
+
+	/**
+	 * Records that {@code link} is emitted on {@code function}, and refuses to
+	 * emit it a second time on a different one.
+	 *
+	 * <p>
+	 * A consumer keys its binding registry by the link id, so an id appearing
+	 * on two functions leaves it with two candidate implementations and no way
+	 * to choose. Every id emitted here designates exactly one element by
+	 * construction, because {@link AbstractModelExporter#minimalLink(String)}
+	 * only shortens to a form that resolves uniquely, and falls back to a full
+	 * id, which resolves exactly. Two functions can therefore collide only when
+	 * a single identifier already designated two elements. That is the
+	 * {@code unique-identifiers} consistency rule, which fails compilation
+	 * before any export runs; this guard catches the same fault when the
+	 * exporter is driven directly, rather than writing a module that cannot
+	 * load.
+	 */
+	private void claim(String link, String function) {
+		String existing = boundTo.putIfAbsent(link, function);
+		if (existing != null && !existing.equals(function)) {
+			throw new IllegalStateException("@jpipe_link(\"" + link
+					+ "\") would be emitted on both '" + existing + "' and '"
+					+ function + "' in model '" + currentModelName
+					+ "': one identifier cannot designate two elements."
+					+ " Check the model against the unique-identifiers rule.");
 		}
 	}
 

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/validation/ConsistencyValidatorTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/validation/ConsistencyValidatorTest.java
@@ -132,6 +132,78 @@ class ConsistencyValidatorTest {
 	// Helpers
 	// -------------------------------------------------------------------------
 
+	@Nested
+	class UniqueIdentifiers {
+
+		@Test
+		void merge_aliases_alone_produce_no_violations() {
+			Justification j = simpleJustification();
+			j.recordAlias("a:s", "s");
+			j.recordAlias("b:s", "s");
+
+			assertThat(validator.validateModel(j)).isEmpty();
+		}
+
+		@Test
+		void alias_colliding_with_another_elements_id_produces_violation() {
+			Justification j = simpleJustification();
+			j.recordAlias("e1", "s"); // "e1" is already the evidence's own id
+
+			List<Violation> violations = validator.validateModel(j);
+
+			assertThat(violations).extracting(Violation::rule)
+					.contains("unique-identifiers");
+		}
+
+		@Test
+		void violation_names_both_elements_the_identifier_designates() {
+			Justification j = simpleJustification();
+			j.recordAlias("e1", "s");
+
+			List<Violation> violations = validator.validateModel(j);
+
+			assertThat(violations).extracting(Violation::message).first()
+					.asString().contains("'e1'", "element 'e1'", "element 's'");
+		}
+
+		@Test
+		void alias_chain_is_followed_to_the_element_it_designates() {
+			Justification j = simpleJustification();
+			j.recordAlias("mid", "s");
+			j.recordAlias("e1", "mid"); // reaches "s" through "mid"
+
+			List<Violation> violations = validator.validateModel(j);
+
+			assertThat(violations).extracting(Violation::rule)
+					.contains("unique-identifiers");
+		}
+
+		@Test
+		void alias_leading_to_no_element_is_ignored() {
+			Justification j = simpleJustification();
+			j.recordAlias("e1", "nowhere");
+
+			assertThat(validator.validateModel(j)).isEmpty();
+		}
+
+		@Test
+		void cyclic_alias_chain_terminates_without_violation() {
+			Justification j = simpleJustification();
+			j.recordAlias("x", "y");
+			j.recordAlias("y", "x");
+
+			assertThat(validator.validateModel(j)).isEmpty();
+		}
+
+		@Test
+		void alias_pointing_at_its_own_element_is_not_a_collision() {
+			Justification j = simpleJustification();
+			j.recordAlias("s", "s");
+
+			assertThat(validator.validateModel(j)).isEmpty();
+		}
+	}
+
 	private static Justification simpleJustification() {
 		Justification j = new Justification("j");
 		Conclusion c = new Conclusion("c", "The system is correct");

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/JsonExporterTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/JsonExporterTest.java
@@ -54,6 +54,23 @@ class JsonExporterTest {
 	}
 
 	@Test
+	void export_chainedAliases_carriesEveryIdAlongTheChain() {
+		String json = new JsonExporter()
+				.export(ModelFixtures.chainedAliasJustification());
+
+		assertThat(json).contains("\"aliases\"", "\"j:outer:s\"",
+				"\"j:outer:a:s1\"", "\"j:outer:b:s2\"");
+	}
+
+	@Test
+	void export_keepsUnificationMintedIdsSoConsumersCanStillResolveThem() {
+		String json = new JsonExporter()
+				.export(ModelFixtures.siblingUnifiedIdJustification());
+
+		assertThat(json).contains("\"j:outer:unified_0\"", "\"j:outer:a:s1\"");
+	}
+
+	@Test
 	void export_withoutAliases_omitsAliasesKey() {
 		String json = new JsonExporter()
 				.export(ModelFixtures.simpleJustification());

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/ModelFixtures.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/ModelFixtures.java
@@ -50,6 +50,80 @@ class ModelFixtures {
 	}
 
 	/**
+	 * A {@link #simpleJustification()} whose strategy {@code "s"} is the merge
+	 * target of a two-level chain, as produced by composing the result of a
+	 * composition: {@code outer:a:s1} and {@code outer:b:s2} were first merged
+	 * into {@code outer:s}, which a later composition merged into {@code "s"}.
+	 *
+	 * <p>
+	 * The leaves are deliberately given distinct short ids, so that resolving
+	 * the chain one hop short, stopping at {@code outer:s}, produces visibly
+	 * different output from resolving it all the way.
+	 *
+	 * <p>
+	 * The recording order mirrors the compiler's: the carry-forward aliases of
+	 * phases 1&ndash;3 are emitted before the unification alias of phase 4.
+	 */
+	static Justification chainedAliasJustification() {
+		Justification j = simpleJustification();
+		j.recordAlias("outer:a:s1", "outer:s");
+		j.recordAlias("outer:b:s2", "outer:s");
+		j.recordAlias("outer:s", "s");
+		return j;
+	}
+
+	/**
+	 * A {@link #simpleJustification()} whose strategy {@code "s"} was merged
+	 * from a group in which a unification id sits <em>beside</em> the ids it
+	 * stood for rather than above them.
+	 *
+	 * <p>
+	 * This is the shape {@code refine} produces over an already-composed
+	 * source: the hook merge aliases {@code outer:unified_0} to the result, and
+	 * the carry-forward then resolves that source's own originals to the same
+	 * result, so all three become siblings. {@code outer:unified_0} is left
+	 * with no originals of its own, so being childless does not make an id
+	 * authored, and only {@link Justification#recordUnifiedId(String)} tells
+	 * them apart.
+	 */
+	static Justification siblingUnifiedIdJustification() {
+		Justification j = simpleJustification();
+		j.recordAlias("outer:unified_0", "s");
+		j.recordAlias("outer:a:s1", "s");
+		j.recordAlias("outer:b:s2", "s");
+		j.recordUnifiedId("outer:unified_0");
+		return j;
+	}
+
+	/**
+	 * A justification whose two evidences share the plain id {@code "e"} under
+	 * different source-model prefixes, so that neither can be linked by
+	 * {@code "e"} alone.
+	 *
+	 * <ul>
+	 * <li>name: {@code "j"}
+	 * <li>Conclusion {@code "c"}, Strategy {@code "s"}
+	 * <li>Evidence {@code "a:e"} &mdash; "First", Evidence {@code "b:e"}
+	 * &mdash; "Second"
+	 * </ul>
+	 */
+	static Justification ambiguousShortIdJustification() {
+		Justification j = new Justification("j");
+		Conclusion c = new Conclusion("c", "The system is correct");
+		Strategy s = new Strategy("s", "Testing");
+		Evidence first = new Evidence("a:e", "First");
+		Evidence second = new Evidence("b:e", "Second");
+		j.setConclusion(c);
+		j.addElement(s);
+		j.addElement(first);
+		j.addElement(second);
+		s.addSupport(first);
+		s.addSupport(second);
+		c.addSupport(s);
+		return j;
+	}
+
+	/**
 	 * Template with a single Conclusion &larr; Strategy &larr; AbstractSupport
 	 * chain.
 	 *

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/PythonExporterTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/PythonExporterTest.java
@@ -1,12 +1,17 @@
 package ca.mcscert.jpipe.visitor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.elements.AbstractSupport;
 import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
 import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
+import java.util.List;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -14,8 +19,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class PythonExporterTest {
 
 	@ParameterizedTest
-	@ValueSource(strings = {"def the_system_is_correct(", "def testing(",
-			"def test_results(", "def the_system_is_correct() -> bool:",
+	@ValueSource(strings = {"def testing(", "def test_results(",
 			"def testing(produce: JpipeProduce) -> bool:",
 			"def test_results(produce: JpipeProduce) -> bool:"})
 	void export_simpleJustificationMethodSignaturesArePresent(String expected) {
@@ -30,18 +34,215 @@ class PythonExporterTest {
 				.export(ModelFixtures.simpleJustification());
 
 		assertThat(py)
-				.contains("@jpipe_link(\"j:c\")", "@jpipe_link(\"j:s\")",
-						"@jpipe_link(\"j:e1\")")
-				.doesNotContain("# @jpipe_link(");
+				.contains("\n@jpipe_link(\"j:s\")", "\n@jpipe_link(\"j:e1\")")
+				.doesNotContain("\n# @jpipe_link(\"j:s\")",
+						"\n# @jpipe_link(\"j:e1\")");
 	}
 
 	@Test
-	void export_mergedElement_emitsExtraJpipeLinkPerAlias() {
+	void export_conclusion_isNotGeneratedAtAll() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.simpleJustification());
+
+		assertThat(py).doesNotContain("the_system_is_correct", "j:c",
+				"[conclusion]");
+	}
+
+	@Test
+	void export_commentedOutElement_saysWhyAndHowToEnableIt() {
+		Justification j = new Justification("j");
+		Conclusion c = new Conclusion("c", "Overall");
+		Strategy s = new Strategy("s", "By parts");
+		SubConclusion sc = new SubConclusion("sc", "Part holds");
+		j.setConclusion(c);
+		j.addElement(s);
+		j.addElement(sc);
+		sc.addSupport(s);
+		c.addSupport(s);
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py)
+				.contains("Uncomment to check it.\n# @jpipe_link(\"j:sc\")")
+				.doesNotContain("j:c");
+	}
+
+	@Test
+	void export_mergedElement_isNamedByItsOriginalsNotByTheMergeId() {
+		Justification j = ModelFixtures.simpleJustification();
+		j.recordAlias("a:s1", "s");
+		j.recordAlias("b:s2", "s");
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py)
+				.contains(
+						"@jpipe_link(\"a:s1\")\n@jpipe_link(\"b:s2\")\n@jpipe(")
+				.doesNotContain("@jpipe_link(\"j:s\")");
+	}
+
+	@Test
+	void export_originalsSharingAPlainId_staySeparatedByTheirSourceModel() {
 		String py = new PythonExporter()
 				.export(ModelFixtures.unifiedJustification());
 
-		assertThat(py).contains("@jpipe_link(\"j:s\")",
-				"@jpipe_link(\"j:a:s\")", "@jpipe_link(\"j:b:s\")");
+		assertThat(py)
+				.contains("@jpipe_link(\"a:s\")\n@jpipe_link(\"b:s\")\n@jpipe(")
+				.doesNotContain("@jpipe_link(\"s\")");
+	}
+
+	@Test
+	void export_originalsShorteningToTheSameForm_areEmittedOnce() {
+		Justification j = ModelFixtures.simpleJustification();
+		j.recordAlias("a:s", "s");
+		j.recordAlias("outer:a:s", "s"); // also shortens to "a:s"
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py).contains("@jpipe_link(\"a:s\")\n@jpipe(")
+				.doesNotContain("@jpipe_link(\"a:s\")\n@jpipe_link(\"a:s\")");
+	}
+
+	@Test
+	void export_chainedAliases_isNamedByTheOriginalSourceModelIds() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.chainedAliasJustification());
+
+		assertThat(py)
+				.contains(
+						"@jpipe_link(\"a:s1\")\n@jpipe_link(\"b:s2\")\n@jpipe(")
+				.doesNotContain("@jpipe_link(\"j:s\")",
+						"@jpipe_link(\"outer:s\")");
+	}
+
+	@Test
+	void export_unifiedIdBesideItsOriginals_isStillLeftOut() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.siblingUnifiedIdJustification());
+
+		assertThat(py)
+				.contains(
+						"@jpipe_link(\"a:s1\")\n@jpipe_link(\"b:s2\")\n@jpipe(")
+				.doesNotContain("unified_0");
+	}
+
+	@Test
+	void export_cyclicAliases_fallsBackToTheElementsOwnId() {
+		Justification j = ModelFixtures.simpleJustification();
+		j.recordAlias("s", "x");
+		j.recordAlias("x", "s");
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py).contains("@jpipe_link(\"j:s\")\n@jpipe(");
+	}
+
+	@Test
+	void export_ambiguousShortId_keepsEnoughQualificationToDesignateOne() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.ambiguousShortIdJustification());
+
+		assertThat(py).contains("@jpipe_link(\"a:e\")", "@jpipe_link(\"b:e\")")
+				.doesNotContain("@jpipe_link(\"e\")", "@jpipe_link(\"j:e\")");
+	}
+
+	@Test
+	void export_everyJpipeLinkInTheModuleIsDistinct() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.chainedAliasJustification());
+
+		List<String> links = Pattern.compile("@jpipe_link\\(\"(.+)\"\\)")
+				.matcher(py).results().map(m -> m.group(1)).toList();
+
+		assertThat(links).isNotEmpty().doesNotHaveDuplicates();
+	}
+
+	@Test
+	void export_identifierDesignatingTwoElements_isRefusedNotEmitted() {
+		Justification j = ModelFixtures.simpleJustification();
+		// "e1" is the evidence's own id and, through this alias, also names the
+		// strategy, so both functions would claim @jpipe_link("e1").
+		j.recordAlias("e1", "s");
+		PythonExporter exporter = new PythonExporter();
+
+		assertThatThrownBy(() -> exporter.export(j))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContainingAll("@jpipe_link(\"j:e1\")", "testing",
+						"test_results", "unique-identifiers");
+	}
+
+	@Test
+	void export_opensEachNamespaceWithABannerSizedToItsName() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.simpleJustification());
+
+		assertThat(py).contains("### ###\n## j ##\n### ###\n");
+	}
+
+	@Test
+	void export_groupsElementsByNamespaceAlphabetically() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.ambiguousShortIdJustification());
+
+		assertThat(py).containsSubsequence("## a ##", "def first(", "## b ##",
+				"def second(", "## j ##");
+	}
+
+	@Test
+	void export_ordersElementsBottomUpWithinANamespace() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.simpleJustification());
+
+		assertThat(py).containsSubsequence("def test_results(", "def testing(");
+	}
+
+	@Test
+	void export_ordersSubConclusionsBetweenStrategiesAndTheConclusion() {
+		Justification j = new Justification("j");
+		Conclusion c = new Conclusion("c", "Overall");
+		Strategy s = new Strategy("s", "By parts");
+		SubConclusion sc = new SubConclusion("sc", "Part holds");
+		Evidence e = new Evidence("e", "Proof");
+		j.setConclusion(c);
+		j.addElement(s);
+		j.addElement(sc);
+		j.addElement(e);
+		s.addSupport(e);
+		sc.addSupport(s);
+		c.addSupport(s);
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py).containsSubsequence("def proof(", "def by_parts(",
+				"def part_holds(");
+	}
+
+	@Test
+	void export_ordersAbstractSupportsWithTheEvidence() {
+		String py = new PythonExporter().export(ModelFixtures.simpleTemplate());
+
+		assertThat(py).containsSubsequence("def abstract_step(",
+				"def strategy(");
+	}
+
+	@Test
+	void export_mergedElement_isGroupedWithTheComposedModelNotASource() {
+		Justification j = new Justification("comp");
+		Conclusion c = new Conclusion("c", "Overall");
+		Strategy s = new Strategy("src:s", "By parts");
+		Evidence merged = new Evidence("merged", "Shared proof");
+		j.setConclusion(c);
+		j.addElement(s);
+		j.addElement(merged);
+		s.addSupport(merged);
+		c.addSupport(s);
+		j.recordAlias("src:e1", "merged");
+		j.recordAlias("other:e2", "merged");
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py).containsSubsequence("## comp ##", "def shared_proof(",
+				"## src ##");
 	}
 
 	@Test
@@ -49,7 +250,7 @@ class PythonExporterTest {
 		String py = new PythonExporter()
 				.export(ModelFixtures.simpleJustification());
 
-		assertThat(py).contains("@jpipe_link(\"j:c\")\n@jpipe(consume=[])",
+		assertThat(py).contains(
 				"@jpipe_link(\"j:s\")\n@jpipe(produce=[], consume=[])",
 				"@jpipe_link(\"j:e1\")\n@jpipe(produce=[])");
 	}
@@ -109,21 +310,19 @@ class PythonExporterTest {
 		String py = new PythonExporter()
 				.export(ModelFixtures.simpleJustification());
 
-		assertThat(py).contains(
-				"\"\"\"[conclusion] The system is correct\"\"\"",
-				"\"\"\"[strategy] Testing\"\"\"",
+		assertThat(py).contains("\"\"\"[strategy] Testing\"\"\"",
 				"\"\"\"[evidence] Test results\"\"\"");
 	}
 
 	@Test
 	void export_labelWithSpecialChars_methodNameEscapedDocstringPreserved() {
 		Justification j = new Justification("j");
-		Conclusion c = new Conclusion("c", "Accuracy <= 0.85");
-		j.setConclusion(c);
+		j.setConclusion(new Conclusion("c", "Overall"));
+		j.addElement(new Evidence("e", "Accuracy <= 0.85"));
 
 		String py = new PythonExporter().export(j);
 
-		assertThat(py).contains("def accuracy_0_85() -> bool:",
-				"\"\"\"[conclusion] Accuracy <= 0.85\"\"\"");
+		assertThat(py).contains("def accuracy_0_85(produce: JpipeProduce)",
+				"\"\"\"[evidence] Accuracy <= 0.85\"\"\"");
 	}
 }

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/CompositionOperator.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/CompositionOperator.java
@@ -2,6 +2,7 @@ package ca.mcscert.jpipe.operators;
 
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
+import ca.mcscert.jpipe.commands.linking.MarkUnified;
 import ca.mcscert.jpipe.commands.linking.RegisterAlias;
 import ca.mcscert.jpipe.model.JustificationModel;
 import ca.mcscert.jpipe.model.SourceLocation;
@@ -267,6 +268,17 @@ public abstract class CompositionOperator {
 		// Persist aliases to Unit via RegisterAlias commands
 		aliases.aliases().forEach((oldId, newId) -> commands
 				.add(new RegisterAlias(resultName, oldId, newId)));
+
+		// Carry forward which ids unification minted in the sources. A source
+		// composed earlier may contribute a "unified_N" element; qualified into
+		// this result it stays an id no author wrote, whether it survives as an
+		// element or lives on only as an alias of a further merge.
+		for (JustificationModel<?> source : sources) {
+			for (String unified : source.unifiedIds()) {
+				commands.add(
+						new MarkUnified(resultName, qualId(source, unified)));
+			}
+		}
 
 		// Phase 2: link reconstruction
 		Set<String> seenEdges = new LinkedHashSet<>();

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
@@ -3,6 +3,7 @@ package ca.mcscert.jpipe.operators;
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.creation.ElementCreationCommand;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
+import ca.mcscert.jpipe.commands.linking.MarkUnified;
 import ca.mcscert.jpipe.commands.linking.RegisterAlias;
 import ca.mcscert.jpipe.model.elements.AbstractSupport;
 import ca.mcscert.jpipe.model.elements.Conclusion;
@@ -31,7 +32,10 @@ import java.util.stream.Collectors;
  * id is {@code "unified_N"} (N = 0-based counter per merged group). All
  * original member ids are aliased to the new id via {@link RegisterAlias}
  * commands, and {@link AddSupport} commands referencing removed ids are
- * rewritten accordingly.
+ * rewritten accordingly. Each new id is also flagged via {@link MarkUnified},
+ * since it names a group by a counter and so appears in no source file;
+ * exporters that address a human audience name the element by its originals
+ * instead.
  *
  * <p>
  * A group may legitimately mix element kinds — one source argued a claim while
@@ -142,6 +146,8 @@ public final class Unifier {
 				phase4Aliases, prototypes);
 		phase4Aliases.forEach((oldId, newId) -> result
 				.add(new RegisterAlias(resultName, oldId, newId)));
+		prototypes.keySet()
+				.forEach(id -> result.add(new MarkUnified(resultName, id)));
 		return List.copyOf(result);
 	}
 


### PR DESCRIPTION
This pull request introduces several improvements and new validation rules to the model export and consistency checking logic, particularly for Python export and identifier handling. The most significant changes are the introduction of a stricter identifier uniqueness rule, enhancements to Python export output structure and naming, and new internal APIs to track unified (compiler-generated) IDs. These changes improve model reliability, export clarity, and error detection for ambiguous references.

**Identifier validation and consistency:**

- Added a new `unique-identifiers` consistency rule that ensures no identifier (including merge aliases) in an exported model designates more than one element. Compilation now fails with a clear error if an ambiguous reference is possible, preventing silent failures at runtime. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R77) [[2]](diffhunk://#diff-f6cae573a83f7c2cbc074e3af6661ee421201c62c0b5d505fcd47ddb48003933R108) [[3]](diffhunk://#diff-eb0b7706c1e4b632d33e2b58a223c7d9607ee9479cdfe7260c662c299a86d797R23-R26) [[4]](diffhunk://#diff-eb0b7706c1e4b632d33e2b58a223c7d9607ee9479cdfe7260c662c299a86d797R56) [[5]](diffhunk://#diff-eb0b7706c1e4b632d33e2b58a223c7d9607ee9479cdfe7260c662c299a86d797R71) [[6]](diffhunk://#diff-eb0b7706c1e4b632d33e2b58a223c7d9607ee9479cdfe7260c662c299a86d797R102-R167) [[7]](diffhunk://#diff-831a34eaa9d48cc75d3a022ad05d2ea95db5ef2d449d8476ce48d833804e72b7R51-R80)

**Python export improvements:**

- Python export now omits the conclusion entirely and emits sub-conclusions commented out, with clear explanations. Only evidence and strategies are exported as active code, matching the runner's requirements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R77) [[2]](diffhunk://#diff-8e7dbfc95ec7447497b3235afd9d17a6b69c11642129e3af848c36d1227874f6L17-R28)
- Python export groups functions by namespace, each with a banner comment, and orders elements bottom-up (evidence, then strategies, then sub-conclusions) for better readability and maintainability. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R77) [[2]](diffhunk://#diff-8e7dbfc95ec7447497b3235afd9d17a6b69c11642129e3af848c36d1227874f6L34-R81)
- Python export now guarantees every `@jpipe_link` is unique and refuses to write a module if a duplicate is detected. Merged elements are now linked by all their original IDs, and unified (compiler-minted) IDs are not exported as links. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R77) [[2]](diffhunk://#diff-8e7dbfc95ec7447497b3235afd9d17a6b69c11642129e3af848c36d1227874f6L34-R81)

**Internal APIs and tracking:**

- Introduced the `MarkUnified` command and corresponding APIs in `JustificationModel` and `Unit` to record and expose which IDs were minted by unification, allowing exporters to distinguish author-written from compiler-generated IDs. [[1]](diffhunk://#diff-030d25e5e02fe1691b2732ec4463263814535b41098dad8d29502e1d57768b82R1-R39) [[2]](diffhunk://#diff-54ce3053251e80fa58e76adf412f299606624cea192d60272eb73253bdce3026R54) [[3]](diffhunk://#diff-54ce3053251e80fa58e76adf412f299606624cea192d60272eb73253bdce3026R102-R124) [[4]](diffhunk://#diff-f39632e11facac75a5f737f60541f840183960bff1c94bfd37b67a797623fa26R137-R144)

**Testing and documentation:**

- Added and updated tests to cover ambiguous identifier detection, Python export structure, and link emission. Updated documentation to describe the new consistency rule and export behaviors. [[1]](diffhunk://#diff-83ddfdef8990cd09a1e3b169d5803faed967c63f705a5cb3f2196070ff3477caR363-R387) [[2]](diffhunk://#diff-831a34eaa9d48cc75d3a022ad05d2ea95db5ef2d449d8476ce48d833804e72b7R51-R80) [[3]](diffhunk://#diff-8e7dbfc95ec7447497b3235afd9d17a6b69c11642129e3af848c36d1227874f6L17-R28) [[4]](diffhunk://#diff-8e7dbfc95ec7447497b3235afd9d17a6b69c11642129e3af848c36d1227874f6L34-R81) [[5]](diffhunk://#diff-f6cae573a83f7c2cbc074e3af6661ee421201c62c0b5d505fcd47ddb48003933R108)

**Exporter base enhancements:**

- Added logic and constants to support minimal identifier shortening while preserving clarity (`container:id` form) in the exporter base class. [[1]](diffhunk://#diff-cecad6697a54d6a2818a1d07c628fda2f029a481042c7770e12f0b77ee443894R7-R16) [[2]](diffhunk://#diff-cecad6697a54d6a2818a1d07c628fda2f029a481042c7770e12f0b77ee443894R46-R52)