### PR TITLE
Release v2.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,11 @@ jobs:
           [ -n "$VERSION" ] || { echo "ERROR: could not extract project version"; exit 1; }
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      # `verify`, not `package`: the shaded-JAR smoke tests (jpipe-cli's *IT)
+      # run after packaging, and only this phase reaches them. It also brings
+      # spotless, checkstyle and coverage into this job.
       - name: Build and test
-        run: mvn -B package
+        run: mvn -B verify
 
       # Locate the shaded fat JAR (exclude the *-original.jar that Shade leaves behind)
       - name: Locate fat JAR

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,28 @@ on:
   push:
     branches:
       - dev
+    # The site is generated from more than docs/: the API reference comes from
+    # every module's main sources, the railroad diagrams from the grammar, and
+    # the schema page from a compiler resource. So this is a deny list, not an
+    # allow list — anything not named here still deploys. Listing what the site
+    # is built from instead would publish a stale site the day someone adds a
+    # new input and forgets this file.
+    paths-ignore:
+      - '**/src/test/**'
+      - 'examples/**'
+      - 'scripts/**'
+      - 'debian/**'
+      - 'bin/**'
+      - 'config/**'
+      - '.github/workflows/build.yml'
+      - '.github/workflows/sonar.yml'
+      - '.github/workflows/release.yml'
+      - '.gitignore'
+      - 'CHANGELOG.md'
+      - 'CLAUDE.md'
+      - 'CITATION.cff'
+      - 'LICENSE'
+      - 'code-of-conduct.md'
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
   outdated Graphviz, which is a common explanation for rendering problems.
 
 ### Fixed
+- `jpipe diagnostic` now reports an unreadable input file as a fatal diagnostic
+  and exits 1, instead of exiting 42 with only a message on standard error.
+  `jpipe process` is unchanged: a missing file there is still a system error.
 - `jpipe diagnostic` now writes a report even when compilation fails fatally —
   a syntax error or an unresolvable `load` — in both `text` and `json`. The
   report carries a diagnostic with `severity: "fatal"` and an empty `models`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- `jpipe doctor` now reports the version of each external tool it finds
+  (e.g. `dot (Graphviz): OK (version 12.2.1)`). Some operating systems ship an
+  outdated Graphviz, which is a common explanation for rendering problems.
+
 ---
 
 ## [2.4.0] — 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
   (e.g. `dot (Graphviz): OK (version 12.2.1)`). Some operating systems ship an
   outdated Graphviz, which is a common explanation for rendering problems.
 
+### Fixed
+- Composition operators are now commutative when unification merges elements
+  of different kinds: a claim that one model argues (a sub-conclusion) and
+  another asserts (an evidence) merges into a sub-conclusion whichever order
+  the sources are listed in. `assemble(a, b)` and `assemble(b, a)` previously
+  produced the same model only by luck, and the unlucky order failed to
+  compile at all (#156).
+- A unification group whose element kinds genuinely cannot be merged (e.g. the
+  assembled conclusion colliding with a source evidence) is now reported as
+  `incompatible-unification`, pointing at the operator call and naming both
+  elements and their shared label, instead of surfacing as an unexplained
+  `invalid-support` further down the build.
+
 ---
 
 ## [2.4.0] — 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+---
+
+## [2.5.0] — 2026-08-14
+
 ### Added
 - Python export now leaves out the conclusion entirely and emits sub-conclusions
   commented out, with a line saying why. The runner requires only evidence and
@@ -402,7 +406,8 @@ server.
 ### Added
 - Initial commit: first version of the compiler.
 
-[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/jpipe-mcscert/jpipe-compiler/compare/v2.2.0...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
   outdated Graphviz, which is a common explanation for rendering problems.
 
 ### Fixed
+- `jpipe diagnostic` now writes a report even when compilation fails fatally —
+  a syntax error or an unresolvable `load` — in both `text` and `json`. The
+  report carries a diagnostic with `severity: "fatal"` and an empty `models`
+  list, and the exit code stays 1, so tooling no longer has to parse stderr for
+  the most common failure of a file being edited (#154).
 - Composition operators are now commutative when unification merges elements
   of different kinds: a claim that one model argues (a sub-conclusion) and
   another asserts (an evidence) merges into a sub-conclusion whichever order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,63 @@ format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- Python export now leaves out the conclusion entirely and emits sub-conclusions
+  commented out, with a line saying why. The runner requires only evidence and
+  strategies to be bound: it never executes a conclusion, so there was nothing to
+  implement there, and it passes an unbound sub-conclusion through. Commenting
+  the sub-conclusions keeps the shape of the argument visible and lets you turn
+  one into a real check by deleting the `# ` prefixes. Both remain in the JSON
+  and DOT exports, which describe the model rather than its execution.
+- Python export now groups functions by namespace, each section opening with a
+  banner comment naming it, so a module assembled from several sources reads as
+  the parts it was built from rather than one flat list. Sections are ordered
+  alphabetically; elements a composition created or merged carry no source
+  prefix and are grouped under the composed model itself. Within a section
+  elements run bottom-up (evidence, then strategies, then sub-conclusions), so
+  the file reads from the steps you implement toward the claim they support.
+
+  ```python
+  ###       ###
+  ## a_claim ##
+  ###       ###
+  ```
+- Python export now guarantees that every `@jpipe_link` in a generated module
+  names a distinct identifier, and refuses to write the module otherwise
+  rather than emitting one that cannot load. A runner keys its binding registry
+  by the link id, so the same id on two functions leaves it with two candidate
+  implementations and no way to choose.
+- New `unique-identifiers` consistency rule: compilation now fails if any
+  identifier an exported model can be referenced by would designate two
+  different elements. Element ids were already checked; this extends the
+  guarantee to the aliases a merge leaves behind, because an alias colliding
+  with another element's id makes a reference ambiguous. Consumers index ids
+  and aliases into one namespace and cannot resolve such a clash —
+  `jpipe-runner` discards the entire model rather than guess — so the compiler
+  now reports it as an error, with the source location, instead of emitting a
+  model that silently fails to load.
+
 ### Changed
 - `jpipe doctor` now reports the version of each external tool it finds
   (e.g. `dot (Graphviz): OK (version 12.2.1)`). Some operating systems ship an
   outdated Graphviz, which is a common explanation for rendering problems.
 
 ### Fixed
+- **Python export:** `@jpipe_link` now names elements the way you wrote them.
+  An element produced by a merge is linked by the ids it was merged from
+  instead of by the internal id unification minted for it (`unified_0`), and a
+  composition of a composition resolves all the way back to the ids in the
+  original source models. Links are also shortened — `@jpipe_link("a_claim:s1")`
+  rather than `@jpipe_link("assembled_2:a_claim:s1")` — but never below
+  `justification:id`, since a bare `s1` would leave a reader of the generated
+  module unable to tell what it refers to, and they lengthen again wherever a
+  shorter form would be ambiguous. Elements a composition operator creates in
+  its own right, such as `assembleConclusion`, keep their id: it is the only
+  name they have, and their label comes from the operator call.
+- **JSON export:** the per-element `aliases` array now lists every pre-merge id
+  rather than only the most recent one. Composing the result of a composition
+  records a chain of merges, and the earlier ids in that chain were dropped,
+  leaving elements that `jpipe-runner` could not bind by their original names.
 - `jpipe diagnostic` now reports an unreadable input file as a fatal diagnostic
   and exits 1, instead of exiting 42 with only a message on standard error.
   `jpipe process` is unchanged: a missing file there is still a system error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ mvn test                                 # run all tests
 mvn test -pl jpipe-model                 # single module
 mvn test -pl jpipe-compiler              # E2E (Cucumber) tests
 mvn test -pl jpipe-compiler -Dtest=Foo   # single test class
-mvn verify                               # includes checkstyle and coverage
+mvn verify                               # + checkstyle, coverage, fat-JAR smoke tests
 mvn spotless:apply                       # auto-format (required before commit)
 mvn spotless:check                       # check formatting without applying
 ```
@@ -219,7 +219,10 @@ Architecture decisions live in `docs/adr/`. Notable ones:
   `ca.mcscert.jpipe.compiler.steps`.
 - **Testing:** New features must include Cucumber scenarios in
   `jpipe-compiler/src/test/resources/features` and JUnit Jupiter unit tests in
-  the relevant module.
+  the relevant module. Anything that only shows up once the fat JAR is
+  assembled — a dependency scope, a shade transformer, a packaged resource —
+  belongs in `jpipe-cli`'s `*IT` smoke tests, which run the built JAR itself;
+  unit tests resolve the module classpath and cannot see those failures.
 - **Logging:** Log4j 2; follow ADR-0006 conventions.
 - **Changelog:** Every user-facing change must be recorded in
   [`CHANGELOG.md`](CHANGELOG.md) under `## [Unreleased]` — see

--- a/docs/adr/0015-consistency-and-completeness-validation.md
+++ b/docs/adr/0015-consistency-and-completeness-validation.md
@@ -105,6 +105,7 @@ misleading completeness results.
 | Rule | Description |
 |------|-------------|
 | `no-duplicate-ids` | All element IDs within a model are unique, including the conclusion's ID. |
+| `unique-identifiers` | No identifier an exported model can be addressed by designates two different elements. Beyond the element IDs this covers the merge aliases, since every ID merged into an element addresses that element too: an alias colliding with another element's ID would make a reference ambiguous. Consumers index IDs and aliases into a single namespace, so the ambiguity has no safe resolution — `jpipe-runner` discards the whole model rather than guess. |
 | `acyclic-support` | The support graph is acyclic. A cycle is detected when following support edges from any node visits a node already on the current traversal path. |
 
 Note: type constraints (Conclusion ← Strategy ← SupportLeaf only) are enforced by

--- a/docs/adr/0016-error-management.md
+++ b/docs/adr/0016-error-management.md
@@ -69,8 +69,9 @@ renderer chooses its own presentation.
 
 Codes are optional by design. Summary diagnostics such as `"model construction
 failed — see errors above"` name no specific rule, and none is invented for
-them. `FATAL` diagnostics carry no code: a fatal aborts the pipeline before any
-report is rendered, so nothing consumes one.
+them. `FATAL` diagnostics carry no code either: a fatal names a
+compilation-level failure — the pipeline cannot continue — rather than a rule
+that was broken.
 
 ### HaltAndCatchFire is placed exclusively after parsing
 
@@ -102,6 +103,23 @@ points to inspect the outcome without access to `CompilationContext`.
 `ChainCompiler` returns `ctx.hasErrors()` after the pipeline completes. If the
 pipeline throws (e.g. due to a `FATAL`), the exception propagates naturally and the
 return value is never reached — the CLI catch blocks handle that path.
+
+### Reporting on a compilation that aborted
+
+The pipeline invariant above is absolute: no step runs after a `FATAL`. That
+makes a report assembled as the last steps of a pipeline unable to describe the
+very failures that stopped it — which is what the `diagnostic` command exists to
+do.
+
+The command therefore has its own `DiagnosticCompiler`, which runs the analysis
+as a pipeline and then writes the report whether that pipeline completed or
+aborted; when it aborted, on the empty unit it never got to build. Rendering is
+reachable outside `fire()` for that reason (`CollectDiagnostics.snapshot` and
+`DiagnosticRenderer.render`). The exit code is unchanged: `hasErrors()` counts a
+`FATAL`, so the command still exits 1.
+
+`process` keeps the original behaviour, because its output stream carries a
+model export and a report written into it would corrupt the artefact.
 
 ### CLI exit codes
 

--- a/docs/adr/0016-error-management.md
+++ b/docs/adr/0016-error-management.md
@@ -128,7 +128,15 @@ model export and a report written into it would corrupt the artefact.
 | Compilation succeeded, no errors | 0 |
 | Compilation succeeded, errors diagnosed | 1 |
 | Pipeline aborted (syntax errors or explicit FATAL) | 1 |
+| Source file unreadable, under `diagnostic` | 1 |
+| Source file unreadable, under `process` | 42 |
 | Unexpected exception (system error) | 42 |
+
+A source file that cannot be read is a `FATAL` under `diagnostic` for the same
+reason as an aborted pipeline: the command reports on a source rather than
+consuming it, so a tool gets a document naming the problem instead of an empty
+stream. Under `process` it stays a system error — there is no artefact to
+produce and nothing to report into.
 
 Exit code 42 is reserved for exceptions that escape all `CompilationException` and
 `UnsupportedOperationException` handlers — i.e., bugs or environmental failures

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -190,6 +190,10 @@ symbol table reads `(empty)`, because nothing could be built. The exit code is
 1. Consumers detect the case by finding a diagnostic with `severity: "fatal"`,
 and need no separate path for it.
 
+A source file that cannot be read at all is reported the same way, as a fatal
+diagnostic with exit code 1, rather than as the system error (42) it remains
+under `process`.
+
 This is why `diagnostic` has its own compiler rather than assembling the report
 as the tail of the analysis chain — a report produced as a pipeline step could
 never describe the failures that stopped that pipeline. `process` deliberately

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -183,10 +183,19 @@ The ASCII logo is suppressed automatically when the JSON report goes to
 standard output, so `jpipe diagnostic -f json | jq .` works without
 `--headless`. Writing to a file with `-o` keeps the banner on stdout.
 
-**Limitation.** A *fatal* error (a syntax error, an unresolvable `load`) aborts
-the pipeline before any report is produced, in either format: nothing is
-written to the output stream, the message goes to standard error, and the exit
-code is 1. Tools must handle that case separately.
+**Reporting on a compilation that aborted.** A *fatal* error — a syntax error,
+an unresolvable `load` — stops the pipeline, but the report is still written in
+both formats: the diagnostics describe the failure, `models` is empty and the
+symbol table reads `(empty)`, because nothing could be built. The exit code is
+1. Consumers detect the case by finding a diagnostic with `severity: "fatal"`,
+and need no separate path for it.
+
+This is why `diagnostic` has its own compiler rather than assembling the report
+as the tail of the analysis chain — a report produced as a pipeline step could
+never describe the failures that stopped that pipeline. `process` deliberately
+keeps the old behaviour: its output stream carries a model export, so a report
+poured into it would corrupt the artefact. A fatal there still reaches standard
+error with exit code 1 and no output.
 
 ### `doctor`
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -46,7 +46,9 @@ package "cli" {
   }
 
   class Doctor <<utility>> {
-    + {static} run() : boolean
+    + {static} run(PrintStream) : boolean
+    ~ {static} probe(String[]) : Optional<String>
+    ~ {static} statusLine(String, Optional<String>) : String
     ~ {static} describe(String) : String
   }
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -47,6 +47,7 @@ package "cli" {
 
   class Doctor <<utility>> {
     + {static} run() : boolean
+    ~ {static} describe(String) : String
   }
 
   class Logo <<utility>> {
@@ -194,9 +195,17 @@ prints a status line for each. Also prints the jPipe version number.
 jpipe doctor
 ```
 
+```
+  dot (Graphviz): OK (version 12.2.1)
+```
+
 Currently checks: `dot` (Graphviz). A tool is considered available if the OS
-can launch the executable; the exit code of the probe is ignored. Returns exit
-code `0` if all tools are found, `1` otherwise.
+can launch the executable; the exit code of the probe is ignored. The probe
+output is scanned for a version number, which is reported next to the status —
+several operating systems ship an outdated Graphviz, and that shows up as
+rendering bugs. When no version can be read out of the banner, the status line
+reads `OK (version unknown)`. Returns exit code `0` if all tools are found, `1`
+otherwise.
 
 ## Shared infrastructure
 

--- a/docs/design/compiler.md
+++ b/docs/design/compiler.md
@@ -73,9 +73,10 @@ every step.
   sources can be expressed as lambdas via `Source.of(Provider)`.
 - **`Transformation<I, O>`** — middle step: a typed function `I → O`. Subclasses
   implement the protected `run` method; callers always go through the final
-  `fire` method, which handles logging, null-output detection, fast-fail on
-  accumulated fatal errors, and wrapping of checked exceptions into
-  `CompilationException`. Lightweight steps can be expressed as lambdas via
+  `fire` method, which handles logging, null-output detection, and fast-fail on
+  accumulated fatal errors. Exceptions from `run` propagate unchanged — a step
+  that cannot continue throws `CompilationException` itself. Lightweight steps
+  can be expressed as lambdas via
   `Transformation.of(Step)`. Steps are composed via `andThen`.
 - **`Checker<I>`** — a specialisation of `Transformation<I, I>` whose `run` is
   sealed to always return its input unchanged. Subclasses implement `check`,

--- a/docs/design/compiler.md
+++ b/docs/design/compiler.md
@@ -18,6 +18,12 @@ the only type that callers outside the module need to reference.
 `compiler.model`. It is not instantiated directly — `ChainBuilder.andThen(Sink)`
 produces it as the final step of pipeline construction.
 
+`DiagnosticCompiler` backs the `diagnostic` command. It runs the analysis as a
+pipeline but writes its report whether that pipeline completed or aborted, so a
+syntax error or an unresolvable `load` is reported rather than swallowed
+(ADR-0016). A report assembled as the tail of the chain could not do that: a
+fatal stops the chain before those steps run.
+
 ```plantuml
 @startuml compiler
 
@@ -38,7 +44,16 @@ package "compiler" {
     + compile(String, String) : boolean
   }
 
+  class DiagnosticCompiler {
+    - source : Source<InputStream>
+    - analysis : Transformation<InputStream, Unit>
+    - renderer : DiagnosticRenderer
+    - sink : Sink<String>
+    + compile(String, String) : boolean
+  }
+
   Compiler <|.. ChainCompiler
+  Compiler <|.. DiagnosticCompiler
 }
 
 @enduml

--- a/docs/design/diagnostic-schema.md
+++ b/docs/design/diagnostic-schema.md
@@ -100,16 +100,22 @@ report.
 
 Instead `JsonDiagnosticReportSchemaTest` validates against the schema every
 report produced from the unit fixtures **and from every file in `examples/`**,
-so code and schema cannot drift apart without CI noticing. The same test also
+compiled through the same wiring the CLI uses — including the sources that
+abort, which are also asserted to carry their fatal — so code and schema cannot
+drift apart without CI noticing. The same test also
 asserts that the schema rejects malformed documents, so it cannot quietly decay
 into one that accepts anything.
 
 ## Note on fatal errors
 
-A *fatal* error — a syntax error, an unresolvable `load` — aborts the pipeline
-before any report is rendered. **Nothing is written to the output stream**, the
-message goes to standard error, and the exit code is 1. Consumers must handle
-that case outside the schema. `severity: "fatal"` is reserved in the schema but
-does not currently appear in any document.
+A *fatal* error — a syntax error, an unresolvable `load` — aborts the
+compilation, and the report describes exactly that: one or more diagnostics
+with `severity: "fatal"`, `status: "errors"`, an empty `models` array and zeroed
+statistics, because nothing could be built. The exit code is 1.
+
+Consumers therefore need no separate path for it: the document has the same
+shape as any other, and an aborted compilation is recognised by the severity.
+That matters most for editor integrations, since a file being edited is
+syntactically broken most of the time.
 
 See [`cli.md`](cli.md#diagnostic) for the command itself.

--- a/docs/design/model.md
+++ b/docs/design/model.md
@@ -34,6 +34,7 @@ package "model.elements" {
   interface JustificationElement <<sealed>> {
     + id() : String
     + label() : String
+    + kind() : String
     + accept(JustificationVisitor<R>) : R
   }
 

--- a/docs/design/operators.md
+++ b/docs/design/operators.md
@@ -87,6 +87,25 @@ Controlled by two optional operator config parameters:
 | `unifyBy` | `"sameLabel"` | Name of the equivalence relation to use |
 | `unifyExclude` | *(empty)* | Comma-separated result-model element ids to exclude from unification |
 
+**Merging a group that mixes element kinds.** Because the default relation
+compares labels, a group can legitimately hold elements of different kinds:
+one source argued a claim (a sub-conclusion) while another still asserts it
+(an evidence). The merged element is built from the group's *dominant*
+member, not from whichever member appears first in the command list, so the
+result does not depend on the order the sources were listed in:
+
+| Group | Merged element |
+|-------|----------------|
+| sub-conclusion + evidence | **sub-conclusion** — being both `StrategyBacked` and `SupportLeaf`, it supports whatever the evidence supported and can additionally carry the strategy that argues it |
+| any other mix of kinds | rejected with the `incompatible-unification` diagnostic, naming both elements and their shared label |
+
+Among members of the same kind the first one wins, and provides the merged
+element's label and source location. Nothing else is comparable: a
+conclusion is the model's single root, a strategy is the support rather than
+a supporter, and an `@support` placeholder is discharged by an explicit
+override, never by a merge. Use `unifyExclude` to keep colliding elements
+apart.
+
 `UnificationEquivalenceRegistry` maps names to `EquivalenceRelation`
 instances. It is populated at compiler startup in
 `CompilerFactory.builtInUnificationEquivalences()`. `SameShortId` is

--- a/docs/design/steps.md
+++ b/docs/design/steps.md
@@ -290,9 +290,13 @@ only step that walks the `Unit` for reporting purposes; the renderers below
 consume the snapshot and never touch the model, which is what keeps the two
 report formats describing the same compilation.
 
+Also callable directly as `snapshot(Unit, CompilationContext)`. `DiagnosticCompiler`
+uses that entry point, with an empty `Unit`, to report on a compilation that
+aborted — a fatal stops the pipeline before this step would otherwise run.
+
 #### `DiagnosticReport`
 
-**Type:** `Transformation<DiagnosticSnapshot, String>`  
+**Type:** `DiagnosticRenderer` (a `Transformation<DiagnosticSnapshot, String>`)  
 **Package:** `compiler.steps.transformations`
 
 Renders the snapshot as the human-readable report printed by the `diagnostic`
@@ -303,13 +307,17 @@ operators), and Executed Actions. Sections whose data is absent are omitted.
 
 #### `JsonDiagnosticReport`
 
-**Type:** `Transformation<DiagnosticSnapshot, String>`  
+**Type:** `DiagnosticRenderer` (a `Transformation<DiagnosticSnapshot, String>`)  
 **Package:** `compiler.steps.transformations`
 
 Renders the same snapshot as JSON for tooling — selected by `diagnostic -f
 json`. Uses `org.json` internally as a builder for correct escaping while the
 pipeline type stays `String` (ADR-0013). The document declares a
 `schemaVersion`; see [`cli.md`](cli.md) for its shape.
+
+Both renderers extend `DiagnosticRenderer`, whose `render(DiagnosticSnapshot)`
+is reachable outside `fire()` for the same reason as `CollectDiagnostics.snapshot`
+above.
 
 ---
 

--- a/examples/005_override.jd
+++ b/examples/005_override.jd
@@ -16,7 +16,7 @@ template a_template {
 
 // Immediately overriding the abstract support with an evidence.
 justification immediate implements a_template {
-    evidence a_template:abs is "An immediate evidence"   
+    evidence a_template:abs is "An immediate evidence"
 }
 
 // Providing an argumentation that leads to overriding the abstract support

--- a/examples/006_multi_inheritance.jd
+++ b/examples/006_multi_inheritance.jd
@@ -4,12 +4,12 @@
  * @compiler 2.x                 *
  *********************************/
 
-// Top-level template, exposing abs1 and abs2 as abstract supports 
+// Top-level template, exposing abs1 and abs2 as abstract supports
 template root {
-    conclusion c is "A root conclusion"
-    strategy   s is "A root strategy"
-    @support abs1 is "A root abstract support #1"
-    @support abs2 is "A root abstract support #2"
+    conclusion c    is "A root conclusion"
+    strategy   s    is "A root strategy"
+    @support   abs1 is "A root abstract support #1"
+    @support   abs2 is "A root abstract support #2"
 
     s    supports c
     abs1 supports s

--- a/examples/012_chaining_operators.jd
+++ b/examples/012_chaining_operators.jd
@@ -26,8 +26,8 @@ justification second {
 }
 
 justification both is assemble(first, second) {
-conclusionLabel: "an assembled conclusion"
-strategyLabel: "a assembled strategy"
+   conclusionLabel: "an assembled conclusion"
+   strategyLabel: "a assembled strategy"
 }
 
 justification refine_1 {

--- a/examples/024_assemble_commutativity.jd
+++ b/examples/024_assemble_commutativity.jd
@@ -1,0 +1,49 @@
+/*********************************
+ * jPipe  -  Reference Examples  *
+ * @author   Sebastien Mosser    *
+ * @compiler 2.x                 *
+ *********************************/
+
+// "X" is asserted here, as a plain evidence.
+justification base {
+    conclusion c is "Base holds"
+    strategy   s is "because X"
+    evidence   x is "X"
+    s supports c
+    x supports s
+}
+
+// ... and argued here, as a conclusion in its own right.
+justification detail {
+    conclusion c is "X"
+    strategy   s is "because Y"
+    evidence   y is "Y"
+    s supports c
+    y supports s
+}
+
+// A third brick that still asserts "X".
+justification other {
+    conclusion c is "Other holds"
+    strategy   s is "also because X"
+    evidence   x is "X"
+    s supports c
+    x supports s
+}
+
+// Refining turns "X" into a sub-conclusion inside deep.
+justification deep is refine(base, detail) { hook: "x" }
+
+// Assembling deep with other unifies a sub-conclusion ("X", argued) with an
+// evidence ("X", asserted). Both argument orders must give the same model:
+// the merged element is a sub-conclusion, which the detail's strategy can
+// support and which can itself support the other bricks' strategies.
+justification left is assemble(deep, other) {
+    conclusionLabel: "All"
+    strategyLabel:   "Both"
+}
+
+justification right is assemble(other, deep) {
+    conclusionLabel: "All"
+    strategyLabel:   "Both"
+}

--- a/examples/invalid/010_implements_cycle.jd
+++ b/examples/invalid/010_implements_cycle.jd
@@ -17,7 +17,7 @@ template t1 implements t2 {
 template t2 implements t1 {
     sub-conclusion t1:placeholder is "Second template sub-conclusion"
     strategy s is "Second template strategy"
-    s supports sc
+    s supports c
     @support placeholder is "Abstract support"
     placeholder supports s
 }

--- a/examples/invalid/024_unifying_incompatible_kinds.jd
+++ b/examples/invalid/024_unifying_incompatible_kinds.jd
@@ -1,0 +1,23 @@
+justification base {
+    conclusion c is "A conclusion"
+    strategy   s is "A strategy"
+    evidence   e is "An evidence"
+    s supports c
+    e supports s
+}
+
+justification other {
+    conclusion c is "Another conclusion"
+    strategy   s is "Another strategy"
+    evidence   e is "Another evidence"
+    s supports c
+    e supports s
+}
+
+// The global conclusion carries the same label as an evidence of a source:
+// unification groups them, but no single element can be both the model's
+// conclusion and a leaf supporting a strategy.
+justification bad is assemble(base, other) {
+    conclusionLabel: "An evidence"
+    strategyLabel:   "An aggregating strategy"
+}

--- a/examples/invalid/025_syntax_error.jd
+++ b/examples/invalid/025_syntax_error.jd
@@ -1,0 +1,16 @@
+/*********************************
+ * jPipe  -  Reference Examples  *
+ * @author   Sebastien Mosser    *
+ * @compiler 2.x                 *
+ *********************************/
+
+// The parser reports each syntax error, then HaltAndCatchFire promotes them
+// into a fatal that aborts the pipeline. The diagnostic command still reports
+// on the aborted compilation: this is the state a file spends most of its time
+// in while being edited.
+justification broken {
+    conclusion c is "A conclusion"
+    strategy   s is
+    this is not valid jd syntax %%%
+    s supports c
+}

--- a/jpipe-cli/README.md
+++ b/jpipe-cli/README.md
@@ -28,7 +28,12 @@ mvn package -pl jpipe-cli --also-make
 
 # Run
 java -jar target/jpipe-cli-*.jar --help
+
+# Build it and smoke-test the JAR itself
+mvn verify -pl jpipe-cli --also-make
 ```
 
 The fat JAR is the only distributable artefact; all other modules are
-internal.
+internal. Because it is assembled after the tests run, packaging mistakes are
+invisible to them: `ShadedJarIT` therefore runs the built JAR through each
+output path, and is what `verify` adds over `package`.

--- a/jpipe-cli/pom.xml
+++ b/jpipe-cli/pom.xml
@@ -100,6 +100,32 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Runs the *IT smoke tests after `package`, so they exercise the
+                 shaded JAR that users actually run. Unit tests cannot: surefire
+                 resolves the module's own classpath, where a dependency the
+                 shade plugin dropped is still present (see issue #153). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Shade replaces the main artifact, so this is the fat
+                             JAR; the pre-shade one is original-*.jar. -->
+                        <shaded.jar>${project.build.directory}/${project.build.finalName}.jar</shaded.jar>
+                        <examples.dir>${maven.multiModuleProjectDirectory}/examples</examples.dir>
+                        <project.version>${project.version}</project.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/jpipe-cli/pom.xml
+++ b/jpipe-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-cli</artifactId>

--- a/jpipe-cli/pom.xml
+++ b/jpipe-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-cli</artifactId>

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
@@ -43,17 +43,23 @@ final class Doctor {
 	 *         missing.
 	 */
 	static boolean run() {
+		return run(TOOLS);
+	}
+
+	/**
+	 * Probes the given tools and prints a status line for each.
+	 *
+	 * @param tools
+	 *            the tools to probe, mapping a name to its probe command.
+	 * @return {@code true} if every tool is available, {@code false} if any is
+	 *         missing.
+	 */
+	static boolean run(Map<String, String[]> tools) {
 		boolean allOk = true;
-		for (Map.Entry<String, String[]> entry : TOOLS.entrySet()) {
-			String name = entry.getKey();
+		for (Map.Entry<String, String[]> entry : tools.entrySet()) {
 			Optional<String> banner = probe(entry.getValue());
-			if (banner.isPresent()) {
-				System.out.println(
-						"  " + name + ": OK (" + describe(banner.get()) + ")");
-			} else {
-				System.out.println("  " + name + ": NOT FOUND");
-				allOk = false;
-			}
+			System.out.println(statusLine(entry.getKey(), banner));
+			allOk = allOk && banner.isPresent();
 		}
 		return allOk;
 	}
@@ -61,27 +67,41 @@ final class Doctor {
 	/**
 	 * Runs a probe command and captures what it printed.
 	 *
+	 * <p>
+	 * The probe output is read to end-of-file, which the tool reaches when it
+	 * terminates; its exit code is deliberately ignored.
+	 *
 	 * @param command
 	 *            the command to run.
 	 * @return the (possibly empty) probe output, or {@link Optional#empty()} if
 	 *         the executable could not be launched.
 	 */
-	private static Optional<String> probe(String[] command) {
+	static Optional<String> probe(String[] command) {
 		try {
 			Process p = new ProcessBuilder(command).redirectErrorStream(true)
 					.start();
-			String output;
 			try (InputStream in = p.getInputStream()) {
-				output = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+				return Optional.of(
+						new String(in.readAllBytes(), StandardCharsets.UTF_8));
 			}
-			p.waitFor();
-			return Optional.of(output);
-		} catch (InterruptedException _) {
-			Thread.currentThread().interrupt();
-			return Optional.empty();
 		} catch (IOException _) {
 			return Optional.empty();
 		}
+	}
+
+	/**
+	 * Builds the status line reported for a tool.
+	 *
+	 * @param name
+	 *            the human-readable tool name.
+	 * @param banner
+	 *            the probe output, empty if the tool could not be launched.
+	 * @return the line to print for that tool.
+	 */
+	static String statusLine(String name, Optional<String> banner) {
+		String status = banner.map(b -> "OK (" + describe(b) + ")")
+				.orElse("NOT FOUND");
+		return "  " + name + ": " + status;
 	}
 
 	/**

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
@@ -2,6 +2,7 @@ package ca.mcscert.jpipe.cli;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -11,7 +12,7 @@ import java.util.regex.Pattern;
 
 /**
  * Checks that external tools required by jPipe are available on {@code PATH}
- * and reports their status to standard output.
+ * and reports their status to a given stream.
  *
  * <p>
  * Each tool is probed by attempting to start a process. A tool is considered
@@ -37,28 +38,32 @@ final class Doctor {
 	}
 
 	/**
-	 * Probes all required external tools and prints a status line for each.
+	 * Probes all required external tools and reports a status line for each.
 	 *
+	 * @param out
+	 *            where the status lines are written.
 	 * @return {@code true} if every tool is available, {@code false} if any is
 	 *         missing.
 	 */
-	static boolean run() {
-		return run(TOOLS);
+	static boolean run(PrintStream out) {
+		return run(TOOLS, out);
 	}
 
 	/**
-	 * Probes the given tools and prints a status line for each.
+	 * Probes the given tools and reports a status line for each.
 	 *
 	 * @param tools
 	 *            the tools to probe, mapping a name to its probe command.
+	 * @param out
+	 *            where the status lines are written.
 	 * @return {@code true} if every tool is available, {@code false} if any is
 	 *         missing.
 	 */
-	static boolean run(Map<String, String[]> tools) {
+	static boolean run(Map<String, String[]> tools, PrintStream out) {
 		boolean allOk = true;
 		for (Map.Entry<String, String[]> entry : tools.entrySet()) {
 			Optional<String> banner = probe(entry.getValue());
-			System.out.println(statusLine(entry.getKey(), banner));
+			out.println(statusLine(entry.getKey(), banner));
 			allOk = allOk && banner.isPresent();
 		}
 		return allOk;
@@ -69,7 +74,9 @@ final class Doctor {
 	 *
 	 * <p>
 	 * The probe output is read to end-of-file, which the tool reaches when it
-	 * terminates; its exit code is deliberately ignored.
+	 * terminates; its exit code is deliberately ignored. A tool that starts but
+	 * whose output cannot be read is still reported as available, with an empty
+	 * banner.
 	 *
 	 * @param command
 	 *            the command to run.
@@ -77,15 +84,19 @@ final class Doctor {
 	 *         the executable could not be launched.
 	 */
 	static Optional<String> probe(String[] command) {
+		Process process;
 		try {
-			Process p = new ProcessBuilder(command).redirectErrorStream(true)
+			process = new ProcessBuilder(command).redirectErrorStream(true)
 					.start();
-			try (InputStream in = p.getInputStream()) {
-				return Optional.of(
-						new String(in.readAllBytes(), StandardCharsets.UTF_8));
-			}
 		} catch (IOException _) {
 			return Optional.empty();
+		}
+		try (InputStream in = process.getInputStream()) {
+			return Optional
+					.of(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+		} catch (IOException _) {
+			process.destroy();
+			return Optional.of("");
 		}
 	}
 

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
@@ -1,9 +1,13 @@
 package ca.mcscert.jpipe.cli;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Checks that external tools required by jPipe are available on {@code PATH}
@@ -12,12 +16,18 @@ import java.util.Map;
  * <p>
  * Each tool is probed by attempting to start a process. A tool is considered
  * available if the OS can locate and launch the executable, regardless of its
- * exit code.
+ * exit code. When the probe output advertises a version number, it is reported
+ * alongside the status: some operating systems ship outdated versions, which is
+ * a common source of rendering issues.
  */
 final class Doctor {
 
 	/** Maps a human-readable tool name to the command used to probe it. */
 	private static final Map<String, String[]> TOOLS = new LinkedHashMap<>();
+
+	/** Extracts a version number out of a {@code --version} style banner. */
+	private static final Pattern VERSION = Pattern
+			.compile("version\\s+v?(\\d[\\w.+-]*)", Pattern.CASE_INSENSITIVE);
 
 	static {
 		TOOLS.put("dot (Graphviz)", new String[]{"dot", "-V"});
@@ -36,9 +46,10 @@ final class Doctor {
 		boolean allOk = true;
 		for (Map.Entry<String, String[]> entry : TOOLS.entrySet()) {
 			String name = entry.getKey();
-			String[] command = entry.getValue();
-			if (isAvailable(command)) {
-				System.out.println("  " + name + ": OK");
+			Optional<String> banner = probe(entry.getValue());
+			if (banner.isPresent()) {
+				System.out.println(
+						"  " + name + ": OK (" + describe(banner.get()) + ")");
 			} else {
 				System.out.println("  " + name + ": NOT FOUND");
 				allOk = false;
@@ -47,18 +58,45 @@ final class Doctor {
 		return allOk;
 	}
 
-	private static boolean isAvailable(String[] command) {
+	/**
+	 * Runs a probe command and captures what it printed.
+	 *
+	 * @param command
+	 *            the command to run.
+	 * @return the (possibly empty) probe output, or {@link Optional#empty()} if
+	 *         the executable could not be launched.
+	 */
+	private static Optional<String> probe(String[] command) {
 		try {
 			Process p = new ProcessBuilder(command).redirectErrorStream(true)
 					.start();
-			p.getInputStream().transferTo(OutputStream.nullOutputStream());
+			String output;
+			try (InputStream in = p.getInputStream()) {
+				output = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+			}
 			p.waitFor();
-			return true;
+			return Optional.of(output);
 		} catch (InterruptedException _) {
 			Thread.currentThread().interrupt();
-			return false;
+			return Optional.empty();
 		} catch (IOException _) {
-			return false;
+			return Optional.empty();
 		}
+	}
+
+	/**
+	 * Turns a probe banner into a human-readable version description.
+	 *
+	 * @param banner
+	 *            the raw output captured from the probe command.
+	 * @return {@code "version X.Y.Z"}, or {@code "version unknown"} when the
+	 *         banner does not advertise one.
+	 */
+	static String describe(String banner) {
+		Matcher matcher = VERSION.matcher(banner);
+		if (matcher.find()) {
+			return "version " + matcher.group(1);
+		}
+		return "version unknown";
 	}
 }

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/Doctor.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
@@ -22,6 +23,9 @@ import java.util.regex.Pattern;
  * a common source of rendering issues.
  */
 final class Doctor {
+
+	/** How long a probed tool may take to exit before it is killed. */
+	private static final long PROBE_TIMEOUT_SECONDS = 5;
 
 	/** Maps a human-readable tool name to the command used to probe it. */
 	private static final Map<String, String[]> TOOLS = new LinkedHashMap<>();
@@ -97,6 +101,30 @@ final class Doctor {
 		} catch (IOException _) {
 			process.destroy();
 			return Optional.of("");
+		} finally {
+			awaitExit(process);
+		}
+	}
+
+	/**
+	 * Waits for a probed tool to finish, so no child outlives the probe that
+	 * started it. The exit code stays irrelevant: the banner has already
+	 * decided the outcome.
+	 *
+	 * <p>
+	 * The wait is bounded. A tool that closes its output without exiting must
+	 * not hang {@code jpipe doctor}, so one that overstays is killed rather
+	 * than waited on. An interrupt is passed on to the caller rather than
+	 * swallowed.
+	 */
+	private static void awaitExit(Process process) {
+		try {
+			if (!process.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+				process.destroyForcibly();
+			}
+		} catch (InterruptedException _) {
+			process.destroyForcibly();
+			Thread.currentThread().interrupt();
 		}
 	}
 

--- a/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/DoctorCommand.java
+++ b/jpipe-cli/src/main/java/ca/mcscert/jpipe/cli/DoctorCommand.java
@@ -26,6 +26,6 @@ class DoctorCommand implements Callable<Integer> {
 		}
 		System.out.println(spec.root().version()[0]);
 		System.out.println("Checking external tools:");
-		return Doctor.run() ? Main.EXIT_OK : Main.EXIT_JPIPE_ERROR;
+		return Doctor.run(System.out) ? Main.EXIT_OK : Main.EXIT_JPIPE_ERROR;
 	}
 }

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DiagnosticCommandTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DiagnosticCommandTest.java
@@ -1,14 +1,14 @@
 package ca.mcscert.jpipe.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ca.mcscert.jpipe.compiler.CompilationConfig;
 import ca.mcscert.jpipe.compiler.DiagnosticFormat;
-import ca.mcscert.jpipe.compiler.model.CompilationException;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -26,14 +26,44 @@ class DiagnosticCommandTest {
 	}
 
 	@Test
-	void doCall_invalid_syntax_throws_compilation_exception() {
+	void doCall_invalid_syntax_still_writes_a_report() throws Exception {
+		// A file being edited is broken most of the time: that is exactly when
+		// a tool needs a report rather than an empty stream (#154).
 		DiagnosticCommand cmd = new DiagnosticCommand();
 		cmd.input = resourcePath("test_invalid.jd");
 		cmd.output = CompilationConfig.STDOUT;
-
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		assertThatThrownBy(() -> cmd.doCall(out))
-				.isInstanceOf(CompilationException.class);
+
+		Integer result = cmd.doCall(out);
+
+		assertThat(result).isEqualTo(Main.EXIT_JPIPE_ERROR);
+		assertThat(out.toString(StandardCharsets.UTF_8))
+				.contains("=== Diagnostics ===").contains("[FATAL]");
+	}
+
+	@Test
+	void doCall_invalid_syntax_writes_a_parseable_json_report()
+			throws Exception {
+		DiagnosticCommand cmd = new DiagnosticCommand();
+		cmd.input = resourcePath("test_invalid.jd");
+		cmd.output = CompilationConfig.STDOUT;
+		cmd.format = DiagnosticFormat.JSON;
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		Integer result = cmd.doCall(out);
+
+		JSONObject report = new JSONObject(
+				out.toString(StandardCharsets.UTF_8));
+		assertThat(result).isEqualTo(Main.EXIT_JPIPE_ERROR);
+		assertThat(report.getString("status")).isEqualTo("errors");
+		assertThat(report.getJSONArray("models")).isEmpty();
+		assertThat(severities(report)).contains("fatal");
+	}
+
+	/** The severity of every diagnostic in a JSON report. */
+	private static List<String> severities(JSONObject report) {
+		return report.getJSONArray("diagnostics").toList().stream()
+				.map(d -> (String) ((Map<?, ?>) d).get("severity")).toList();
 	}
 
 	@Test

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
@@ -3,14 +3,40 @@ package ca.mcscert.jpipe.cli;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class DoctorTest {
+
+	/** A name no executable on PATH is expected to have. */
+	private static final String MISSING_TOOL = "jpipe-no-such-tool-42";
+
+	/** The executable of the JVM running the tests: always available. */
+	private static String javaBinary() {
+		return System.getProperty("java.home") + File.separator + "bin"
+				+ File.separator + "java";
+	}
+
+	/** Runs the doctor on the given tools, capturing what it prints. */
+	private static String capturedRun(Map<String, String[]> tools) {
+		PrintStream original = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+		try {
+			Doctor.run(tools);
+		} finally {
+			System.setOut(original);
+		}
+		return captured.toString(StandardCharsets.UTF_8);
+	}
 
 	@Test
 	void run_returns_boolean() {
@@ -20,17 +46,62 @@ class DoctorTest {
 
 	@Test
 	void run_reports_a_status_line_per_tool() {
-		PrintStream original = System.out;
-		ByteArrayOutputStream captured = new ByteArrayOutputStream();
-		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
-		try {
-			Doctor.run();
-		} finally {
-			System.setOut(original);
-		}
-		assertThat(captured.toString(StandardCharsets.UTF_8))
-				.startsWith("  dot (Graphviz): ").containsPattern(
-						"dot \\(Graphviz\\): (OK \\(version .+\\)|NOT FOUND)");
+		String output = capturedRun(
+				Map.of("dot (Graphviz)", new String[]{"dot", "-V"}));
+		assertThat(output).startsWith("  dot (Graphviz): ").containsPattern(
+				"dot \\(Graphviz\\): (OK \\(version .+\\)|NOT FOUND)");
+	}
+
+	// The runtime tools are not guaranteed to be installed where the tests run,
+	// so the probe is exercised against the running JVM, which always is.
+
+	@Test
+	void run_reports_every_tool_and_fails_on_a_missing_one() {
+		Map<String, String[]> tools = new LinkedHashMap<>();
+		tools.put("java (JVM)", new String[]{javaBinary(), "-version"});
+		tools.put("ghost", new String[]{MISSING_TOOL});
+		String output = capturedRun(tools);
+		assertThat(output).contains("  java (JVM): OK (version ")
+				.contains("  ghost: NOT FOUND");
+	}
+
+	@Test
+	void run_succeeds_when_every_tool_is_available() {
+		boolean allOk = Doctor.run(
+				Map.of("java (JVM)", new String[]{javaBinary(), "-version"}));
+		assertThat(allOk).isTrue();
+	}
+
+	@Test
+	void run_fails_when_a_tool_is_missing() {
+		boolean allOk = Doctor.run(Map.of("ghost", new String[]{MISSING_TOOL}));
+		assertThat(allOk).isFalse();
+	}
+
+	@Test
+	void probe_captures_the_output_of_an_existing_tool() {
+		Optional<String> banner = Doctor
+				.probe(new String[]{javaBinary(), "-version"});
+		assertThat(banner).hasValueSatisfying(
+				b -> assertThat(b).containsIgnoringCase("version"));
+	}
+
+	@Test
+	void probe_is_empty_when_the_tool_cannot_be_launched() {
+		assertThat(Doctor.probe(new String[]{MISSING_TOOL})).isEmpty();
+	}
+
+	@Test
+	void statusLine_reports_the_version_of_an_available_tool() {
+		assertThat(Doctor.statusLine("dot (Graphviz)",
+				Optional.of("dot - graphviz version 12.2.1 (20241206.2353)")))
+				.isEqualTo("  dot (Graphviz): OK (version 12.2.1)");
+	}
+
+	@Test
+	void statusLine_reports_a_missing_tool() {
+		assertThat(Doctor.statusLine("dot (Graphviz)", Optional.empty()))
+				.isEqualTo("  dot (Graphviz): NOT FOUND");
 	}
 
 	@ParameterizedTest(name = "extracts {1} out of \"{0}\"")

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
@@ -2,7 +2,13 @@ package ca.mcscert.jpipe.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class DoctorTest {
 
@@ -10,5 +16,36 @@ class DoctorTest {
 	void run_returns_boolean() {
 		boolean result = Doctor.run();
 		assertThat(result).isIn(true, false);
+	}
+
+	@Test
+	void run_reports_a_status_line_per_tool() {
+		PrintStream original = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+		try {
+			Doctor.run();
+		} finally {
+			System.setOut(original);
+		}
+		assertThat(captured.toString(StandardCharsets.UTF_8))
+				.startsWith("  dot (Graphviz): ").containsPattern(
+						"dot \\(Graphviz\\): (OK \\(version .+\\)|NOT FOUND)");
+	}
+
+	@ParameterizedTest(name = "extracts {1} out of \"{0}\"")
+	@CsvSource({"dot - graphviz version 12.2.1 (20241206.2353), version 12.2.1",
+			"dot - graphviz version 2.43.0 (0), version 2.43.0",
+			"Graphviz VERSION v1.2.3-beta, version 1.2.3-beta"})
+	void describe_extracts_the_advertised_version(String banner,
+			String expected) {
+		assertThat(Doctor.describe(banner)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest(name = "falls back to unknown for \"{0}\"")
+	@ValueSource(strings = {"", "some tool with no version banner",
+			"version without a number"})
+	void describe_falls_back_when_no_version_is_advertised(String banner) {
+		assertThat(Doctor.describe(banner)).isEqualTo("version unknown");
 	}
 }

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/DoctorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -25,22 +26,31 @@ class DoctorTest {
 				+ File.separator + "java";
 	}
 
-	/** Runs the doctor on the given tools, capturing what it prints. */
+	/** Runs the doctor on the given tools, capturing what it reports. */
 	private static String capturedRun(Map<String, String[]> tools) {
-		PrintStream original = System.out;
 		ByteArrayOutputStream captured = new ByteArrayOutputStream();
-		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
-		try {
-			Doctor.run(tools);
-		} finally {
-			System.setOut(original);
+		try (PrintStream out = new PrintStream(captured, true,
+				StandardCharsets.UTF_8)) {
+			Doctor.run(tools, out);
 		}
 		return captured.toString(StandardCharsets.UTF_8);
 	}
 
+	/** Runs the doctor on the given tools, discarding what it reports. */
+	private static boolean silentRun(Map<String, String[]> tools) {
+		try (PrintStream out = new PrintStream(OutputStream.nullOutputStream(),
+				true, StandardCharsets.UTF_8)) {
+			return Doctor.run(tools, out);
+		}
+	}
+
 	@Test
 	void run_returns_boolean() {
-		boolean result = Doctor.run();
+		boolean result;
+		try (PrintStream out = new PrintStream(OutputStream.nullOutputStream(),
+				true, StandardCharsets.UTF_8)) {
+			result = Doctor.run(out);
+		}
 		assertThat(result).isIn(true, false);
 	}
 
@@ -67,14 +77,14 @@ class DoctorTest {
 
 	@Test
 	void run_succeeds_when_every_tool_is_available() {
-		boolean allOk = Doctor.run(
+		boolean allOk = silentRun(
 				Map.of("java (JVM)", new String[]{javaBinary(), "-version"}));
 		assertThat(allOk).isTrue();
 	}
 
 	@Test
 	void run_fails_when_a_tool_is_missing() {
-		boolean allOk = Doctor.run(Map.of("ghost", new String[]{MISSING_TOOL}));
+		boolean allOk = silentRun(Map.of("ghost", new String[]{MISSING_TOOL}));
 		assertThat(allOk).isFalse();
 	}
 

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/InputOutputCommandTest.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/InputOutputCommandTest.java
@@ -28,9 +28,18 @@ class InputOutputCommandTest {
 	}
 
 	@Test
-	void call_missing_file_returns_system_error() {
+	void call_missing_file_is_reported_by_diagnostic() {
+		// `diagnostic` reports on a source rather than consuming it, so a file
+		// it cannot read is a fatal diagnostic like any other, not a crash.
 		int result = Main.commandLine().execute("--headless", "diagnostic",
 				"-i", "/no/such/file.jd", "-o", "<stdout>");
+		assertThat(result).isEqualTo(Main.EXIT_JPIPE_ERROR);
+	}
+
+	@Test
+	void call_missing_file_returns_system_error_when_processing() {
+		int result = Main.commandLine().execute("--headless", "process", "-i",
+				"/no/such/file.jd", "-m", "whatever", "-o", "<stdout>");
 		assertThat(result).isEqualTo(Main.EXIT_SYSTEM_ERROR);
 	}
 

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
@@ -1,0 +1,197 @@
+package ca.mcscert.jpipe.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarFile;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Smoke tests running the shaded JAR as a user would: {@code java -jar}.
+ *
+ * <p>
+ * The unit and Cucumber suites run against each module's own classpath, so a
+ * packaging mistake — a dependency the shade plugin dropped, a clobbered
+ * {@code META-INF} service file, a resource left out of the JAR — passes them
+ * all while the shipped CLI is broken. These tests exercise the artifact
+ * itself, once per output path, asserting exit codes and output shape rather
+ * than exact bytes.
+ *
+ * <p>
+ * Named {@code *IT} so failsafe runs them after {@code package}, when the JAR
+ * exists. They are part of {@code mvn verify}.
+ */
+class ShadedJarIT {
+
+	private static final String MINIMAL = example("000_minimal.jd");
+
+	/** Outcome of one CLI invocation. */
+	private record Execution(int exitCode, String out, String err) {
+	}
+
+	// ── the JAR loads and each output path runs ──────────────────────────────
+
+	@ParameterizedTest(name = "{0} exits 0 and writes {1}")
+	@CsvSource({"diagnostic, === Diagnostics ===", "process, digraph"})
+	void everyOutputPathRuns(String subcommand, String expected)
+			throws IOException {
+		Execution run = subcommand.equals("diagnostic")
+				? jpipe("--headless", "diagnostic", "-i", MINIMAL)
+				: jpipe("--headless", "process", "-i", MINIMAL, "-m", "minimal",
+						"-f", "dot");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(run.out()).contains(expected);
+	}
+
+	@Test
+	void theDiagnosticReportIsParseableJson() throws IOException {
+		// org.json is a transitive dependency: it went missing from the JAR
+		// once, and every unit test stayed green (#153).
+		Execution run = jpipe("--headless", "diagnostic", "-i", MINIMAL, "-f",
+				"json");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(new JSONObject(run.out()).getInt("schemaVersion"))
+				.isEqualTo(1);
+	}
+
+	@Test
+	void theExportedModelIsParseableJson() throws IOException {
+		Execution run = jpipe("--headless", "process", "-i", MINIMAL, "-m",
+				"minimal", "-f", "json");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(new JSONObject(run.out()).getString("name"))
+				.isEqualTo("minimal");
+	}
+
+	// ── the contract tools rely on ───────────────────────────────────────────
+
+	@Test
+	void theJsonReportStaysParseableWithoutHeadless() throws IOException {
+		// The logo must step aside on its own when the report goes to stdout,
+		// or every IDE integration would have to strip it.
+		Execution run = jpipe("diagnostic", "-i", MINIMAL, "-f", "json");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(new JSONObject(run.out()).getInt("schemaVersion"))
+				.isEqualTo(1);
+	}
+
+	@Test
+	void aFileWithValidationErrorsStillReportsAndExitsOne() throws IOException {
+		Execution run = jpipe("--headless", "diagnostic", "-i",
+				example("invalid/001_no_conclusion.jd"), "-f", "json");
+
+		assertThat(run.exitCode()).isEqualTo(1);
+		assertThat(new JSONObject(run.out()).getJSONArray("diagnostics"))
+				.isNotEmpty();
+	}
+
+	// ── packaging-sensitive plumbing ─────────────────────────────────────────
+
+	@Test
+	void theManifestCarriesTheProjectVersion() throws IOException {
+		// Proves the ManifestResourceTransformer kept Main-Class (the JAR ran
+		// at all) and Implementation-Version.
+		Execution run = jpipe("--version");
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(run.out()).contains(System.getProperty("project.version"));
+	}
+
+	@Test
+	void loggingSurvivesShading() throws IOException {
+		// Log4j2's plugin registry is merged across JARs by a shade
+		// transformer;
+		// without it logging silently degrades to nothing.
+		Execution run = jpipe("--headless", "--log-level=INFO", "diagnostic",
+				"-i", MINIMAL);
+
+		assertThat(run.exitCode()).isZero();
+		assertThat(run.err()).contains("ChainCompiler");
+	}
+
+	@Test
+	void doctorReportsOnTheToolsItProbes() throws IOException {
+		// Exit code depends on whether Graphviz is installed on the machine
+		// running the build, so only the report itself is asserted.
+		Execution run = jpipe("--headless", "doctor");
+
+		assertThat(run.exitCode()).isIn(Main.EXIT_OK, Main.EXIT_JPIPE_ERROR);
+		assertThat(run.out()).contains("dot (Graphviz):");
+	}
+
+	@Test
+	void theDiagnosticSchemaIsPackaged() throws IOException {
+		// Served from the site at the $id URL the JSON report declares, so its
+		// loss would break consumers without breaking any command.
+		try (JarFile jar = new JarFile(new File(jarPath()))) {
+			assertThat(jar.getEntry("schema/diagnostic-report-v1.schema.json"))
+					.isNotNull();
+		}
+	}
+
+	// ── helpers ──────────────────────────────────────────────────────────────
+
+	/** Runs the shaded JAR with {@code args}, and captures what it produced. */
+	private static Execution jpipe(String... args) throws IOException {
+		List<String> command = new ArrayList<>(
+				List.of(javaBinary(), "-jar", jarPath()));
+		command.addAll(List.of(args));
+		Process process = new ProcessBuilder(command).start();
+		String out = read(process.getInputStream());
+		String err = read(process.getErrorStream());
+		return new Execution(waitFor(process), out, err);
+	}
+
+	private static int waitFor(Process process) {
+		try {
+			return process.waitFor();
+		} catch (InterruptedException _) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(
+					"interrupted while running the JAR");
+		}
+	}
+
+	private static String read(InputStream stream) throws IOException {
+		try (stream) {
+			return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+	}
+
+	/** The executable of the JVM running the build: always available. */
+	private static String javaBinary() {
+		return System.getProperty("java.home") + File.separator + "bin"
+				+ File.separator + "java";
+	}
+
+	private static String jarPath() {
+		return required("shaded.jar");
+	}
+
+	private static String example(String name) {
+		return Path.of(required("examples.dir"), name).toString();
+	}
+
+	/** Reads a system property failsafe is expected to have set. */
+	private static String required(String key) {
+		String value = System.getProperty(key);
+		if (value == null) {
+			throw new IllegalStateException("'" + key
+					+ "' is not set: run these tests through `mvn verify`");
+		}
+		return value;
+	}
+}

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
@@ -99,6 +99,20 @@ class ShadedJarIT {
 				.isNotEmpty();
 	}
 
+	@Test
+	void aFileThatFailsFatallyStillReportsAndExitsOne() throws IOException {
+		// The issue's own repro: an unresolvable load used to leave stdout
+		// empty, which is the case a tool most needs to read (#154).
+		Execution run = jpipe("--headless", "diagnostic", "-i",
+				example("invalid/021_load_glob_invalid.jd"), "-f", "json");
+
+		JSONObject report = new JSONObject(run.out());
+		assertThat(run.exitCode()).isEqualTo(1);
+		assertThat(report.getString("status")).isEqualTo("errors");
+		assertThat(report.getJSONArray("diagnostics").getJSONObject(0)
+				.getString("severity")).isEqualTo("fatal");
+	}
+
 	// ── packaging-sensitive plumbing ─────────────────────────────────────────
 
 	@Test
@@ -120,7 +134,7 @@ class ShadedJarIT {
 				"-i", MINIMAL);
 
 		assertThat(run.exitCode()).isZero();
-		assertThat(run.err()).contains("ChainCompiler");
+		assertThat(run.err()).contains("Compiling [");
 	}
 
 	@Test

--- a/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
+++ b/jpipe-cli/src/test/java/ca/mcscert/jpipe/cli/ShadedJarIT.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarFile;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -150,9 +151,23 @@ class ShadedJarIT {
 				List.of(javaBinary(), "-jar", jarPath()));
 		command.addAll(List.of(args));
 		Process process = new ProcessBuilder(command).start();
+
+		// Drain stderr in a virtual thread, as RenderWithDot does: reading the
+		// two streams one after the other lets a chatty stderr fill its pipe
+		// buffer and block the process before it can close stdout.
+		AtomicReference<String> stderr = new AtomicReference<>("");
+		Thread drain = Thread.ofVirtual().start(() -> {
+			try {
+				stderr.set(read(process.getErrorStream()));
+			} catch (IOException _) {
+				// Process died before stderr was fully read; safe to ignore.
+			}
+		});
+
 		String out = read(process.getInputStream());
-		String err = read(process.getErrorStream());
-		return new Execution(waitFor(process), out, err);
+		int exitCode = waitFor(process);
+		join(drain);
+		return new Execution(exitCode, out, stderr.get());
 	}
 
 	private static int waitFor(Process process) {
@@ -162,6 +177,15 @@ class ShadedJarIT {
 			Thread.currentThread().interrupt();
 			throw new IllegalStateException(
 					"interrupted while running the JAR");
+		}
+	}
+
+	private static void join(Thread thread) {
+		try {
+			thread.join();
+		} catch (InterruptedException _) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("interrupted while reading stderr");
 		}
 	}
 

--- a/jpipe-compiler/pom.xml
+++ b/jpipe-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-compiler</artifactId>

--- a/jpipe-compiler/pom.xml
+++ b/jpipe-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-compiler</artifactId>

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/CompilerFactory.java
@@ -2,7 +2,6 @@ package ca.mcscert.jpipe.compiler;
 
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.compiler.model.ChainBuilder;
-import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
 import ca.mcscert.jpipe.operators.OperatorRegistry;
 import ca.mcscert.jpipe.operators.UnificationEquivalenceRegistry;
 import ca.mcscert.jpipe.operators.equivalences.SameLabel;
@@ -18,6 +17,7 @@ import ca.mcscert.jpipe.compiler.steps.transformations.ActionListProvider;
 import ca.mcscert.jpipe.compiler.steps.transformations.LoadResolver;
 import ca.mcscert.jpipe.compiler.steps.transformations.CharStreamProvider;
 import ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics;
+import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticRenderer;
 import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
 import ca.mcscert.jpipe.compiler.steps.transformations.ExportToDot;
 import ca.mcscert.jpipe.compiler.steps.transformations.ExportToJson;
@@ -114,6 +114,11 @@ public final class CompilerFactory {
 	 * Both formats share the {@link CollectDiagnostics} step and differ only in
 	 * their renderer, so they always describe the same compilation.
 	 *
+	 * <p>
+	 * The report is written by a {@link DiagnosticCompiler} rather than
+	 * assembled as the tail of the analysis chain, so that a compilation which
+	 * aborts on a fatal diagnostic is still reported on.
+	 *
 	 * @param format
 	 *            how to render the report.
 	 * @param stdout
@@ -123,13 +128,13 @@ public final class CompilerFactory {
 	 */
 	public static Compiler buildDiagnosticCompiler(DiagnosticFormat format,
 			OutputStream stdout) {
-		Transformation<DiagnosticSnapshot, String> renderer = switch (format) {
+		DiagnosticRenderer renderer = switch (format) {
 			case TEXT -> new DiagnosticReport();
 			case JSON -> new JsonDiagnosticReport();
 		};
-		return parsingChain().andThen(unitBuilder())
-				.andThen(new CollectDiagnostics()).andThen(renderer)
-				.andThen(new StringSink(stdout));
+		return new DiagnosticCompiler(new FileSource(),
+				parsingChain().andThen(unitBuilder()).asTransformation(),
+				renderer, new StringSink(stdout));
 	}
 
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticCompiler.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticCompiler.java
@@ -1,0 +1,72 @@
+package ca.mcscert.jpipe.compiler;
+
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.CompilationException;
+import ca.mcscert.jpipe.compiler.model.Sink;
+import ca.mcscert.jpipe.compiler.model.Source;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+import ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics;
+import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticRenderer;
+import ca.mcscert.jpipe.model.Unit;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The compiler behind the {@code diagnostic} command: it reports on a
+ * compilation rather than producing an artefact from it.
+ *
+ * <p>
+ * That distinction is why this is not a {@link ChainCompiler
+ * ca.mcscert.jpipe.compiler.model.ChainCompiler}. A fatal diagnostic aborts the
+ * pipeline at the next {@code fire()} boundary (ADR-0016), so a report
+ * assembled as the last steps of that same pipeline could never describe a
+ * syntax error or an unresolvable {@code load} — precisely the failures a tool
+ * most needs to read. Here the analysis runs as a pipeline, and the report is
+ * written whether it completed or aborted; when it aborted, on the empty unit
+ * it never got to build.
+ *
+ * <p>
+ * The pipeline invariant is untouched: no step runs after a fatal, and
+ * {@code process} still fails without writing anything, since a report poured
+ * into an export stream would corrupt the artefact.
+ */
+final class DiagnosticCompiler implements Compiler {
+
+	private static final Logger logger = LogManager.getLogger();
+
+	private final Source<InputStream> source;
+	private final Transformation<InputStream, Unit> analysis;
+	private final DiagnosticRenderer renderer;
+	private final Sink<String> sink;
+
+	DiagnosticCompiler(Source<InputStream> source,
+			Transformation<InputStream, Unit> analysis,
+			DiagnosticRenderer renderer, Sink<String> sink) {
+		this.source = source;
+		this.analysis = analysis;
+		this.renderer = renderer;
+		this.sink = sink;
+	}
+
+	@Override
+	public boolean compile(String sourceFile, String sinkFile)
+			throws IOException {
+		logger.info("Compiling [{}]", sourceFile);
+		CompilationContext ctx = new CompilationContext(sourceFile);
+		InputStream input = source.provideFrom(sourceFile);
+		Unit unit;
+		try {
+			unit = analysis.fire(input, ctx);
+		} catch (CompilationException _) {
+			// The abort is the subject of the report, not a reason to skip it.
+			// Only a fatal is caught here: a bug in a step still propagates.
+			unit = new Unit(sourceFile);
+		}
+		sink.pourInto(
+				renderer.render(new CollectDiagnostics().snapshot(unit, ctx)));
+		logger.info("Compilation finished [{}]", sourceFile);
+		return ctx.hasErrors();
+	}
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticCompiler.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticCompiler.java
@@ -56,8 +56,10 @@ final class DiagnosticCompiler implements Compiler {
 		logger.info("Compiling [{}]", sourceFile);
 		CompilationContext ctx = new CompilationContext(sourceFile);
 		Unit unit = new Unit(sourceFile);
+		InputStream input = null;
 		try {
-			unit = analysis.fire(source.provideFrom(sourceFile), ctx);
+			input = source.provideFrom(sourceFile);
+			unit = analysis.fire(input, ctx);
 		} catch (CompilationException _) {
 			// The abort is the subject of the report, not a reason to skip it.
 			// Only a fatal is caught here: a bug in a step still propagates.
@@ -66,10 +68,34 @@ final class DiagnosticCompiler implements Compiler {
 			// is something to report on, not something to die on. Failing to
 			// write the report is still an I/O error, and still propagates.
 			ctx.fatal("cannot read source: " + e.getMessage());
+		} finally {
+			release(input);
 		}
 		sink.pourInto(
 				renderer.render(new CollectDiagnostics().snapshot(unit, ctx)));
 		logger.info("Compilation finished [{}]", sourceFile);
 		return ctx.hasErrors();
+	}
+
+	/**
+	 * Closes the source stream, leaving {@link System#in} open: the pipeline
+	 * borrows standard input rather than owning it, and closing it would break
+	 * any later read.
+	 *
+	 * <p>
+	 * A failure to close is logged rather than raised. The report still has to
+	 * be written, and whether the descriptor came back is no part of what the
+	 * command set out to say about the source.
+	 */
+	private void release(InputStream input) {
+		if (input == null || input == System.in) {
+			return;
+		}
+		try {
+			input.close();
+		} catch (IOException e) {
+			logger.warn("Could not close the source stream: {}",
+					e.getMessage());
+		}
 	}
 }

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticCompiler.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/DiagnosticCompiler.java
@@ -55,14 +55,17 @@ final class DiagnosticCompiler implements Compiler {
 			throws IOException {
 		logger.info("Compiling [{}]", sourceFile);
 		CompilationContext ctx = new CompilationContext(sourceFile);
-		InputStream input = source.provideFrom(sourceFile);
-		Unit unit;
+		Unit unit = new Unit(sourceFile);
 		try {
-			unit = analysis.fire(input, ctx);
+			unit = analysis.fire(source.provideFrom(sourceFile), ctx);
 		} catch (CompilationException _) {
 			// The abort is the subject of the report, not a reason to skip it.
 			// Only a fatal is caught here: a bug in a step still propagates.
-			unit = new Unit(sourceFile);
+		} catch (IOException e) {
+			// Same reasoning one step earlier: a source the command cannot read
+			// is something to report on, not something to die on. Failing to
+			// write the report is still an I/O error, and still propagates.
+			ctx.fatal("cannot read source: " + e.getMessage());
 		}
 		sink.pourInto(
 				renderer.render(new CollectDiagnostics().snapshot(unit, ctx)));

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/ChainCompiler.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/ChainCompiler.java
@@ -39,9 +39,7 @@ public final class ChainCompiler<I, O> implements Compiler {
 			O output = chain.fire(input, ctx);
 			sink.pourInto(output);
 		} finally {
-			if (!ctx.diagnosticsRendered()) {
-				printDiagnostics(ctx);
-			}
+			printDiagnostics(ctx);
 		}
 		logger.info("Compilation finished [{}]", sourceFile);
 		return ctx.hasErrors();

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/ChainCompiler.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/ChainCompiler.java
@@ -1,6 +1,7 @@
 package ca.mcscert.jpipe.compiler.model;
 
 import ca.mcscert.jpipe.compiler.Compiler;
+import java.io.Closeable;
 import java.io.IOException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,10 +40,32 @@ public final class ChainCompiler<I, O> implements Compiler {
 			O output = chain.fire(input, ctx);
 			sink.pourInto(output);
 		} finally {
+			release(input);
 			printDiagnostics(ctx);
 		}
 		logger.info("Compilation finished [{}]", sourceFile);
 		return ctx.hasErrors();
+	}
+
+	/**
+	 * Closes the pipeline's input if it holds a resource, leaving
+	 * {@link System#in} open: the pipeline borrows standard input rather than
+	 * owning it, and closing it would break any later read. A source value that
+	 * is not {@link Closeable} needs no release.
+	 *
+	 * <p>
+	 * A failure to close is logged rather than raised, so it cannot mask the
+	 * outcome the compilation was run to produce.
+	 */
+	private void release(I input) {
+		if (!(input instanceof Closeable closeable) || input == System.in) {
+			return;
+		}
+		try {
+			closeable.close();
+		} catch (IOException e) {
+			logger.warn("Could not close the source: {}", e.getMessage());
+		}
 	}
 
 	private void printDiagnostics(CompilationContext ctx) {

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/CompilationContext.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/CompilationContext.java
@@ -35,7 +35,6 @@ public final class CompilationContext {
 	private final List<Diagnostic> diagnostics = new ArrayList<>();
 	private final Map<String, Long> stats = new LinkedHashMap<>();
 	private List<ExecutedAction> executedActions = List.of();
-	private boolean diagnosticsRendered = false;
 
 	public CompilationContext(String sourcePath) {
 		this.sourcePath = sourcePath;
@@ -137,21 +136,6 @@ public final class CompilationContext {
 	/** Ordered list of actions that occurred during interpretation. */
 	public List<ExecutedAction> executedActions() {
 		return executedActions;
-	}
-
-	/**
-	 * Signal that a pipeline step has already rendered the diagnostics (e.g.
-	 * {@code DiagnosticReport}), so
-	 * {@link ca.mcscert.jpipe.compiler.model.ChainCompiler} should not print
-	 * them a second time.
-	 */
-	public void markDiagnosticsRendered() {
-		this.diagnosticsRendered = true;
-	}
-
-	/** True when a step has already rendered the diagnostics. */
-	public boolean diagnosticsRendered() {
-		return diagnosticsRendered;
 	}
 
 }

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticCodes.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/DiagnosticCodes.java
@@ -60,6 +60,12 @@ public final class DiagnosticCodes {
 	/** A command references an element ID that does not exist in its model. */
 	public static final String UNKNOWN_ELEMENT = "unknown-element";
 
+	/**
+	 * Unification grouped elements whose kinds cannot be merged into a single
+	 * element, e.g. a strategy and an evidence sharing the same label.
+	 */
+	public static final String INCOMPATIBLE_UNIFICATION = "incompatible-unification";
+
 	// ---- execution ----------------------------------------------------------
 
 	/** A command could not be executed (catch-all for unexpected failures). */

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/Transformation.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/model/Transformation.java
@@ -102,10 +102,14 @@ public abstract class Transformation<I, O> {
 	 * <ul>
 	 * <li>Fast-fails if the context already holds fatal errors (a previous step
 	 * marked the pipeline as broken).</li>
-	 * <li>Wraps any checked exception in {@link CompilationException}.</li>
 	 * <li>Rejects a {@code null} return from {@link #run} as a programming
 	 * error in the step implementation.</li>
 	 * </ul>
+	 *
+	 * <p>
+	 * Exceptions raised by {@link #run} propagate unchanged: a step that cannot
+	 * continue reports through {@code ctx} or throws
+	 * {@link CompilationException} itself.
 	 *
 	 * @param in
 	 *            the input value.

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnostics.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnostics.java
@@ -43,6 +43,25 @@ public final class CollectDiagnostics
 
 	@Override
 	protected DiagnosticSnapshot run(Unit input, CompilationContext ctx) {
+		return snapshot(input, ctx);
+	}
+
+	/**
+	 * Describes what a compilation produced and reported.
+	 *
+	 * <p>
+	 * Callable directly, and not only as a pipeline step, so that a compilation
+	 * which aborted on a fatal diagnostic can still be reported on — pass an
+	 * empty {@link Unit} for the models it never got to build.
+	 *
+	 * @param input
+	 *            the compiled unit; empty, never {@code null}, when the
+	 *            pipeline aborted.
+	 * @param ctx
+	 *            the context carrying diagnostics, statistics and actions.
+	 * @return the render-agnostic report payload.
+	 */
+	public DiagnosticSnapshot snapshot(Unit input, CompilationContext ctx) {
 		Map<String, List<ImplementorInfo>> implementors = implementorsOf(input);
 		Map<String, Map<String, String>> aliases = groupAliasesByModel(input);
 		List<ModelInfo> models = new ArrayList<>();

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticRenderer.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticRenderer.java
@@ -1,0 +1,39 @@
+package ca.mcscert.jpipe.compiler.steps.transformations;
+
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+
+/**
+ * Common base of the {@code diagnostic} command's renderers.
+ *
+ * <p>
+ * Rendering is exposed as {@link #render(DiagnosticSnapshot)}, callable
+ * directly and not only as a pipeline step. That is what lets a compilation
+ * which aborted still be reported on: a fatal diagnostic stops the pipeline at
+ * the next {@link Transformation#fire} boundary (ADR-0016), so a report that
+ * could only be produced as a step could never describe the very failures it
+ * exists to report.
+ *
+ * @see DiagnosticReport
+ * @see JsonDiagnosticReport
+ */
+public abstract class DiagnosticRenderer
+		extends
+			Transformation<DiagnosticSnapshot, String> {
+
+	/**
+	 * Renders a snapshot into the report text.
+	 *
+	 * @param snapshot
+	 *            what the compilation produced and reported.
+	 * @return the rendered report.
+	 */
+	public abstract String render(DiagnosticSnapshot snapshot);
+
+	@Override
+	protected final String run(DiagnosticSnapshot input,
+			CompilationContext ctx) {
+		return render(input);
+	}
+}

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReport.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReport.java
@@ -1,6 +1,5 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
-import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_DEFERRALS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_MACROS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
@@ -11,7 +10,6 @@ import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.AliasInfo;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ElementCounts;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ModelInfo;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.SymbolInfo;
-import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.model.SourceLocation;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,9 +37,7 @@ import java.util.stream.Collectors;
  * @see CollectDiagnostics
  * @see JsonDiagnosticReport
  */
-public final class DiagnosticReport
-		extends
-			Transformation<DiagnosticSnapshot, String> {
+public final class DiagnosticReport extends DiagnosticRenderer {
 
 	private static final String HDR_DIAGNOSTICS = "=== Diagnostics ===\n";
 	private static final String HDR_ACTION_STATS = "\n=== Action Statistics ===\n";
@@ -52,14 +48,13 @@ public final class DiagnosticReport
 	private static final String ARROW = "\u2192";
 
 	@Override
-	protected String run(DiagnosticSnapshot input, CompilationContext ctx) {
+	public String render(DiagnosticSnapshot input) {
 		StringBuilder sb = new StringBuilder();
 		appendDiagnostics(sb, input);
 		appendActionStats(sb, input);
 		appendModelSummary(sb, input);
 		appendSymbolTable(sb, input);
 		appendActionList(sb, input);
-		ctx.markDiagnosticsRendered();
 		return sb.toString();
 	}
 

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ExecutionFailureDiagnostics.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/ExecutionFailureDiagnostics.java
@@ -9,6 +9,8 @@ import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import ca.mcscert.jpipe.compiler.model.DiagnosticCodes;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.operators.ApplyOperator;
+import ca.mcscert.jpipe.operators.IncompatibleUnificationException;
 import java.util.List;
 
 /**
@@ -57,6 +59,17 @@ final class ExecutionFailureDiagnostics {
 	 */
 	static void diagnoseExecutionFailure(Command cmd, Unit unit,
 			Throwable cause, CompilationContext ctx) {
+		if (cause instanceof IncompatibleUnificationException) {
+			// Raised while expanding an operator call: anchor the diagnostic on
+			// the call site rather than on the command's own text.
+			SourceLocation loc = cmd instanceof ApplyOperator op
+					? op.location()
+					: SourceLocation.UNKNOWN;
+			error(ctx, DiagnosticCodes.INCOMPATIBLE_UNIFICATION, loc,
+					cause.getMessage());
+			ctx.error("model construction failed — see errors above");
+			return;
+		}
 		switch (cmd) {
 			case ImplementsTemplate c -> {
 				SourceLocation loc = c.location();

--- a/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReport.java
+++ b/jpipe-compiler/src/main/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReport.java
@@ -1,6 +1,5 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
-import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_DEFERRALS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_MACROS;
 import static ca.mcscert.jpipe.compiler.model.CompilationContext.STAT_COMMANDS_TOTAL;
@@ -12,7 +11,6 @@ import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ElementCounts;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ImplementorInfo;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.ModelInfo;
 import ca.mcscert.jpipe.compiler.model.DiagnosticSnapshot.SymbolInfo;
-import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.model.SourceLocation;
 import java.util.Map;
 import java.util.Optional;
@@ -59,9 +57,7 @@ import org.json.JSONObject;
  * @see CollectDiagnostics
  * @see DiagnosticReport
  */
-public final class JsonDiagnosticReport
-		extends
-			Transformation<DiagnosticSnapshot, String> {
+public final class JsonDiagnosticReport extends DiagnosticRenderer {
 
 	/** Version of the emitted document shape. */
 	public static final int SCHEMA_VERSION = 1;
@@ -74,7 +70,7 @@ public final class JsonDiagnosticReport
 	private static final String KEY_LOCATION = "location";
 
 	@Override
-	protected String run(DiagnosticSnapshot input, CompilationContext ctx) {
+	public String render(DiagnosticSnapshot input) {
 		JSONObject result = new JSONObject();
 		result.put("schemaVersion", SCHEMA_VERSION);
 		result.put(KEY_SOURCE, input.source());
@@ -83,7 +79,6 @@ public final class JsonDiagnosticReport
 		result.put("stats", stats(input.stats()));
 		result.put("models", models(input));
 		result.put("actions", actions(input));
-		ctx.markDiagnosticsRendered();
 		return result.toString(INDENT);
 	}
 

--- a/jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json
+++ b/jpipe-compiler/src/main/resources/schema/diagnostic-report-v1.schema.json
@@ -74,7 +74,7 @@
       "required": ["severity", "source", "message"],
       "properties": {
         "severity": {
-          "description": "'error' accumulates and sets the exit code (ADR-0016). 'fatal' is reserved: a fatal aborts the pipeline before any report is rendered, so it does not currently appear in a document — consumers should still handle it.",
+          "description": "'error' accumulates and sets the exit code (ADR-0016). 'fatal' aborts the compilation: the report still describes it, with an empty 'models' array, since nothing could be built.",
           "enum": ["error", "fatal"]
         },
         "code": { "$ref": "#/$defs/code" },

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/DiagnosticCompilerTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/DiagnosticCompilerTest.java
@@ -1,0 +1,105 @@
+package ca.mcscert.jpipe.compiler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.mcscert.jpipe.compiler.model.CompilationContext;
+import ca.mcscert.jpipe.compiler.model.Sink;
+import ca.mcscert.jpipe.compiler.model.Source;
+import ca.mcscert.jpipe.compiler.model.Transformation;
+import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
+import ca.mcscert.jpipe.model.Unit;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class DiagnosticCompilerTest {
+
+	private final StringBuilder poured = new StringBuilder();
+
+	// ── stubs ────────────────────────────────────────────────────────────────
+
+	/** A source that never touches the filesystem. */
+	private static Source<InputStream> source() {
+		return new Source<>() {
+			@Override
+			public InputStream provideFrom(String path) {
+				return new ByteArrayInputStream(
+						"ignored".getBytes(StandardCharsets.UTF_8));
+			}
+		};
+	}
+
+	/** An analysis step that reports {@code diagnostic} and returns a unit. */
+	private static Transformation<InputStream, Unit> analysis(
+			java.util.function.Consumer<CompilationContext> diagnostic) {
+		return new Transformation<>() {
+			@Override
+			protected Unit run(InputStream in, CompilationContext ctx) {
+				diagnostic.accept(ctx);
+				return new Unit(ctx.sourcePath());
+			}
+		};
+	}
+
+	private Sink<String> sink() {
+		return poured::append;
+	}
+
+	private DiagnosticCompiler compiler(
+			Transformation<InputStream, Unit> analysis) {
+		return new DiagnosticCompiler(source(), analysis,
+				new DiagnosticReport(), sink());
+	}
+
+	// ── tests ────────────────────────────────────────────────────────────────
+
+	@Test
+	void aCleanCompilationIsReportedAndSucceeds() throws IOException {
+		boolean hasErrors = compiler(analysis(ctx -> {
+			// intentionally quiet: nothing to report
+		})).compile("clean.jd", "<stdout>");
+
+		assertThat(hasErrors).isFalse();
+		assertThat(poured).contains("=== Diagnostics ===").contains("(none)");
+	}
+
+	@Test
+	void anAbortedCompilationIsStillReported() throws IOException {
+		// The fatal makes the *next* fire() boundary throw, which is exactly
+		// the case that used to produce no report at all (#154).
+		boolean hasErrors = compiler(analysis(ctx -> ctx.fatal("unrecoverable"))
+				.andThen(passThrough())).compile("broken.jd", "<stdout>");
+
+		assertThat(hasErrors).isTrue();
+		assertThat(poured).contains("[FATAL]").contains("unrecoverable")
+				.contains("(empty)");
+	}
+
+	@Test
+	void aBugInAStepIsNotSwallowed() {
+		Transformation<InputStream, Unit> exploding = new Transformation<>() {
+			@Override
+			protected Unit run(InputStream in, CompilationContext ctx) {
+				throw new IllegalStateException("a bug, not a diagnostic");
+			}
+		};
+		DiagnosticCompiler compiler = compiler(exploding);
+
+		assertThatThrownBy(() -> compiler.compile("any.jd", "<stdout>"))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("a bug");
+	}
+
+	/** A step that only exists to give the fatal a boundary to abort at. */
+	private static Transformation<Unit, Unit> passThrough() {
+		return new Transformation<>() {
+			@Override
+			protected Unit run(Unit in, CompilationContext ctx) {
+				return in;
+			}
+		};
+	}
+}

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/DiagnosticCompilerTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/DiagnosticCompilerTest.java
@@ -2,6 +2,7 @@ package ca.mcscert.jpipe.compiler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import ca.mcscert.jpipe.compiler.model.Sink;
@@ -10,6 +11,7 @@ import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
 import ca.mcscert.jpipe.model.Unit;
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -76,6 +78,24 @@ class DiagnosticCompilerTest {
 		assertThat(hasErrors).isTrue();
 		assertThat(poured).contains("[FATAL]").contains("unrecoverable")
 				.contains("(empty)");
+	}
+
+	@Test
+	void anUnreadableSourceIsReportedRatherThanThrown() throws IOException {
+		Source<InputStream> missing = new Source<>() {
+			@Override
+			public InputStream provideFrom(String path) throws IOException {
+				throw new FileNotFoundException(path + " (No such file)");
+			}
+		};
+
+		boolean hasErrors = new DiagnosticCompiler(missing,
+				analysis(ctx -> fail("the analysis must not run")),
+				new DiagnosticReport(), sink()).compile("gone.jd", "<stdout>");
+
+		assertThat(hasErrors).isTrue();
+		assertThat(poured).contains("[FATAL]").contains("cannot read source")
+				.contains("gone.jd");
 	}
 
 	@Test

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
@@ -360,6 +360,31 @@ public class CompilationSteps {
 				.doesNotContain("# @jpipe_link(\"" + qualifiedId + "\")");
 	}
 
+	@Then("the Python output has @jpipe_link for id {string} commented out")
+	public void thePythonOutputHasJpipeLinkCommentedOut(String qualifiedId) {
+		assertThat(pythonOutput)
+				.contains("# @jpipe_link(\"" + qualifiedId + "\")");
+	}
+
+	@Then("the Python output declares {string} before {string}")
+	public void thePythonOutputDeclaresBefore(String first, String second) {
+		assertThat(pythonOutput).containsSubsequence("def " + first + "(",
+				"def " + second + "(");
+	}
+
+	@Then("the Python output has a namespace section for {string}")
+	public void thePythonOutputHasANamespaceSectionFor(String namespace) {
+		String edge = "###" + " ".repeat(namespace.length()) + "###";
+		assertThat(pythonOutput)
+				.contains(edge + "\n## " + namespace + " ##\n" + edge + "\n");
+	}
+
+	@Then("the Python output has no @jpipe_link for id {string}")
+	public void thePythonOutputHasNoJpipeLinkFor(String qualifiedId) {
+		assertThat(pythonOutput)
+				.doesNotContain("@jpipe_link(\"" + qualifiedId + "\")");
+	}
+
 	@Then("the compilation has validation errors")
 	public void theCompilationHasValidationErrors() {
 		assertThat(ctx.hasErrors()).isTrue();

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/e2e/CompilationSteps.java
@@ -3,7 +3,9 @@ package ca.mcscert.jpipe.compiler.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
+import ca.mcscert.jpipe.compiler.CompilationConfig;
 import ca.mcscert.jpipe.compiler.CompilerFactory;
+import ca.mcscert.jpipe.compiler.DiagnosticFormat;
 import ca.mcscert.jpipe.compiler.model.CompilationContext;
 import ca.mcscert.jpipe.compiler.model.CompilationException;
 import ca.mcscert.jpipe.compiler.model.Diagnostic;
@@ -25,10 +27,14 @@ import io.cucumber.java.en.When;
 import ca.mcscert.jpipe.compiler.steps.transformations.CollectDiagnostics;
 import ca.mcscert.jpipe.compiler.steps.transformations.DiagnosticReport;
 import ca.mcscert.jpipe.compiler.steps.transformations.JsonDiagnosticReport;
+import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -45,6 +51,7 @@ public class CompilationSteps {
 	private String dotOutput;
 	private String pythonOutput;
 	private String jsonOutput;
+	private boolean reportedErrors;
 	private String textReport;
 	private JSONObject jsonReport;
 
@@ -209,6 +216,42 @@ public class CompilationSteps {
 				.andThen(new JsonDiagnosticReport()).fire(unit, ctx));
 	}
 
+	/**
+	 * Runs the {@code diagnostic} command's own compiler, which reports on a
+	 * compilation whether it completed or aborted — unlike the steps above,
+	 * which need a unit and so cannot describe a fatal (#154).
+	 */
+	@When("I run the diagnostic compiler with format {string}")
+	public void iRunTheDiagnosticCompilerWithFormat(String format)
+			throws IOException {
+		DiagnosticFormat target = DiagnosticFormat
+				.valueOf(format.toUpperCase(Locale.ROOT));
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		reportedErrors = CompilerFactory.buildDiagnosticCompiler(target, out)
+				.compile(sourcePath, CompilationConfig.STDOUT);
+		String rendered = out.toString(StandardCharsets.UTF_8);
+		if (target == DiagnosticFormat.JSON) {
+			jsonReport = new JSONObject(rendered);
+		} else {
+			textReport = rendered;
+		}
+	}
+
+	@Then("the report signals errors")
+	public void theReportSignalsErrors() {
+		assertThat(reportedErrors).isTrue();
+	}
+
+	@Then("the JSON report has a diagnostic with severity {string}")
+	public void theJsonReportHasADiagnosticWithSeverity(String severity) {
+		assertThat(severitiesIn(jsonReport)).contains(severity);
+	}
+
+	@Then("the JSON report describes no model")
+	public void theJsonReportDescribesNoModel() {
+		assertThat(jsonReport.getJSONArray("models")).isEmpty();
+	}
+
 	@Then("the text report contains {string}")
 	public void theTextReportContains(String fragment) {
 		assertThat(textReport).contains(fragment);
@@ -257,6 +300,15 @@ public class CompilationSteps {
 	public void bothReportsAgreeOnTheNumberOfDiagnostics() {
 		assertThat(jsonReport.getJSONArray("diagnostics").length())
 				.isEqualTo(ctx.diagnostics().size());
+	}
+
+	private static List<String> severitiesIn(JSONObject report) {
+		JSONArray diagnostics = report.getJSONArray("diagnostics");
+		List<String> severities = new ArrayList<>();
+		for (int i = 0; i < diagnostics.length(); i++) {
+			severities.add(diagnostics.getJSONObject(i).getString("severity"));
+		}
+		return severities;
 	}
 
 	private static List<String> codesIn(JSONObject report) {

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/checkers/ConsistencyCheckerTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/checkers/ConsistencyCheckerTest.java
@@ -48,6 +48,36 @@ class ConsistencyCheckerTest {
 		assertThat(ctx.hasFatalErrors()).isFalse();
 	}
 
+	@Test
+	void ambiguous_identifier_produces_error_diagnostic() {
+		Unit unit = new Unit("src");
+		Justification j = new Justification("j");
+		j.setConclusion(new Conclusion("c", "C"));
+		j.addElement(new Strategy("s", "S"));
+		j.addElement(new Evidence("e", "E"));
+		// "e" would designate the evidence and, through the alias, the strategy
+		j.recordAlias("e", "s");
+		unit.add(j);
+
+		new ConsistencyChecker().fire(unit, ctx);
+
+		assertThat(ctx.hasErrors()).isTrue();
+		assertThat(ctx.hasFatalErrors()).isFalse();
+	}
+
+	@Test
+	void merge_aliases_produce_no_diagnostics() {
+		Unit unit = validUnit();
+		unit.getModels().forEach(m -> {
+			m.recordAlias("a:s", "s");
+			m.recordAlias("b:s", "s");
+		});
+
+		new ConsistencyChecker().fire(unit, ctx);
+
+		assertThat(ctx.hasErrors()).isFalse();
+	}
+
 	// -------------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/CollectDiagnosticsTest.java
@@ -121,16 +121,6 @@ class CollectDiagnosticsTest {
 				.isInstanceOf(UnsupportedOperationException.class);
 	}
 
-	@Test
-	void collectingDoesNotMarkDiagnosticsRendered() {
-		collect();
-
-		// Only a renderer may claim the diagnostics were shown to the user;
-		// otherwise a failure between collect and render would silently
-		// swallow ChainCompiler's fallback dump.
-		assertThat(ctx.diagnosticsRendered()).isFalse();
-	}
-
 	// -------------------------------------------------------------------------
 	// Models
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReportTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/DiagnosticReportTest.java
@@ -122,11 +122,6 @@ class DiagnosticReportTest {
 			assertThat(report).contains("5:10").contains("bad token");
 		}
 
-		@Test
-		void markDiagnosticsRendered_is_called_after_run() {
-			report();
-			assertThat(ctx.diagnosticsRendered()).isTrue();
-		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportSchemaTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportSchemaTest.java
@@ -1,13 +1,12 @@
 package ca.mcscert.jpipe.compiler.steps.transformations;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ca.mcscert.jpipe.compiler.CompilationConfig;
 import ca.mcscert.jpipe.compiler.CompilerFactory;
+import ca.mcscert.jpipe.compiler.DiagnosticFormat;
 import ca.mcscert.jpipe.compiler.model.CompilationContext;
-import ca.mcscert.jpipe.compiler.model.CompilationException;
 import ca.mcscert.jpipe.compiler.model.DiagnosticCodes;
-import ca.mcscert.jpipe.compiler.model.Transformation;
 import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.Template;
@@ -22,14 +21,19 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
-import java.io.FileInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -107,19 +111,20 @@ class JsonDiagnosticReportSchemaTest {
 	}
 
 	/**
-	 * No fatal fixture exists above because one cannot: {@code fire()}
-	 * fast-fails on a fatal, so a report is never produced for a compilation
-	 * that has one. The schema still admits the value — see
-	 * {@link #schemaAdmitsFatalSeverityForFutureUse()}.
+	 * A compilation that aborted is reported on like any other, describing the
+	 * empty unit it never got to build (#154). Rendered directly rather than
+	 * through {@code fire()}, which still fast-fails on a fatal by design.
 	 */
 	@Test
-	void aFatalPreventsAnyReportFromBeingProduced() {
+	void aFatalStillProducesAConformingReport() {
 		CompilationContext ctx = new CompilationContext("test.jd");
 		ctx.fatal("unrecoverable");
-		Unit unit = new Unit("test.jd");
 
-		assertThatThrownBy(() -> reportOf(unit, ctx))
-				.isInstanceOf(CompilationException.class);
+		String report = renderedReportOf(new Unit("test.jd"), ctx);
+
+		assertConforms(report);
+		assertThat(new JSONObject(report).getJSONArray("diagnostics")
+				.getJSONObject(0).getString("severity")).isEqualTo("fatal");
 	}
 
 	@Test
@@ -143,25 +148,27 @@ class JsonDiagnosticReportSchemaTest {
 	}
 
 	/**
-	 * The whole example corpus, compiled for real. Sources that fail fatally
-	 * produce no report at all (documented behaviour), so they are skipped
-	 * rather than asserted on.
+	 * The whole example corpus, compiled through the production wiring — every
+	 * file, including the ones that abort on a fatal (#154).
 	 */
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("exampleSources")
 	void everyExampleConformsToTheSchema(Path source) throws IOException {
-		Transformation<InputStream, Unit> pipeline = CompilerFactory
-				.parsingChain().andThen(CompilerFactory.unitBuilder())
-				.asTransformation();
-		CompilationContext ctx = new CompilationContext(source.toString());
-		Unit unit;
-		try (FileInputStream stream = new FileInputStream(source.toFile())) {
-			unit = pipeline.fire(stream, ctx);
-		} catch (CompilationException _) {
-			return; // fatal: no report is produced, in either format
-		}
+		assertConforms(compileToJsonReport(source));
+	}
 
-		assertConforms(reportOf(unit, ctx));
+	/**
+	 * Sources that abort still describe the failure: conformance alone would
+	 * pass on an empty document, which is the bug this guards against.
+	 */
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("fatalExampleSources")
+	void everyFatalExampleReportsItsFatal(Path source) throws IOException {
+		JSONObject report = new JSONObject(compileToJsonReport(source));
+
+		assertThat(report.getString("status")).isEqualTo("errors");
+		assertThat(report.getJSONArray("models")).isEmpty();
+		assertThat(severitiesOf(report)).contains("fatal");
 	}
 
 	static Stream<Path> exampleSources() throws IOException {
@@ -170,6 +177,36 @@ class JsonDiagnosticReportSchemaTest {
 			return paths.filter(p -> p.toString().endsWith(".jd"))
 					.sorted(Comparator.naturalOrder()).toList().stream();
 		}
+	}
+
+	/** The examples that abort: a syntax error, and the unresolvable loads. */
+	static Stream<Path> fatalExampleSources() throws IOException {
+		return exampleSources().filter(JsonDiagnosticReportSchemaTest::isFatal);
+	}
+
+	private static boolean isFatal(Path source) {
+		try {
+			return new JSONObject(compileToJsonReport(source))
+					.getJSONArray("diagnostics").toList().stream()
+					.anyMatch(d -> "fatal"
+							.equals(((Map<?, ?>) d).get("severity")));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	/** Compiles a source through the production diagnostic wiring. */
+	private static String compileToJsonReport(Path source) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		CompilerFactory.buildDiagnosticCompiler(DiagnosticFormat.JSON, out)
+				.compile(source.toString(), CompilationConfig.STDOUT);
+		return out.toString(StandardCharsets.UTF_8);
+	}
+
+	/** The severity of every diagnostic in a report. */
+	private static List<String> severitiesOf(JSONObject report) {
+		return report.getJSONArray("diagnostics").toList().stream()
+				.map(d -> (String) ((Map<?, ?>) d).get("severity")).toList();
 	}
 
 	// -------------------------------------------------------------------------
@@ -202,16 +239,22 @@ class JsonDiagnosticReportSchemaTest {
 	}
 
 	/**
-	 * The value is reserved rather than reachable today: a fatal aborts before
-	 * any report is rendered. Pinned so the schema stays ready if that
-	 * limitation is lifted.
+	 * A fatal carries no code and usually no location, both of which the schema
+	 * allows. Rendered from a real fatal rather than synthesised, so the schema
+	 * is held to what the emitter actually produces.
 	 */
 	@Test
-	void schemaAdmitsFatalSeverityForFutureUse() throws IOException {
-		JsonNode report = MAPPER.readTree(reportWithCode("unknown-model"));
-		((ObjectNode) report.at("/diagnostics/0")).put("severity", "fatal");
+	void schemaAcceptsARealFatalDiagnostic() throws IOException {
+		CompilationContext ctx = new CompilationContext("t.jd");
+		ctx.fatal("unrecoverable");
+
+		JsonNode report = MAPPER
+				.readTree(renderedReportOf(new Unit("t.jd"), ctx));
 
 		assertThat(SCHEMA.validate(report)).isEmpty();
+		assertThat(report.at("/diagnostics/0/severity").asText())
+				.isEqualTo("fatal");
+		assertThat(report.at("/diagnostics/0").has("code")).isFalse();
 	}
 
 	@Test
@@ -261,6 +304,15 @@ class JsonDiagnosticReportSchemaTest {
 	private static String reportOf(Unit unit, CompilationContext ctx) {
 		return new CollectDiagnostics().andThen(new JsonDiagnosticReport())
 				.fire(unit, ctx);
+	}
+
+	/**
+	 * Renders without going through {@code fire()}, the way the diagnostic
+	 * compiler does when a compilation aborted.
+	 */
+	private static String renderedReportOf(Unit unit, CompilationContext ctx) {
+		return new JsonDiagnosticReport()
+				.render(new CollectDiagnostics().snapshot(unit, ctx));
 	}
 
 	private static String reportWithCode(String code) {

--- a/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportTest.java
+++ b/jpipe-compiler/src/test/java/ca/mcscert/jpipe/compiler/steps/transformations/JsonDiagnosticReportTest.java
@@ -82,11 +82,6 @@ class JsonDiagnosticReportTest {
 			assertThat(report().getString("status")).isEqualTo("errors");
 		}
 
-		@Test
-		void markDiagnosticsRenderedIsCalled() {
-			report();
-			assertThat(ctx.diagnosticsRendered()).isTrue();
-		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/jpipe-compiler/src/test/resources/features/diagnostic.feature
+++ b/jpipe-compiler/src/test/resources/features/diagnostic.feature
@@ -60,3 +60,29 @@ Feature: Reporting on a compilation unit
     When I produce a JSON diagnostic report
     Then the JSON report describes a "template" named "t"
       And the JSON report status is "ok"
+
+  # A file being edited is syntactically broken most of the time, which is
+  # exactly when a tool needs something machine-readable back (#154).
+  Scenario: A syntax error is reported in JSON rather than aborting silently
+    Given the source file "invalid/025_syntax_error.jd"
+    When I run the diagnostic compiler with format "json"
+    Then the report signals errors
+      And the JSON report status is "errors"
+      And the JSON report declares a schema version
+      And the JSON report has a diagnostic with severity "fatal"
+      And the JSON report describes no model
+
+  Scenario: An unresolvable load is reported in JSON
+    Given the source file "invalid/011_missing_load.jd"
+    When I run the diagnostic compiler with format "json"
+    Then the report signals errors
+      And the JSON report has a diagnostic with severity "fatal"
+      And the JSON report describes no model
+
+  Scenario: An aborted compilation still renders the text report
+    Given the source file "invalid/025_syntax_error.jd"
+    When I run the diagnostic compiler with format "text"
+    Then the report signals errors
+      And the text report contains "[FATAL]"
+      And the text report contains "=== Symbol Table ==="
+      And the text report contains "(empty)"

--- a/jpipe-compiler/src/test/resources/features/exports.feature
+++ b/jpipe-compiler/src/test/resources/features/exports.feature
@@ -14,10 +14,18 @@ Feature: Exporting compiled models to various formats
     When I compile it into a unit
     Then the unit contains a justification named "minimal"
     When I export the current model to Python format
-    Then the Python output contains a method named "a_conclusion"
-      And the Python output contains a method named "a_strategy"
+    Then the Python output contains a method named "a_strategy"
       And the Python output contains a method named "an_evidence"
-      And the Python output has @jpipe_link for id "minimal:c" active
+      And the Python output has @jpipe_link for id "minimal:s" active
+      And the Python output has @jpipe_link for id "minimal:e" active
+      And the Python output has no @jpipe_link for id "c"
+
+  Scenario: Python export leaves out the conclusion the runner never executes
+    Given the source file "000_minimal.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "minimal"
+    When I export the current model to Python format
+    Then the Python output has no @jpipe_link for id "minimal:c"
       And the Python output has @jpipe_link for id "minimal:s" active
       And the Python output has @jpipe_link for id "minimal:e" active
 
@@ -31,11 +39,43 @@ Feature: Exporting compiled models to various formats
       And the JSON output contains "assembled_2:a_claim:s1"
       And the JSON output contains "assembled_2:another_claim:s2"
 
-  Scenario: Python export links the merged element by every original id
+  Scenario: Python export names the merged element by its original ids only
     Given the source file "011_unifying_while_compising.jd"
     When I compile it into a unit
     Then the unit contains a justification named "assembled_2"
     When I export the current model to Python format
-    Then the Python output has @jpipe_link for id "assembled_2:unified_0" active
-      And the Python output has @jpipe_link for id "assembled_2:a_claim:s1" active
-      And the Python output has @jpipe_link for id "assembled_2:another_claim:s2" active
+    Then the Python output has @jpipe_link for id "a_claim:s1" active
+      And the Python output has @jpipe_link for id "another_claim:s2" active
+      And the Python output has no @jpipe_link for id "s1"
+      And the Python output has no @jpipe_link for id "assembled_2:unified_0"
+      And the Python output has no @jpipe_link for id "unified_0"
+
+  Scenario: Python export groups elements under a banner per namespace
+    Given the source file "011_unifying_while_compising.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "assembled_2"
+    When I export the current model to Python format
+    Then the Python output has a namespace section for "a_claim"
+      And the Python output has a namespace section for "another_claim"
+      And the Python output has a namespace section for "assembled_2"
+
+  Scenario: Python export orders a namespace bottom-up, evidence first
+    Given the source file "011_unifying_while_compising.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "assembled_2"
+    When I export the current model to Python format
+    Then the Python output declares "an_evidence" before "a_strategy"
+      And the Python output declares "a_strategy" before "a_conclusion"
+      And the Python output declares "a_shared_evidence" before "an_aggregating_strategy"
+
+  Scenario: Python export resolves a composition of a composition to the authored ids
+    Given the source file "012_chaining_operators.jd"
+    When I compile it into a unit
+    Then the unit contains a justification named "with_refine_1"
+    When I export the current model to Python format
+    # The refine hook merges the base's evidence with the refinement's
+    # conclusion into a sub-conclusion, so it is emitted commented out.
+    Then the Python output has @jpipe_link for id "first:e" commented out
+      And the Python output has @jpipe_link for id "second:e" commented out
+      And the Python output has @jpipe_link for id "refine_1:c" commented out
+      And the Python output has no @jpipe_link for id "unified_0"

--- a/jpipe-compiler/src/test/resources/features/operators.feature
+++ b/jpipe-compiler/src/test/resources/features/operators.feature
@@ -87,6 +87,49 @@ Feature: Composition operators
     And the sub-conclusion "hook" supports the strategy "both:second:s"
     And the strategy "refine_1:s" supports the sub-conclusion "hook"
 
+  Scenario: assemble is commutative when a merged group mixes element kinds
+    Given the source file "024_assemble_commutativity.jd"
+    When I compile it into a unit
+    Then the compilation succeeds
+    # "X" is argued in deep (a sub-conclusion) and asserted in other (an
+    # evidence). Whichever source comes first, the merged element must be the
+    # sub-conclusion: it carries the strategy that argues it, and supports the
+    # strategies that lean on it.
+    And the unit contains a justification named "left"
+    And it has a conclusion with id "assembleConclusion" and label "All"
+    And it has a strategy with id "assembleStrategy" and label "Both"
+    And it has a sub-conclusion with id "unified_0" and label "X"
+    And it has a sub-conclusion with id "deep:base:c" and label "Base holds"
+    And it has a sub-conclusion with id "other:c" and label "Other holds"
+    And it has evidence with id "deep:detail:y" and label "Y"
+    And the strategy "deep:detail:s" supports the sub-conclusion "unified_0"
+    And the sub-conclusion "unified_0" supports the strategy "deep:base:s"
+    And the sub-conclusion "unified_0" supports the strategy "other:s"
+    And the sub-conclusion "deep:base:c" supports the strategy "assembleStrategy"
+    And the sub-conclusion "other:c" supports the strategy "assembleStrategy"
+    And the strategy "assembleStrategy" supports the conclusion "assembleConclusion"
+    # Same assertions, sources listed the other way round.
+    And the unit contains a justification named "right"
+    And it has a conclusion with id "assembleConclusion" and label "All"
+    And it has a strategy with id "assembleStrategy" and label "Both"
+    And it has a sub-conclusion with id "unified_0" and label "X"
+    And it has a sub-conclusion with id "deep:base:c" and label "Base holds"
+    And it has a sub-conclusion with id "other:c" and label "Other holds"
+    And it has evidence with id "deep:detail:y" and label "Y"
+    And the strategy "deep:detail:s" supports the sub-conclusion "unified_0"
+    And the sub-conclusion "unified_0" supports the strategy "deep:base:s"
+    And the sub-conclusion "unified_0" supports the strategy "other:s"
+    And the sub-conclusion "deep:base:c" supports the strategy "assembleStrategy"
+    And the sub-conclusion "other:c" supports the strategy "assembleStrategy"
+    And the strategy "assembleStrategy" supports the conclusion "assembleConclusion"
+
+  Scenario: unifying incompatible element kinds reports a dedicated error
+    Given the source file "invalid/024_unifying_incompatible_kinds.jd"
+    When I compile it into a unit
+    Then the compilation has validation errors
+    And a validation error is reported for rule "incompatible-unification"
+    And a validation error mentions "cannot unify"
+
   Scenario: unknown unification method reports an execution error
     Given the source file "invalid/015_unknown_unification_method.jd"
     When I compile it into a unit

--- a/jpipe-lang/pom.xml
+++ b/jpipe-lang/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-lang</artifactId>

--- a/jpipe-lang/pom.xml
+++ b/jpipe-lang/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-lang</artifactId>

--- a/jpipe-model/pom.xml
+++ b/jpipe-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-model</artifactId>

--- a/jpipe-model/pom.xml
+++ b/jpipe-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-model</artifactId>

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateAbstractSupport.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateAbstractSupport.java
@@ -25,8 +25,13 @@ public final class CreateAbstractSupport
 	}
 
 	@Override
+	public AbstractSupport element() {
+		return new AbstractSupport(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.addInto(container, new AbstractSupport(identifier, label));
+		context.addInto(container, element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateConclusion.java
@@ -22,8 +22,13 @@ public final class CreateConclusion extends AbstractElementCreationCommand {
 	}
 
 	@Override
+	public Conclusion element() {
+		return new Conclusion(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.get(container).setConclusion(new Conclusion(identifier, label));
+		context.get(container).setConclusion(element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateEvidence.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateEvidence.java
@@ -22,8 +22,13 @@ public final class CreateEvidence extends AbstractElementCreationCommand {
 	}
 
 	@Override
+	public Evidence element() {
+		return new Evidence(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.addInto(container, new Evidence(identifier, label));
+		context.addInto(container, element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateStrategy.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateStrategy.java
@@ -22,8 +22,13 @@ public final class CreateStrategy extends AbstractElementCreationCommand {
 	}
 
 	@Override
+	public Strategy element() {
+		return new Strategy(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.addInto(container, new Strategy(identifier, label));
+		context.addInto(container, element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateSubConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/CreateSubConclusion.java
@@ -23,8 +23,13 @@ public final class CreateSubConclusion extends AbstractElementCreationCommand {
 	}
 
 	@Override
+	public SubConclusion element() {
+		return new SubConclusion(identifier, label);
+	}
+
+	@Override
 	public void doExecute(Unit context) {
-		context.addInto(container, new SubConclusion(identifier, label));
+		context.addInto(container, element());
 		context.recordLocation(container, identifier, location);
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/ElementCreationCommand.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/creation/ElementCreationCommand.java
@@ -3,6 +3,7 @@ package ca.mcscert.jpipe.commands.creation;
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.model.SourceLocation;
 import ca.mcscert.jpipe.model.elements.ElementView;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
 
 /**
  * Sealed interface common to all element-creation commands.
@@ -52,4 +53,19 @@ public sealed interface ElementCreationCommand extends Command, ElementView
 	 * identifier. The container, label, and location are preserved.
 	 */
 	ElementCreationCommand withId(String newId);
+
+	/**
+	 * The element this command creates, built from the command's own id and
+	 * label but not attached to any model.
+	 *
+	 * <p>
+	 * Lets callers reason about the kind of element a command produces using
+	 * the element hierarchy itself (e.g.
+	 * {@link ca.mcscert.jpipe.model.elements.SupportLeaf} and
+	 * {@link ca.mcscert.jpipe.model.elements.StrategyBacked}) instead of
+	 * matching on command types.
+	 *
+	 * @return a fresh element, as {@link #doExecute} would create it.
+	 */
+	JustificationElement element();
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/MarkUnified.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/commands/linking/MarkUnified.java
@@ -1,0 +1,39 @@
+package ca.mcscert.jpipe.commands.linking;
+
+import ca.mcscert.jpipe.commands.RegularCommand;
+import ca.mcscert.jpipe.model.Unit;
+
+/**
+ * Records that {@code id} inside a result model was minted by unification to
+ * stand for a group of merged elements. Persisted to {@link Unit} so that
+ * exporters can tell an id the compiler invented from one an author wrote; see
+ * {@link ca.mcscert.jpipe.model.JustificationModel#recordUnifiedId(String)}.
+ */
+public final class MarkUnified extends RegularCommand {
+
+	private final String container;
+	private final String id;
+
+	public MarkUnified(String container, String id) {
+		this.container = container;
+		this.id = id;
+	}
+
+	public String container() {
+		return container;
+	}
+
+	public String id() {
+		return id;
+	}
+
+	@Override
+	public void doExecute(Unit context) {
+		context.recordUnifiedId(container, id);
+	}
+
+	@Override
+	public String toString() {
+		return "markUnified('" + container + "', '" + id + "').";
+	}
+}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/JustificationModel.java
@@ -13,9 +13,11 @@ import ca.mcscert.jpipe.visitor.JustificationVisitor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Abstract base for all named justification models. Sealed to exactly two
@@ -49,6 +51,7 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 	private Template parent = null;
 	private final List<E> elements = new ArrayList<>();
 	private final Map<String, String> aliases = new LinkedHashMap<>();
+	private final Set<String> unifiedIds = new LinkedHashSet<>();
 
 	protected JustificationModel(String name) {
 		this.name = name;
@@ -94,6 +97,29 @@ public abstract sealed class JustificationModel<E extends JustificationElement>
 	 */
 	public void recordAlias(String oldId, String newId) {
 		aliases.put(oldId, newId);
+	}
+
+	/**
+	 * Records that {@code id} was minted by unification to stand for a group of
+	 * merged elements, rather than written in a source file.
+	 *
+	 * <p>
+	 * Unification names a merged group after a counter ({@code unified_0}), so
+	 * the id carries no meaning outside the compiler and cannot be traced back
+	 * to anything the author wrote. Exporters that address an audience, such as
+	 * the Python module a developer implements against, use this to name the
+	 * element by the ids it was merged from instead. Contrast the elements a
+	 * composition operator synthesises ({@code assembleConclusion}), which are
+	 * genuine elements of the composed model carrying labels the author
+	 * supplied in the operator call, and are <em>not</em> recorded here.
+	 */
+	public void recordUnifiedId(String id) {
+		unifiedIds.add(id);
+	}
+
+	/** Unmodifiable view of the ids unification minted within this model. */
+	public Set<String> unifiedIds() {
+		return Collections.unmodifiableSet(unifiedIds);
 	}
 
 	/**

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/Unit.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/Unit.java
@@ -135,6 +135,14 @@ public final class Unit {
 	}
 
 	/**
+	 * Records that {@code id} in model {@code modelName} was minted by
+	 * unification. See {@link JustificationModel#recordUnifiedId(String)}.
+	 */
+	public void recordUnifiedId(String modelName, String id) {
+		findModel(modelName).ifPresent(m -> m.recordUnifiedId(id));
+	}
+
+	/**
 	 * Returns the id that {@code id} resolves to in {@code modelName}, or
 	 * {@code id} itself if no alias was registered.
 	 */

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/AbstractSupport.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/AbstractSupport.java
@@ -6,4 +6,9 @@ package ca.mcscert.jpipe.model.elements;
  */
 public record AbstractSupport(String id,
 		String label) implements JustificationElement, SupportLeaf {
+
+	@Override
+	public String kind() {
+		return "abstract-support";
+	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Conclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Conclusion.java
@@ -9,4 +9,9 @@ public final class Conclusion extends AbstractSupportedElement
 	public Conclusion(String id, String label) {
 		super(id, label);
 	}
+
+	@Override
+	public String kind() {
+		return "conclusion";
+	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Evidence.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Evidence.java
@@ -3,4 +3,9 @@ package ca.mcscert.jpipe.model.elements;
 /** A leaf evidence element supporting a strategy. */
 public record Evidence(String id,
 		String label) implements CommonElement, SupportLeaf {
+
+	@Override
+	public String kind() {
+		return "evidence";
+	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/JustificationElement.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/JustificationElement.java
@@ -10,6 +10,15 @@ import ca.mcscert.jpipe.visitor.JustificationVisitor;
 public sealed interface JustificationElement extends ElementView
 		permits CommonElement, AbstractSupport {
 
+	/**
+	 * The kebab-case name of this element's kind, as used in user-facing
+	 * output: {@code conclusion}, {@code sub-conclusion}, {@code strategy},
+	 * {@code evidence}, {@code abstract-support}.
+	 *
+	 * @return the kind name of this element.
+	 */
+	String kind();
+
 	default <R> R accept(JustificationVisitor<R> visitor) {
 		return switch (this) {
 			case Conclusion c -> visitor.visit(c);

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/Strategy.java
@@ -26,6 +26,11 @@ public final class Strategy implements CommonElement {
 		return label;
 	}
 
+	@Override
+	public String kind() {
+		return "strategy";
+	}
+
 	/**
 	 * Adds {@code supporter} to this strategy. A strategy can never
 	 * legitimately be supported twice by the same element id, so the call is

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/SubConclusion.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/elements/SubConclusion.java
@@ -10,4 +10,9 @@ public final class SubConclusion extends AbstractSupportedElement
 	public SubConclusion(String id, String label) {
 		super(id, label);
 	}
+
+	@Override
+	public String kind() {
+		return "sub-conclusion";
+	}
 }

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/model/validation/ConsistencyValidator.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/model/validation/ConsistencyValidator.java
@@ -20,6 +20,10 @@ import java.util.function.Function;
  * Rules:
  * <ul>
  * <li>{@code no-duplicate-ids} — all element IDs within a model are unique.
+ * <li>{@code unique-identifiers}: no identifier an exported model can be
+ * addressed by designates two different elements. This covers the merge aliases
+ * as well as the ids: an alias that collides with another element's id would
+ * make a reference ambiguous.
  * <li>{@code acyclic-support} — the support graph contains no cycles (it must
  * be a DAG).
  * <li>{@code acyclic-implements} — the implements chain between models contains
@@ -49,6 +53,7 @@ public final class ConsistencyValidator {
 		List<Violation> violations = new ArrayList<>();
 		for (JustificationModel<?> model : unit.getModels()) {
 			violations.addAll(checkNoDuplicateIds(model, ctx));
+			violations.addAll(checkUniqueIdentifiers(model, ctx));
 			violations.addAll(checkAcyclicSupport(model, ctx));
 		}
 		violations.addAll(checkAcyclicImplements(unit, ctx));
@@ -63,6 +68,7 @@ public final class ConsistencyValidator {
 		ValidationContext ctx = ValidationContext.STANDALONE;
 		List<Violation> violations = new ArrayList<>();
 		violations.addAll(checkNoDuplicateIds(model, ctx));
+		violations.addAll(checkUniqueIdentifiers(model, ctx));
 		violations.addAll(checkAcyclicSupport(model, ctx));
 		violations.addAll(checkAcyclicImplements(model));
 		return violations;
@@ -91,6 +97,72 @@ public final class ConsistencyValidator {
 			}
 		});
 		return violations;
+	}
+
+	/**
+	 * Checks that no identifier designates two different elements.
+	 *
+	 * <p>
+	 * An exported model can be addressed by more than an element's own id:
+	 * every id merged into an element addresses it too, so that a reference
+	 * written before a composition keeps working afterwards. Consumers
+	 * therefore index ids and merge aliases into one namespace, and a key
+	 * landing on two elements leaves them no way to choose. jpipe-runner
+	 * rejects the whole model rather than guess. Element ids alone are covered
+	 * by {@code no-duplicate-ids}; what this adds is the aliases.
+	 */
+	private List<Violation> checkUniqueIdentifiers(JustificationModel<?> model,
+			ValidationContext ctx) {
+		Set<String> elementIds = elementIdsOf(model);
+		Map<String, String> designated = new HashMap<>();
+		elementIds.forEach(id -> designated.put(id, id));
+
+		List<Violation> violations = new ArrayList<>();
+		model.aliases().forEach((alias, target) -> {
+			String canonical = elementDesignatedBy(model, elementIds, target);
+			if (canonical == null) {
+				// The chain leads to no element of this model, so the alias is
+				// never exported and can collide with nothing.
+				return;
+			}
+			String existing = designated.putIfAbsent(alias, canonical);
+			if (existing != null && !existing.equals(canonical)) {
+				violations.add(new Violation("unique-identifiers",
+						"Identifier '" + alias + IN_MODEL + model.getName()
+								+ "' designates both element '" + existing
+								+ "' and element '" + canonical + "'",
+						ctx.locationOf(model.getName(), alias)));
+			}
+		});
+		return violations;
+	}
+
+	/** Element ids of {@code model}, conclusion included. */
+	private static Set<String> elementIdsOf(JustificationModel<?> model) {
+		Set<String> ids = new HashSet<>();
+		model.conclusion().ifPresent(c -> ids.add(c.id()));
+		model.getElements().forEach(element -> ids.add(element.id()));
+		return ids;
+	}
+
+	/**
+	 * Follows {@code id} through the alias map until it reaches an element of
+	 * {@code model}, or {@code null} if it reaches none or loops.
+	 */
+	private static String elementDesignatedBy(JustificationModel<?> model,
+			Set<String> elementIds, String id) {
+		Set<String> visited = new HashSet<>();
+		String current = id;
+		while (visited.add(current)) {
+			if (elementIds.contains(current)) {
+				return current;
+			}
+			current = model.aliases().get(current);
+			if (current == null) {
+				return null;
+			}
+		}
+		return null;
 	}
 
 	private List<Violation> checkAcyclicSupport(JustificationModel<?> model,

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/AbstractModelExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/AbstractModelExporter.java
@@ -4,10 +4,16 @@ import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.JustificationModel;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Abstract base for exporters that serialise a single
@@ -37,6 +43,13 @@ public abstract class AbstractModelExporter
 		implements
 			JustificationVisitor<Void> {
 
+	/**
+	 * Fewest colon-separated segments a shortened identifier may keep, so that
+	 * it always reads as {@code container:id}. See
+	 * {@link #minimalLink(String)}.
+	 */
+	private static final int MIN_SEGMENTS = 2;
+
 	/** Accumulates the serialised output. Reset at the start of each export. */
 	protected final StringBuilder builder = new StringBuilder();
 
@@ -55,6 +68,23 @@ public abstract class AbstractModelExporter
 	private final Map<String, List<String>> aliasesByTarget = new HashMap<>();
 
 	/**
+	 * The identifiers a consumer of the exported model may use to designate an
+	 * element: every element's qualified id, plus every qualified id it was
+	 * merged from. Maps each such key to the plain id of the element it
+	 * designates. Populated by {@link #initAliases(JustificationModel)} and
+	 * used by {@link #minimalLink(String)} to decide how far a link can be
+	 * shortened.
+	 */
+	private final Map<String, String> linkIndex = new LinkedHashMap<>();
+
+	/**
+	 * Ids unification minted within the model being exported. Populated by
+	 * {@link #initAliases(JustificationModel)}; see
+	 * {@link JustificationModel#recordUnifiedId(String)}.
+	 */
+	private Set<String> unifiedIds = Set.of();
+
+	/**
 	 * Qualifies {@code elementId} with the current model name:
 	 * {@code "currentModelName:elementId"}.
 	 */
@@ -63,8 +93,8 @@ public abstract class AbstractModelExporter
 	}
 
 	/**
-	 * Builds the inverted alias lookup for {@code model}. Subclasses that
-	 * surface aliases must call this at the start of
+	 * Builds the inverted alias lookup and the link index for {@code model}.
+	 * Subclasses that surface aliases must call this at the start of
 	 * {@link #exportModel(JustificationModel)}, after setting
 	 * {@link #currentModelName}.
 	 */
@@ -72,6 +102,17 @@ public abstract class AbstractModelExporter
 		aliasesByTarget.clear();
 		model.aliases().forEach((oldId, newId) -> aliasesByTarget
 				.computeIfAbsent(newId, _ -> new ArrayList<>()).add(oldId));
+		unifiedIds = model.unifiedIds();
+		linkIndex.clear();
+		model.conclusion().ifPresent(this::indexElement);
+		model.getElements().forEach(this::indexElement);
+	}
+
+	private void indexElement(JustificationElement element) {
+		linkIndex.put(qualify(element.id()), element.id());
+		for (String original : qualifiedOriginalsOf(element.id())) {
+			linkIndex.put(original, element.id());
+		}
 	}
 
 	/**
@@ -86,6 +127,143 @@ public abstract class AbstractModelExporter
 			return List.of();
 		}
 		return originals.stream().map(this::qualify).toList();
+	}
+
+	/**
+	 * Returns every qualified id {@code plainElementId} was merged from,
+	 * following alias chains transitively.
+	 *
+	 * <p>
+	 * A composition applied to the result of another composition records a
+	 * chain ({@code a -> merged -> unified_0}) rather than a flat mapping, so a
+	 * one-hop lookup ({@link #qualifiedAliasesOf(String)}) stops at the
+	 * intermediate and loses the id the user actually wrote. The returned list
+	 * holds both the intermediates and the leaves, nearest first.
+	 */
+	protected final List<String> qualifiedOriginalsOf(String plainElementId) {
+		return collectOriginals(plainElementId, false);
+	}
+
+	/**
+	 * Returns the qualified ids {@code plainElementId} was merged from that an
+	 * author actually wrote: the ids as they stood in the source models. Empty
+	 * when the element is not a merge product.
+	 *
+	 * <p>
+	 * Two kinds of id are passed over. One that was merged from further ids is
+	 * skipped in favour of those, which stand closer to the source. One that
+	 * unification minted ({@code unified_0}) is skipped outright: it names a
+	 * merged group by a counter and appears in no source file. The latter is
+	 * not always the former, since composing the result of a composition can
+	 * leave a minted id recorded as a sibling of the ids it stood for rather
+	 * than as their parent, so being childless does not make an id authored.
+	 */
+	protected final List<String> qualifiedAuthoredOriginalsOf(
+			String plainElementId) {
+		return collectOriginals(plainElementId, true);
+	}
+
+	private List<String> collectOriginals(String plainElementId,
+			boolean authoredOnly) {
+		if (!aliasesByTarget.containsKey(plainElementId)) {
+			return List.of();
+		}
+		Set<String> found = new LinkedHashSet<>();
+		Set<String> visited = new HashSet<>();
+		visited.add(plainElementId);
+		collectFrom(plainElementId, authoredOnly, visited, found);
+		return found.stream().map(this::qualify).toList();
+	}
+
+	private void collectFrom(String id, boolean authoredOnly,
+			Set<String> visited, Set<String> found) {
+		for (String original : aliasesByTarget.getOrDefault(id, List.of())) {
+			if (!visited.add(original)) {
+				continue;
+			}
+			if (!authoredOnly || isAuthored(original)) {
+				found.add(original);
+			}
+			collectFrom(original, authoredOnly, visited, found);
+		}
+	}
+
+	private boolean isAuthored(String plainId) {
+		return !aliasesByTarget.containsKey(plainId)
+				&& !unifiedIds.contains(plainId);
+	}
+
+	/**
+	 * Shortens {@code qualifiedKey} to the shortest trailing run of
+	 * colon-separated segments that still designates the same element, never
+	 * going below {@code container:id}.
+	 *
+	 * <p>
+	 * Consumers resolve a link by exact match against the link index first,
+	 * then by strict segment-suffix match; a suffix designating two different
+	 * elements is ambiguous and is not a valid link. Candidates are therefore
+	 * checked against the very index a consumer builds from the exported model,
+	 * shortest first, and {@code qualifiedKey} itself is returned when no
+	 * shorter form is unambiguous, because a full id always resolves exactly.
+	 *
+	 * <p>
+	 * The {@value #MIN_SEGMENTS}-segment floor is a readability requirement
+	 * rather than a resolution one: a bare {@code id} would often resolve, but
+	 * a reader of the exported artefact has no way to tell what it belongs to.
+	 * Keeping the owning model or source justification in front of it, as
+	 * {@code a_claim:s1} rather than {@code s1}, makes the reference legible on
+	 * its own. Every key starts qualified with the model name, so the floor is
+	 * always reachable.
+	 */
+	protected final String minimalLink(String qualifiedKey) {
+		String canonical = linkIndex.get(qualifiedKey);
+		if (canonical == null) {
+			return qualifiedKey;
+		}
+		String[] segments = qualifiedKey.split(":");
+		for (int length = MIN_SEGMENTS; length < segments.length; length++) {
+			String candidate = String.join(":", Arrays.copyOfRange(segments,
+					segments.length - length, segments.length));
+			if (canonical.equals(designatedBy(candidate))) {
+				return candidate;
+			}
+		}
+		return qualifiedKey;
+	}
+
+	/**
+	 * Returns the plain id of the single element {@code candidate} designates,
+	 * or {@code null} when it designates none or more than one.
+	 */
+	private String designatedBy(String candidate) {
+		String exact = linkIndex.get(candidate);
+		if (exact != null) {
+			return exact;
+		}
+		String[] wanted = candidate.split(":");
+		String found = null;
+		for (Map.Entry<String, String> entry : linkIndex.entrySet()) {
+			String[] segments = entry.getKey().split(":");
+			if (!isStrictSuffix(wanted, segments)) {
+				continue;
+			}
+			if (found != null && !found.equals(entry.getValue())) {
+				return null;
+			}
+			found = entry.getValue();
+		}
+		return found;
+	}
+
+	/**
+	 * Tells whether {@code wanted} is a strictly shorter tail of {@code of}.
+	 */
+	private static boolean isStrictSuffix(String[] wanted, String[] of) {
+		if (wanted.length >= of.length) {
+			return false;
+		}
+		return Arrays.equals(of, of.length - wanted.length, of.length, wanted,
+				0, wanted.length);
 	}
 
 	/**

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/JsonExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/JsonExporter.java
@@ -37,7 +37,10 @@ import org.json.JSONObject;
  * <p>
  * The optional per-element {@code "aliases"} array lists the qualified original
  * ids that were merged into the element during composition/unification; it is
- * omitted for elements that are not the target of any alias.
+ * omitted for elements that are not the target of any alias. Merges compose, so
+ * the array is transitive: composing the result of a composition records a
+ * chain, and the array lists every id along it, down to those written in the
+ * original source models.
  */
 public class JsonExporter extends AbstractModelExporter {
 
@@ -139,7 +142,7 @@ public class JsonExporter extends AbstractModelExporter {
 		obj.put("id", qualify(element.id()));
 		obj.put("label", element.label());
 		obj.put("escaped", LabelEscaper.toMethodName(element.label()));
-		List<String> aliases = qualifiedAliasesOf(element.id());
+		List<String> aliases = qualifiedOriginalsOf(element.id());
 		if (!aliases.isEmpty()) {
 			obj.put("aliases", new JSONArray(aliases));
 		}

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
@@ -9,19 +9,29 @@ import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
 import ca.mcscert.jpipe.util.LabelEscaper;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Serialises a single {@link JustificationModel} to a Python module: each
  * element becomes a decorated function named after the element's label
- * (snake_case via {@link LabelEscaper}). Two decorators are emitted per
- * function:
+ * (snake_case via {@link LabelEscaper}), carrying:
  *
  * <ul>
- * <li>{@code @jpipe_link("<modelName:elementId>")} — links the function back to
- * the originating jPipe element. When the element resulted from a
- * composition/unification merge, one additional {@code @jpipe_link} is emitted
- * per original (pre-merge) id, so the function can be resolved by any of
- * them.</li>
+ * <li>one or more {@code @jpipe_link("<id>")}, linking the function back to the
+ * originating jPipe element. An element that resulted from a merge is linked by
+ * the ids it was merged from rather than by its own, transitively, so a
+ * composition of a composition still names the ids as the original source
+ * models had them; ids unification minted along the way ({@code unified_0}) are
+ * left out, having been written in no source file. Every id is then shortened
+ * to the least qualified form that still designates the element unambiguously,
+ * but never past {@code container:id}, because a bare id would leave a reader
+ * of the generated module unable to tell what it refers to; see
+ * {@link AbstractModelExporter#minimalLink(String)}.</li>
  * <li>{@code @jpipe(produce=[], consume=[])} — placeholder decorators to be
  * filled in by the developer.</li>
  * </ul>
@@ -36,6 +46,17 @@ import java.time.Instant;
  * invoking this exporter.
  */
 public class PythonExporter extends AbstractModelExporter {
+
+	/** Prefix that comments out a line of generated Python. */
+	private static final String COMMENT = "# ";
+
+	/**
+	 * Link id &rarr; the function it has already been emitted on, for the
+	 * module being written. Consumers key their registry by the link id, so the
+	 * same id on two functions has no resolution; see
+	 * {@link #claim(String, String)}.
+	 */
+	private final Map<String, String> boundTo = new LinkedHashMap<>();
 
 	/**
 	 * Serialise {@code model} to Python source text without a file header.
@@ -73,9 +94,14 @@ public class PythonExporter extends AbstractModelExporter {
 	// Element visit methods
 	// -------------------------------------------------------------------------
 
+	/**
+	 * Emits nothing. The runner never executes a conclusion: it concludes one
+	 * from whatever supports it, so a function here could never run and there
+	 * is nothing for a developer to implement. The conclusion remains in the
+	 * JSON and DOT exports, which describe the model rather than its execution.
+	 */
 	@Override
 	public Void visit(Conclusion conclusion) {
-		appendMethod(conclusion);
 		return null;
 	}
 
@@ -111,13 +137,84 @@ public class PythonExporter extends AbstractModelExporter {
 	protected void exportModel(JustificationModel<?> model) {
 		currentModelName = model.getName();
 		initAliases(model);
-		model.conclusion().ifPresent(c -> c.accept(this));
-		model.getElements().forEach(e -> e.accept(this));
+		boundTo.clear();
+
+		// The conclusion is deliberately absent: it is never executed, so it
+		// would open a section holding nothing a developer can implement.
+		Map<String, List<JustificationElement>> byNamespace = new TreeMap<>();
+		model.getElements()
+				.forEach(e -> group(byNamespace, e, currentModelName));
+
+		byNamespace.forEach((namespace, elements) -> {
+			appendNamespaceBanner(namespace);
+			elements.stream()
+					.sorted(Comparator
+							.comparingInt(PythonExporter::supportRank))
+					.forEach(e -> e.accept(this));
+		});
 	}
 
 	// -------------------------------------------------------------------------
 	// Private helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Orders elements within a namespace bottom-up, so a section reads from the
+	 * evidence a developer has to implement toward the claim it ends up
+	 * supporting, rather than asking them to start at the conclusion and work
+	 * backwards. Ties keep the order the model holds them in.
+	 *
+	 * <p>
+	 * An {@link AbstractSupport} ranks with the evidence: it is a
+	 * {@link ca.mcscert.jpipe.model.elements.SupportLeaf} standing where one
+	 * will go, and it is the other thing in a module still awaiting an
+	 * implementation.
+	 */
+	private static int supportRank(JustificationElement element) {
+		return switch (element) {
+			case Evidence _ -> 0;
+			case AbstractSupport _ -> 1;
+			case Strategy _ -> 2;
+			case SubConclusion _ -> 3;
+			case Conclusion _ -> 4;
+		};
+	}
+
+	private static void group(
+			Map<String, List<JustificationElement>> byNamespace,
+			JustificationElement element, String modelName) {
+		byNamespace.computeIfAbsent(namespaceOf(element.id(), modelName),
+				_ -> new ArrayList<>()).add(element);
+	}
+
+	/**
+	 * The namespace an element belongs to: the part of its id in front of the
+	 * last segment, or the model itself when the id carries no prefix.
+	 *
+	 * <p>
+	 * An element copied in from a source model or expanded from a template
+	 * keeps that origin as its prefix ({@code a_claim:c}, {@code root:abs1}),
+	 * so this groups the module the way the author thinks of it. An element the
+	 * composition created or merged has no prefix, and belongs to the composed
+	 * model itself, being owned by no single source.
+	 */
+	private static String namespaceOf(String plainElementId, String modelName) {
+		int lastSeparator = plainElementId.lastIndexOf(':');
+		return lastSeparator < 0
+				? modelName
+				: plainElementId.substring(0, lastSeparator);
+	}
+
+	/**
+	 * Opens a namespace section with a banner comment, so the reader can find
+	 * where one origin's steps end and the next begins.
+	 */
+	private void appendNamespaceBanner(String namespace) {
+		String edge = "###" + " ".repeat(namespace.length()) + "###";
+		builder.append(edge).append("\n");
+		builder.append("## ").append(namespace).append(" ##\n");
+		builder.append(edge).append("\n\n");
+	}
 
 	private void appendHeader(String sourcePath) {
 		builder.append("# Generated by jPipe\n");
@@ -138,28 +235,109 @@ public class PythonExporter extends AbstractModelExporter {
 	}
 
 	private void appendMethod(JustificationElement element) {
-		String qid = qualify(element.id());
+		List<String> links = linksFor(element);
 		String name = LabelEscaper.toMethodName(element.label());
 		String params = element instanceof Conclusion
 				? ""
 				: "produce: JpipeProduce";
-		String decoratorArgs = jpipeDecoratorArgs(element);
 
-		builder.append("@jpipe_link(\"").append(qid).append("\")\n");
-		for (String alias : qualifiedAliasesOf(element.id())) {
-			builder.append("@jpipe_link(\"").append(alias).append("\")\n");
+		StringBuilder block = new StringBuilder();
+		for (String link : links) {
+			claim(link, name);
+			block.append("@jpipe_link(\"").append(link).append("\")\n");
 		}
-		builder.append("@jpipe(").append(decoratorArgs).append(")\n");
-		builder.append("def ").append(name).append("(").append(params)
+		block.append("@jpipe(").append(jpipeDecoratorArgs(element))
+				.append(")\n");
+		block.append("def ").append(name).append("(").append(params)
 				.append(") -> bool:\n");
-		builder.append("    \"\"\"[").append(element.kind()).append("] ")
+		block.append("    \"\"\"[").append(element.kind()).append("] ")
 				.append(escapeDocstring(element.label())).append("\"\"\"\n");
 		if (element instanceof AbstractSupport) {
-			builder.append("    raise NotImplementedError(\"").append(qid)
-					.append(" is abstract and must be"
-							+ " overridden before execution\")\n\n\n");
+			block.append("    raise NotImplementedError(\"")
+					.append(links.get(0)).append(" is abstract and must be"
+							+ " overridden before execution\")\n");
 		} else {
-			builder.append("    pass\n\n\n");
+			block.append("    pass\n");
+		}
+
+		appendBlock(block.toString(), element);
+		builder.append("\n\n");
+	}
+
+	/**
+	 * Writes a function, commenting it out when the runner does not need it
+	 * implemented.
+	 *
+	 * <p>
+	 * Only evidence and strategies must be bound to run. A sub-conclusion
+	 * executes solely when it happens to be bound, so leaving it live would add
+	 * a function that never runs, while leaving it out would drop the claim it
+	 * states from the module. Emitting it commented keeps the shape of the
+	 * argument visible and lets a developer turn the check on by deleting the
+	 * prefixes.
+	 */
+	private void appendBlock(String block, JustificationElement element) {
+		if (!(element instanceof SubConclusion)) {
+			builder.append(block);
+			return;
+		}
+		builder.append(COMMENT).append("The runner passes this claim through"
+				+ " unless it is bound. Uncomment to check it.\n");
+		block.lines().forEach(
+				line -> builder.append(COMMENT).append(line).append("\n"));
+	}
+
+	/**
+	 * The ids this element should be linkable by: the ids it was merged from
+	 * when it is a merge product, its own id otherwise, each shortened to the
+	 * least qualified form that still designates it.
+	 *
+	 * <p>
+	 * A merge product is named by what it was merged from rather than by its
+	 * own id, which the operator chose ({@code hook}) or unification minted
+	 * ({@code unified_0}). That own id stays the fallback for when no authored
+	 * original can be resolved, so every function carries at least one link.
+	 *
+	 * <p>
+	 * Two originals that shorten to the same form are emitted once, since the
+	 * second decorator would say nothing the first does not. Source models that
+	 * named an element identically do not collide this way: the shortened form
+	 * keeps the model in front of the id, so {@code a:s} and {@code b:s} stay
+	 * apart. The unshortened ids remain in the JSON export either way.
+	 */
+	private List<String> linksFor(JustificationElement element) {
+		List<String> originals = qualifiedAuthoredOriginalsOf(element.id());
+		List<String> keys = originals.isEmpty()
+				? List.of(qualify(element.id()))
+				: originals;
+		return keys.stream().map(this::minimalLink).distinct().toList();
+	}
+
+	/**
+	 * Records that {@code link} is emitted on {@code function}, and refuses to
+	 * emit it a second time on a different one.
+	 *
+	 * <p>
+	 * A consumer keys its binding registry by the link id, so an id appearing
+	 * on two functions leaves it with two candidate implementations and no way
+	 * to choose. Every id emitted here designates exactly one element by
+	 * construction, because {@link AbstractModelExporter#minimalLink(String)}
+	 * only shortens to a form that resolves uniquely, and falls back to a full
+	 * id, which resolves exactly. Two functions can therefore collide only when
+	 * a single identifier already designated two elements. That is the
+	 * {@code unique-identifiers} consistency rule, which fails compilation
+	 * before any export runs; this guard catches the same fault when the
+	 * exporter is driven directly, rather than writing a module that cannot
+	 * load.
+	 */
+	private void claim(String link, String function) {
+		String existing = boundTo.putIfAbsent(link, function);
+		if (existing != null && !existing.equals(function)) {
+			throw new IllegalStateException("@jpipe_link(\"" + link
+					+ "\") would be emitted on both '" + existing + "' and '"
+					+ function + "' in model '" + currentModelName
+					+ "': one identifier cannot designate two elements."
+					+ " Check the model against the unique-identifiers rule.");
 		}
 	}
 

--- a/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
+++ b/jpipe-model/src/main/java/ca/mcscert/jpipe/visitor/PythonExporter.java
@@ -152,9 +152,8 @@ public class PythonExporter extends AbstractModelExporter {
 		builder.append("@jpipe(").append(decoratorArgs).append(")\n");
 		builder.append("def ").append(name).append("(").append(params)
 				.append(") -> bool:\n");
-		builder.append("    \"\"\"[").append(elementTypeName(element))
-				.append("] ").append(escapeDocstring(element.label()))
-				.append("\"\"\"\n");
+		builder.append("    \"\"\"[").append(element.kind()).append("] ")
+				.append(escapeDocstring(element.label())).append("\"\"\"\n");
 		if (element instanceof AbstractSupport) {
 			builder.append("    raise NotImplementedError(\"").append(qid)
 					.append(" is abstract and must be"
@@ -162,16 +161,6 @@ public class PythonExporter extends AbstractModelExporter {
 		} else {
 			builder.append("    pass\n\n\n");
 		}
-	}
-
-	private static String elementTypeName(JustificationElement element) {
-		return switch (element) {
-			case Conclusion _ -> "conclusion";
-			case SubConclusion _ -> "sub-conclusion";
-			case Strategy _ -> "strategy";
-			case Evidence _ -> "evidence";
-			case AbstractSupport _ -> "abstract-support";
-		};
 	}
 
 	private static String jpipeDecoratorArgs(JustificationElement element) {

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/elements/JustificationElementTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/elements/JustificationElementTest.java
@@ -7,8 +7,12 @@ import ca.mcscert.jpipe.visitor.JustificationVisitor;
 import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class JustificationElementTest {
 
@@ -54,6 +58,21 @@ class JustificationElementTest {
 	}
 
 	private final RecordingVisitor visitor = new RecordingVisitor();
+
+	static Stream<Arguments> elementKinds() {
+		return Stream.of(Arguments.of(new Conclusion("c", "l"), "conclusion"),
+				Arguments.of(new SubConclusion("sc", "l"), "sub-conclusion"),
+				Arguments.of(new Strategy("s", "l"), "strategy"),
+				Arguments.of(new Evidence("e", "l"), "evidence"), Arguments.of(
+						new AbstractSupport("as", "l"), "abstract-support"));
+	}
+
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("elementKinds")
+	void eachElementNamesItsOwnKind(JustificationElement element,
+			String expected) {
+		assertThat(element.kind()).isEqualTo(expected);
+	}
 
 	@Nested
 	class ConclusionTest {

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/model/validation/ConsistencyValidatorTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/model/validation/ConsistencyValidatorTest.java
@@ -132,6 +132,78 @@ class ConsistencyValidatorTest {
 	// Helpers
 	// -------------------------------------------------------------------------
 
+	@Nested
+	class UniqueIdentifiers {
+
+		@Test
+		void merge_aliases_alone_produce_no_violations() {
+			Justification j = simpleJustification();
+			j.recordAlias("a:s", "s");
+			j.recordAlias("b:s", "s");
+
+			assertThat(validator.validateModel(j)).isEmpty();
+		}
+
+		@Test
+		void alias_colliding_with_another_elements_id_produces_violation() {
+			Justification j = simpleJustification();
+			j.recordAlias("e1", "s"); // "e1" is already the evidence's own id
+
+			List<Violation> violations = validator.validateModel(j);
+
+			assertThat(violations).extracting(Violation::rule)
+					.contains("unique-identifiers");
+		}
+
+		@Test
+		void violation_names_both_elements_the_identifier_designates() {
+			Justification j = simpleJustification();
+			j.recordAlias("e1", "s");
+
+			List<Violation> violations = validator.validateModel(j);
+
+			assertThat(violations).extracting(Violation::message).first()
+					.asString().contains("'e1'", "element 'e1'", "element 's'");
+		}
+
+		@Test
+		void alias_chain_is_followed_to_the_element_it_designates() {
+			Justification j = simpleJustification();
+			j.recordAlias("mid", "s");
+			j.recordAlias("e1", "mid"); // reaches "s" through "mid"
+
+			List<Violation> violations = validator.validateModel(j);
+
+			assertThat(violations).extracting(Violation::rule)
+					.contains("unique-identifiers");
+		}
+
+		@Test
+		void alias_leading_to_no_element_is_ignored() {
+			Justification j = simpleJustification();
+			j.recordAlias("e1", "nowhere");
+
+			assertThat(validator.validateModel(j)).isEmpty();
+		}
+
+		@Test
+		void cyclic_alias_chain_terminates_without_violation() {
+			Justification j = simpleJustification();
+			j.recordAlias("x", "y");
+			j.recordAlias("y", "x");
+
+			assertThat(validator.validateModel(j)).isEmpty();
+		}
+
+		@Test
+		void alias_pointing_at_its_own_element_is_not_a_collision() {
+			Justification j = simpleJustification();
+			j.recordAlias("s", "s");
+
+			assertThat(validator.validateModel(j)).isEmpty();
+		}
+	}
+
 	private static Justification simpleJustification() {
 		Justification j = new Justification("j");
 		Conclusion c = new Conclusion("c", "The system is correct");

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/JsonExporterTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/JsonExporterTest.java
@@ -54,6 +54,23 @@ class JsonExporterTest {
 	}
 
 	@Test
+	void export_chainedAliases_carriesEveryIdAlongTheChain() {
+		String json = new JsonExporter()
+				.export(ModelFixtures.chainedAliasJustification());
+
+		assertThat(json).contains("\"aliases\"", "\"j:outer:s\"",
+				"\"j:outer:a:s1\"", "\"j:outer:b:s2\"");
+	}
+
+	@Test
+	void export_keepsUnificationMintedIdsSoConsumersCanStillResolveThem() {
+		String json = new JsonExporter()
+				.export(ModelFixtures.siblingUnifiedIdJustification());
+
+		assertThat(json).contains("\"j:outer:unified_0\"", "\"j:outer:a:s1\"");
+	}
+
+	@Test
 	void export_withoutAliases_omitsAliasesKey() {
 		String json = new JsonExporter()
 				.export(ModelFixtures.simpleJustification());

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/ModelFixtures.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/ModelFixtures.java
@@ -50,6 +50,80 @@ class ModelFixtures {
 	}
 
 	/**
+	 * A {@link #simpleJustification()} whose strategy {@code "s"} is the merge
+	 * target of a two-level chain, as produced by composing the result of a
+	 * composition: {@code outer:a:s1} and {@code outer:b:s2} were first merged
+	 * into {@code outer:s}, which a later composition merged into {@code "s"}.
+	 *
+	 * <p>
+	 * The leaves are deliberately given distinct short ids, so that resolving
+	 * the chain one hop short, stopping at {@code outer:s}, produces visibly
+	 * different output from resolving it all the way.
+	 *
+	 * <p>
+	 * The recording order mirrors the compiler's: the carry-forward aliases of
+	 * phases 1&ndash;3 are emitted before the unification alias of phase 4.
+	 */
+	static Justification chainedAliasJustification() {
+		Justification j = simpleJustification();
+		j.recordAlias("outer:a:s1", "outer:s");
+		j.recordAlias("outer:b:s2", "outer:s");
+		j.recordAlias("outer:s", "s");
+		return j;
+	}
+
+	/**
+	 * A {@link #simpleJustification()} whose strategy {@code "s"} was merged
+	 * from a group in which a unification id sits <em>beside</em> the ids it
+	 * stood for rather than above them.
+	 *
+	 * <p>
+	 * This is the shape {@code refine} produces over an already-composed
+	 * source: the hook merge aliases {@code outer:unified_0} to the result, and
+	 * the carry-forward then resolves that source's own originals to the same
+	 * result, so all three become siblings. {@code outer:unified_0} is left
+	 * with no originals of its own, so being childless does not make an id
+	 * authored, and only {@link Justification#recordUnifiedId(String)} tells
+	 * them apart.
+	 */
+	static Justification siblingUnifiedIdJustification() {
+		Justification j = simpleJustification();
+		j.recordAlias("outer:unified_0", "s");
+		j.recordAlias("outer:a:s1", "s");
+		j.recordAlias("outer:b:s2", "s");
+		j.recordUnifiedId("outer:unified_0");
+		return j;
+	}
+
+	/**
+	 * A justification whose two evidences share the plain id {@code "e"} under
+	 * different source-model prefixes, so that neither can be linked by
+	 * {@code "e"} alone.
+	 *
+	 * <ul>
+	 * <li>name: {@code "j"}
+	 * <li>Conclusion {@code "c"}, Strategy {@code "s"}
+	 * <li>Evidence {@code "a:e"} &mdash; "First", Evidence {@code "b:e"}
+	 * &mdash; "Second"
+	 * </ul>
+	 */
+	static Justification ambiguousShortIdJustification() {
+		Justification j = new Justification("j");
+		Conclusion c = new Conclusion("c", "The system is correct");
+		Strategy s = new Strategy("s", "Testing");
+		Evidence first = new Evidence("a:e", "First");
+		Evidence second = new Evidence("b:e", "Second");
+		j.setConclusion(c);
+		j.addElement(s);
+		j.addElement(first);
+		j.addElement(second);
+		s.addSupport(first);
+		s.addSupport(second);
+		c.addSupport(s);
+		return j;
+	}
+
+	/**
 	 * Template with a single Conclusion &larr; Strategy &larr; AbstractSupport
 	 * chain.
 	 *

--- a/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/PythonExporterTest.java
+++ b/jpipe-model/src/test/java/ca/mcscert/jpipe/visitor/PythonExporterTest.java
@@ -1,12 +1,17 @@
 package ca.mcscert.jpipe.visitor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ca.mcscert.jpipe.model.Justification;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.elements.AbstractSupport;
 import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
 import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
+import java.util.List;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -14,8 +19,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class PythonExporterTest {
 
 	@ParameterizedTest
-	@ValueSource(strings = {"def the_system_is_correct(", "def testing(",
-			"def test_results(", "def the_system_is_correct() -> bool:",
+	@ValueSource(strings = {"def testing(", "def test_results(",
 			"def testing(produce: JpipeProduce) -> bool:",
 			"def test_results(produce: JpipeProduce) -> bool:"})
 	void export_simpleJustificationMethodSignaturesArePresent(String expected) {
@@ -30,18 +34,215 @@ class PythonExporterTest {
 				.export(ModelFixtures.simpleJustification());
 
 		assertThat(py)
-				.contains("@jpipe_link(\"j:c\")", "@jpipe_link(\"j:s\")",
-						"@jpipe_link(\"j:e1\")")
-				.doesNotContain("# @jpipe_link(");
+				.contains("\n@jpipe_link(\"j:s\")", "\n@jpipe_link(\"j:e1\")")
+				.doesNotContain("\n# @jpipe_link(\"j:s\")",
+						"\n# @jpipe_link(\"j:e1\")");
 	}
 
 	@Test
-	void export_mergedElement_emitsExtraJpipeLinkPerAlias() {
+	void export_conclusion_isNotGeneratedAtAll() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.simpleJustification());
+
+		assertThat(py).doesNotContain("the_system_is_correct", "j:c",
+				"[conclusion]");
+	}
+
+	@Test
+	void export_commentedOutElement_saysWhyAndHowToEnableIt() {
+		Justification j = new Justification("j");
+		Conclusion c = new Conclusion("c", "Overall");
+		Strategy s = new Strategy("s", "By parts");
+		SubConclusion sc = new SubConclusion("sc", "Part holds");
+		j.setConclusion(c);
+		j.addElement(s);
+		j.addElement(sc);
+		sc.addSupport(s);
+		c.addSupport(s);
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py)
+				.contains("Uncomment to check it.\n# @jpipe_link(\"j:sc\")")
+				.doesNotContain("j:c");
+	}
+
+	@Test
+	void export_mergedElement_isNamedByItsOriginalsNotByTheMergeId() {
+		Justification j = ModelFixtures.simpleJustification();
+		j.recordAlias("a:s1", "s");
+		j.recordAlias("b:s2", "s");
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py)
+				.contains(
+						"@jpipe_link(\"a:s1\")\n@jpipe_link(\"b:s2\")\n@jpipe(")
+				.doesNotContain("@jpipe_link(\"j:s\")");
+	}
+
+	@Test
+	void export_originalsSharingAPlainId_staySeparatedByTheirSourceModel() {
 		String py = new PythonExporter()
 				.export(ModelFixtures.unifiedJustification());
 
-		assertThat(py).contains("@jpipe_link(\"j:s\")",
-				"@jpipe_link(\"j:a:s\")", "@jpipe_link(\"j:b:s\")");
+		assertThat(py)
+				.contains("@jpipe_link(\"a:s\")\n@jpipe_link(\"b:s\")\n@jpipe(")
+				.doesNotContain("@jpipe_link(\"s\")");
+	}
+
+	@Test
+	void export_originalsShorteningToTheSameForm_areEmittedOnce() {
+		Justification j = ModelFixtures.simpleJustification();
+		j.recordAlias("a:s", "s");
+		j.recordAlias("outer:a:s", "s"); // also shortens to "a:s"
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py).contains("@jpipe_link(\"a:s\")\n@jpipe(")
+				.doesNotContain("@jpipe_link(\"a:s\")\n@jpipe_link(\"a:s\")");
+	}
+
+	@Test
+	void export_chainedAliases_isNamedByTheOriginalSourceModelIds() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.chainedAliasJustification());
+
+		assertThat(py)
+				.contains(
+						"@jpipe_link(\"a:s1\")\n@jpipe_link(\"b:s2\")\n@jpipe(")
+				.doesNotContain("@jpipe_link(\"j:s\")",
+						"@jpipe_link(\"outer:s\")");
+	}
+
+	@Test
+	void export_unifiedIdBesideItsOriginals_isStillLeftOut() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.siblingUnifiedIdJustification());
+
+		assertThat(py)
+				.contains(
+						"@jpipe_link(\"a:s1\")\n@jpipe_link(\"b:s2\")\n@jpipe(")
+				.doesNotContain("unified_0");
+	}
+
+	@Test
+	void export_cyclicAliases_fallsBackToTheElementsOwnId() {
+		Justification j = ModelFixtures.simpleJustification();
+		j.recordAlias("s", "x");
+		j.recordAlias("x", "s");
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py).contains("@jpipe_link(\"j:s\")\n@jpipe(");
+	}
+
+	@Test
+	void export_ambiguousShortId_keepsEnoughQualificationToDesignateOne() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.ambiguousShortIdJustification());
+
+		assertThat(py).contains("@jpipe_link(\"a:e\")", "@jpipe_link(\"b:e\")")
+				.doesNotContain("@jpipe_link(\"e\")", "@jpipe_link(\"j:e\")");
+	}
+
+	@Test
+	void export_everyJpipeLinkInTheModuleIsDistinct() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.chainedAliasJustification());
+
+		List<String> links = Pattern.compile("@jpipe_link\\(\"(.+)\"\\)")
+				.matcher(py).results().map(m -> m.group(1)).toList();
+
+		assertThat(links).isNotEmpty().doesNotHaveDuplicates();
+	}
+
+	@Test
+	void export_identifierDesignatingTwoElements_isRefusedNotEmitted() {
+		Justification j = ModelFixtures.simpleJustification();
+		// "e1" is the evidence's own id and, through this alias, also names the
+		// strategy, so both functions would claim @jpipe_link("e1").
+		j.recordAlias("e1", "s");
+		PythonExporter exporter = new PythonExporter();
+
+		assertThatThrownBy(() -> exporter.export(j))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContainingAll("@jpipe_link(\"j:e1\")", "testing",
+						"test_results", "unique-identifiers");
+	}
+
+	@Test
+	void export_opensEachNamespaceWithABannerSizedToItsName() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.simpleJustification());
+
+		assertThat(py).contains("### ###\n## j ##\n### ###\n");
+	}
+
+	@Test
+	void export_groupsElementsByNamespaceAlphabetically() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.ambiguousShortIdJustification());
+
+		assertThat(py).containsSubsequence("## a ##", "def first(", "## b ##",
+				"def second(", "## j ##");
+	}
+
+	@Test
+	void export_ordersElementsBottomUpWithinANamespace() {
+		String py = new PythonExporter()
+				.export(ModelFixtures.simpleJustification());
+
+		assertThat(py).containsSubsequence("def test_results(", "def testing(");
+	}
+
+	@Test
+	void export_ordersSubConclusionsBetweenStrategiesAndTheConclusion() {
+		Justification j = new Justification("j");
+		Conclusion c = new Conclusion("c", "Overall");
+		Strategy s = new Strategy("s", "By parts");
+		SubConclusion sc = new SubConclusion("sc", "Part holds");
+		Evidence e = new Evidence("e", "Proof");
+		j.setConclusion(c);
+		j.addElement(s);
+		j.addElement(sc);
+		j.addElement(e);
+		s.addSupport(e);
+		sc.addSupport(s);
+		c.addSupport(s);
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py).containsSubsequence("def proof(", "def by_parts(",
+				"def part_holds(");
+	}
+
+	@Test
+	void export_ordersAbstractSupportsWithTheEvidence() {
+		String py = new PythonExporter().export(ModelFixtures.simpleTemplate());
+
+		assertThat(py).containsSubsequence("def abstract_step(",
+				"def strategy(");
+	}
+
+	@Test
+	void export_mergedElement_isGroupedWithTheComposedModelNotASource() {
+		Justification j = new Justification("comp");
+		Conclusion c = new Conclusion("c", "Overall");
+		Strategy s = new Strategy("src:s", "By parts");
+		Evidence merged = new Evidence("merged", "Shared proof");
+		j.setConclusion(c);
+		j.addElement(s);
+		j.addElement(merged);
+		s.addSupport(merged);
+		c.addSupport(s);
+		j.recordAlias("src:e1", "merged");
+		j.recordAlias("other:e2", "merged");
+
+		String py = new PythonExporter().export(j);
+
+		assertThat(py).containsSubsequence("## comp ##", "def shared_proof(",
+				"## src ##");
 	}
 
 	@Test
@@ -49,7 +250,7 @@ class PythonExporterTest {
 		String py = new PythonExporter()
 				.export(ModelFixtures.simpleJustification());
 
-		assertThat(py).contains("@jpipe_link(\"j:c\")\n@jpipe(consume=[])",
+		assertThat(py).contains(
 				"@jpipe_link(\"j:s\")\n@jpipe(produce=[], consume=[])",
 				"@jpipe_link(\"j:e1\")\n@jpipe(produce=[])");
 	}
@@ -109,21 +310,19 @@ class PythonExporterTest {
 		String py = new PythonExporter()
 				.export(ModelFixtures.simpleJustification());
 
-		assertThat(py).contains(
-				"\"\"\"[conclusion] The system is correct\"\"\"",
-				"\"\"\"[strategy] Testing\"\"\"",
+		assertThat(py).contains("\"\"\"[strategy] Testing\"\"\"",
 				"\"\"\"[evidence] Test results\"\"\"");
 	}
 
 	@Test
 	void export_labelWithSpecialChars_methodNameEscapedDocstringPreserved() {
 		Justification j = new Justification("j");
-		Conclusion c = new Conclusion("c", "Accuracy <= 0.85");
-		j.setConclusion(c);
+		j.setConclusion(new Conclusion("c", "Overall"));
+		j.addElement(new Evidence("e", "Accuracy <= 0.85"));
 
 		String py = new PythonExporter().export(j);
 
-		assertThat(py).contains("def accuracy_0_85() -> bool:",
-				"\"\"\"[conclusion] Accuracy <= 0.85\"\"\"");
+		assertThat(py).contains("def accuracy_0_85(produce: JpipeProduce)",
+				"\"\"\"[evidence] Accuracy <= 0.85\"\"\"");
 	}
 }

--- a/jpipe-operators/pom.xml
+++ b/jpipe-operators/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-operators</artifactId>

--- a/jpipe-operators/pom.xml
+++ b/jpipe-operators/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jpipe</groupId>
         <artifactId>jpipe</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jpipe-operators</artifactId>

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/CompositionOperator.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/CompositionOperator.java
@@ -269,16 +269,7 @@ public abstract class CompositionOperator {
 		aliases.aliases().forEach((oldId, newId) -> commands
 				.add(new RegisterAlias(resultName, oldId, newId)));
 
-		// Carry forward which ids unification minted in the sources. A source
-		// composed earlier may contribute a "unified_N" element; qualified into
-		// this result it stays an id no author wrote, whether it survives as an
-		// element or lives on only as an alias of a further merge.
-		for (JustificationModel<?> source : sources) {
-			for (String unified : source.unifiedIds()) {
-				commands.add(
-						new MarkUnified(resultName, qualId(source, unified)));
-			}
-		}
+		commands.addAll(carryForwardUnifiedIds(resultName, sources));
 
 		// Phase 2: link reconstruction
 		Set<String> seenEdges = new LinkedHashSet<>();
@@ -320,6 +311,22 @@ public abstract class CompositionOperator {
 			commands.add(
 					new AddSupport(resultName, newSupportable, newSupporter));
 		}
+	}
+
+	/**
+	 * Carries forward which ids unification minted in the sources. A source
+	 * composed earlier may contribute a {@code unified_N} element; qualified
+	 * into this result it stays an id no author wrote, whether it survives as
+	 * an element or lives on only as an alias of a further merge.
+	 */
+	private static List<Command> carryForwardUnifiedIds(String resultName,
+			List<JustificationModel<?>> sources) {
+		return sources.stream()
+				.flatMap(
+						source -> source.unifiedIds().stream()
+								.map(unified -> (Command) new MarkUnified(
+										resultName, qualId(source, unified))))
+				.toList();
 	}
 
 	private static String qualId(JustificationModel<?> source, String id) {

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/CompositionOperator.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/CompositionOperator.java
@@ -2,6 +2,7 @@ package ca.mcscert.jpipe.operators;
 
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
+import ca.mcscert.jpipe.commands.linking.MarkUnified;
 import ca.mcscert.jpipe.commands.linking.RegisterAlias;
 import ca.mcscert.jpipe.model.JustificationModel;
 import ca.mcscert.jpipe.model.SourceLocation;
@@ -267,6 +268,17 @@ public abstract class CompositionOperator {
 		// Persist aliases to Unit via RegisterAlias commands
 		aliases.aliases().forEach((oldId, newId) -> commands
 				.add(new RegisterAlias(resultName, oldId, newId)));
+
+		// Carry forward which ids unification minted in the sources. A source
+		// composed earlier may contribute a "unified_N" element; qualified into
+		// this result it stays an id no author wrote, whether it survives as an
+		// element or lives on only as an alias of a further merge.
+		for (JustificationModel<?> source : sources) {
+			for (String unified : source.unifiedIds()) {
+				commands.add(
+						new MarkUnified(resultName, qualId(source, unified)));
+			}
+		}
 
 		// Phase 2: link reconstruction
 		Set<String> seenEdges = new LinkedHashSet<>();

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/IncompatibleUnificationException.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/IncompatibleUnificationException.java
@@ -1,0 +1,17 @@
+package ca.mcscert.jpipe.operators;
+
+/**
+ * Raised when unification groups elements whose kinds cannot be merged into a
+ * single element, e.g. a strategy and an evidence sharing the same label.
+ *
+ * <p>
+ * Reported independently of the order in which the source models were listed:
+ * the operator is commutative, so the same group is rejected, with the same
+ * message, whichever way its members were written.
+ */
+public final class IncompatibleUnificationException extends RuntimeException {
+
+	public IncompatibleUnificationException(String message) {
+		super(message);
+	}
+}

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
@@ -198,19 +198,22 @@ public final class Unifier {
 	 */
 	private static ElementCreationCommand dominant(String resultName,
 			List<ElementCreationCommand> group) {
-		ElementCreationCommand best = group.get(0);
-		for (ElementCreationCommand candidate : group) {
+		List<JustificationElement> elements = group.stream()
+				.map(ElementCreationCommand::element).toList();
+		int best = 0;
+		for (int i = 1; i < elements.size(); i++) {
 			// Strict upgrade only: among equals, the first member wins.
-			if (!subsumes(best.element(), candidate.element())) {
-				best = candidate;
+			if (!subsumes(elements.get(best), elements.get(i))) {
+				best = i;
 			}
 		}
-		for (ElementCreationCommand member : group) {
-			if (!subsumes(best.element(), member.element())) {
+		JustificationElement winner = elements.get(best);
+		for (JustificationElement element : elements) {
+			if (!subsumes(winner, element)) {
 				throw incompatible(resultName, group);
 			}
 		}
-		return best;
+		return group.get(best);
 	}
 
 	/**

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
@@ -3,6 +3,7 @@ package ca.mcscert.jpipe.operators;
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.creation.ElementCreationCommand;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
+import ca.mcscert.jpipe.commands.linking.MarkUnified;
 import ca.mcscert.jpipe.commands.linking.RegisterAlias;
 import ca.mcscert.jpipe.model.elements.AbstractSupport;
 import ca.mcscert.jpipe.model.elements.Conclusion;
@@ -31,7 +32,10 @@ import java.util.stream.Collectors;
  * id is {@code "unified_N"} (N = 0-based counter per merged group). All
  * original member ids are aliased to the new id via {@link RegisterAlias}
  * commands, and {@link AddSupport} commands referencing removed ids are
- * rewritten accordingly.
+ * rewritten accordingly. Each new id is also flagged via {@link MarkUnified},
+ * since it names a group by a counter and so appears in no source file;
+ * exporters that address a human audience name the element by its originals
+ * instead.
  *
  * <p>
  * A group may legitimately mix element kinds — one source argued a claim while
@@ -142,6 +146,8 @@ public final class Unifier {
 				phase4Aliases, prototypes);
 		phase4Aliases.forEach((oldId, newId) -> result
 				.add(new RegisterAlias(resultName, oldId, newId)));
+		prototypes.keySet()
+				.forEach(id -> result.add(new MarkUnified(resultName, id)));
 		return List.copyOf(result);
 	}
 

--- a/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
+++ b/jpipe-operators/src/main/java/ca/mcscert/jpipe/operators/Unifier.java
@@ -4,7 +4,14 @@ import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.creation.ElementCreationCommand;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
 import ca.mcscert.jpipe.commands.linking.RegisterAlias;
+import ca.mcscert.jpipe.model.elements.AbstractSupport;
+import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.Evidence;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
+import ca.mcscert.jpipe.model.elements.Strategy;
+import ca.mcscert.jpipe.model.elements.SubConclusion;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -25,6 +32,23 @@ import java.util.stream.Collectors;
  * original member ids are aliased to the new id via {@link RegisterAlias}
  * commands, and {@link AddSupport} commands referencing removed ids are
  * rewritten accordingly.
+ *
+ * <p>
+ * A group may legitimately mix element kinds — one source argued a claim while
+ * another still asserts it — so the merged element is built from the group's
+ * <em>dominant</em> member rather than from whichever member happens to come
+ * first: a sub-conclusion subsumes an evidence, and among members of the same
+ * kind the first one wins (it also provides the merged element's label and
+ * source location). A group whose kinds are incomparable cannot be merged and
+ * raises an {@link IncompatibleUnificationException}. This makes composition
+ * operators commutative: the result no longer depends on the order the source
+ * models were listed in.
+ *
+ * <p>
+ * Note that for an equivalence relation that does not compare labels, the
+ * merged element's <em>label</em> is still the dominant member's, hence still
+ * order-dependent among members of the same kind. The only registered relation,
+ * {@code sameLabel}, cannot exhibit that.
  *
  * <p>
  * Controlled by two optional config parameters:
@@ -95,12 +119,15 @@ public final class Unifier {
 		List<List<ElementCreationCommand>> groups = Partitions
 				.partitionBy(candidates, equiv);
 
-		// Build phase4Aliases: oldId → unified_N for every group with >1 member
+		// For every group with more than one member: alias each member id to
+		// unified_N, and elect the command the merged element is built from.
 		Map<String, String> phase4Aliases = new LinkedHashMap<>();
+		Map<String, ElementCreationCommand> prototypes = new LinkedHashMap<>();
 		int counter = 0;
 		for (List<ElementCreationCommand> group : groups) {
 			if (group.size() > 1) {
 				String unifiedId = UNIFIED_PREFIX + counter++;
+				prototypes.put(unifiedId, dominant(resultName, group));
 				for (ElementCreationCommand ecc : group) {
 					phase4Aliases.put(ecc.identifier(), unifiedId);
 				}
@@ -112,7 +139,7 @@ public final class Unifier {
 		}
 
 		List<Command> result = rebuildCommands(resultName, commands,
-				phase4Aliases);
+				phase4Aliases, prototypes);
 		phase4Aliases.forEach((oldId, newId) -> result
 				.add(new RegisterAlias(resultName, oldId, newId)));
 		return List.copyOf(result);
@@ -122,13 +149,15 @@ public final class Unifier {
 	// ─────────────────────────────────────────────────────────────────
 
 	private static List<Command> rebuildCommands(String resultName,
-			List<Command> commands, Map<String, String> phase4Aliases) {
+			List<Command> commands, Map<String, String> phase4Aliases,
+			Map<String, ElementCreationCommand> prototypes) {
 		List<Command> result = new ArrayList<>();
 		Set<String> insertedUnified = new LinkedHashSet<>();
 		Set<String> seenEdges = new LinkedHashSet<>();
 		for (Command cmd : commands) {
 			if (isElement(cmd)) {
-				appendElement(result, cmd, phase4Aliases, insertedUnified);
+				appendElement(result, cmd, phase4Aliases, prototypes,
+						insertedUnified);
 			} else if (cmd instanceof AddSupport as) {
 				appendEdge(result, resultName, as, phase4Aliases, seenEdges);
 			} else {
@@ -139,16 +168,106 @@ public final class Unifier {
 	}
 
 	private static void appendElement(List<Command> result, Command cmd,
-			Map<String, String> phase4Aliases, Set<String> insertedUnified) {
+			Map<String, String> phase4Aliases,
+			Map<String, ElementCreationCommand> prototypes,
+			Set<String> insertedUnified) {
 		String id = idOf(cmd);
 		if (phase4Aliases.containsKey(id)) {
 			String unifiedId = phase4Aliases.get(id);
+			// The merged element takes the position of the first member met,
+			// but is built from the group's dominant one.
 			if (insertedUnified.add(unifiedId)) {
-				result.add(synthesized(cmd, unifiedId));
+				result.add(prototypes.get(unifiedId).withId(unifiedId));
 			}
 		} else {
 			result.add(cmd);
 		}
+	}
+
+	/**
+	 * Elects the command a merged group is synthesized from.
+	 *
+	 * <p>
+	 * The elected command is the first member whose kind subsumes every other
+	 * kind in the group; its label and location are the ones the merged element
+	 * carries. A group whose kinds are incomparable cannot be merged into a
+	 * single element and is rejected.
+	 *
+	 * @throws IncompatibleUnificationException
+	 *             if no member subsumes all the others.
+	 */
+	private static ElementCreationCommand dominant(String resultName,
+			List<ElementCreationCommand> group) {
+		ElementCreationCommand best = group.get(0);
+		for (ElementCreationCommand candidate : group) {
+			// Strict upgrade only: among equals, the first member wins.
+			if (!subsumes(best.element(), candidate.element())) {
+				best = candidate;
+			}
+		}
+		for (ElementCreationCommand member : group) {
+			if (!subsumes(best.element(), member.element())) {
+				throw incompatible(resultName, group);
+			}
+		}
+		return best;
+	}
+
+	/**
+	 * Tells whether an element of {@code winner}'s kind can stand for one of
+	 * {@code other}'s kind in a merged group.
+	 *
+	 * <p>
+	 * A {@link SubConclusion} subsumes an {@link Evidence}: being both
+	 * {@link ca.mcscert.jpipe.model.elements.StrategyBacked} and
+	 * {@link ca.mcscert.jpipe.model.elements.SupportLeaf}, it supports whatever
+	 * the evidence supported and can additionally carry the strategy that
+	 * argues it. No other pair of distinct kinds is comparable: a conclusion is
+	 * the model's single root, a strategy is the support rather than a
+	 * supporter, and an {@link AbstractSupport} placeholder is discharged by an
+	 * explicit override, never by a merge.
+	 */
+	private static boolean subsumes(JustificationElement winner,
+			JustificationElement other) {
+		return switch (winner) {
+			case SubConclusion _ ->
+				other instanceof SubConclusion || other instanceof Evidence;
+			case Conclusion _ -> other instanceof Conclusion;
+			case Strategy _ -> other instanceof Strategy;
+			case Evidence _ -> other instanceof Evidence;
+			case AbstractSupport _ -> other instanceof AbstractSupport;
+		};
+	}
+
+	/**
+	 * Builds the rejection for a group that mixes incomparable kinds, naming
+	 * the first incomparable pair in a canonical order so that the message does
+	 * not depend on the order the source models were listed in.
+	 */
+	private static IncompatibleUnificationException incompatible(
+			String resultName, List<ElementCreationCommand> group) {
+		List<ElementCreationCommand> sorted = group.stream()
+				.sorted(Comparator.comparing(
+						(ElementCreationCommand c) -> c.element().kind())
+						.thenComparing(ElementCreationCommand::identifier))
+				.toList();
+		ElementCreationCommand first = sorted.get(0);
+		ElementCreationCommand clashing = sorted.stream()
+				.filter(c -> !subsumes(first.element(), c.element())
+						&& !subsumes(c.element(), first.element()))
+				.findFirst().orElse(sorted.get(sorted.size() - 1));
+		return new IncompatibleUnificationException("cannot unify "
+				+ describe(first) + " with " + describe(clashing)
+				+ " in model '" + resultName
+				+ "': these element kinds are incompatible."
+				+ " Rename one of the labels, or keep the elements apart with "
+				+ UNIFY_EXCLUDE_KEY + ".");
+	}
+
+	/** Renders an element command as {@code 'id' (kind, "label")}. */
+	private static String describe(ElementCreationCommand cmd) {
+		return "'" + cmd.identifier() + "' (" + cmd.element().kind() + ", \""
+				+ cmd.label() + "\")";
 	}
 
 	private static void appendEdge(List<Command> result, String resultName,
@@ -187,14 +306,6 @@ public final class Unifier {
 	/** Extracts the label from an element-creation command. */
 	static String labelOf(Command cmd) {
 		return ((ElementCreationCommand) cmd).label();
-	}
-
-	/**
-	 * Returns a copy of {@code original} with {@code newId} as the element
-	 * identifier, preserving the command type, container, label, and location.
-	 */
-	private static Command synthesized(Command original, String newId) {
-		return ((ElementCreationCommand) original).withId(newId);
 	}
 
 	private static String resolve(String id, Map<String, String> aliases) {

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/UnifierTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/UnifierTest.java
@@ -6,10 +6,12 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 
 import ca.mcscert.jpipe.commands.Command;
 import ca.mcscert.jpipe.commands.ExecutionEngine;
+import ca.mcscert.jpipe.commands.creation.CreateAbstractSupport;
 import ca.mcscert.jpipe.commands.creation.CreateConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateEvidence;
 import ca.mcscert.jpipe.commands.creation.CreateJustification;
 import ca.mcscert.jpipe.commands.creation.CreateStrategy;
+import ca.mcscert.jpipe.commands.creation.CreateSubConclusion;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
 import ca.mcscert.jpipe.commands.linking.RegisterAlias;
 import ca.mcscert.jpipe.model.Justification;
@@ -17,14 +19,26 @@ import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.Evidence;
 import ca.mcscert.jpipe.model.elements.JustificationElement;
 import ca.mcscert.jpipe.operators.equivalences.SameLabel;
+import ca.mcscert.jpipe.operators.equivalences.SameShortId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class UnifierTest {
+
+	/** Label shared by the members of a merged group. */
+	private static final String SHARED = "A shared claim";
+
+	/** Name of the model under test; {@link #model()} for instance contexts. */
+	private static final String MODEL = "m";
 
 	private Unifier unifier;
 	private ExecutionEngine engine;
@@ -254,6 +268,151 @@ class UnifierTest {
 		}
 	}
 
+	// ── groups mixing element kinds
+	// ───────────────────────────────────────────────
+
+	@Nested
+	class MixedKinds {
+
+		/**
+		 * A group mixing a sub-conclusion and an evidence carrying the same
+		 * claim: one source argued it, the other still asserts it.
+		 */
+		private List<Command> argued(boolean subConclusionFirst) {
+			List<Command> elements = subConclusionFirst
+					? List.of(new CreateSubConclusion(model(), "sc", SHARED),
+							new CreateEvidence(model(), "e", SHARED))
+					: List.of(new CreateEvidence(model(), "e", SHARED),
+							new CreateSubConclusion(model(), "sc", SHARED));
+			List<Command> cmds = new ArrayList<>(
+					List.of(new CreateJustification(model())));
+			cmds.addAll(elements);
+			return cmds;
+		}
+
+		@ParameterizedTest(name = "sub-conclusion listed first: {0}")
+		@ValueSource(booleans = {true, false})
+		void subConclusionWinsWhateverTheOrder(boolean subConclusionFirst) {
+			List<Command> result = unifier.unify(model(),
+					argued(subConclusionFirst), Map.of());
+
+			assertThat(result).filteredOn(Unifier::isElement)
+					.filteredOn(cmd -> "unified_0".equals(Unifier.idOf(cmd)))
+					.singleElement().isInstanceOf(CreateSubConclusion.class)
+					.extracting(Unifier::labelOf).isEqualTo(SHARED);
+		}
+
+		@Test
+		void mergedElementKeepsThePositionOfItsFirstMember() {
+			// The evidence is listed first, so unified_0 takes its slot even
+			// though the sub-conclusion is the one it is built from.
+			List<Command> cmds = argued(false);
+			cmds.add(new CreateEvidence(model(), "last", "Something else"));
+
+			List<Command> result = unifier.unify(model(), cmds, Map.of());
+
+			assertThat(result).filteredOn(Unifier::isElement)
+					.extracting(Unifier::idOf)
+					.containsExactly("unified_0", "last");
+		}
+
+		@Test
+		void mergedSubConclusionCanCarryAStrategyAndSupportAnother() {
+			// The reason sub-conclusion must win: it is both supported by the
+			// strategy that argues it, and a supporter of the strategy that
+			// used to lean on the evidence.
+			List<Command> cmds = argued(false);
+			cmds.addAll(List.of(new CreateStrategy(model(), "arguing", "why"),
+					new CreateStrategy(model(), "leaning", "because"),
+					new AddSupport(model(), "sc", "arguing"),
+					new AddSupport(model(), "leaning", "e")));
+
+			Unit unit = engine.spawn("test",
+					unifier.unify(model(), cmds, Map.of()));
+			Justification result = (Justification) unit.get(model());
+
+			assertThat(result.subConclusions()).singleElement()
+					.satisfies(sc -> assertThat(sc.id()).isEqualTo("unified_0"))
+					.satisfies(sc -> assertThat(sc.getSupport()).get()
+							.extracting(JustificationElement::id)
+							.isEqualTo("arguing"));
+		}
+
+		static Stream<Arguments> incomparablePairs() {
+			return Stream.of(
+					Arguments.of("strategy and evidence",
+							new CreateStrategy(MODEL, "s", SHARED),
+							new CreateEvidence(MODEL, "e", SHARED)),
+					Arguments.of("conclusion and evidence",
+							new CreateConclusion(MODEL, "c", SHARED),
+							new CreateEvidence(MODEL, "e", SHARED)),
+					Arguments.of("conclusion and sub-conclusion",
+							new CreateConclusion(MODEL, "c", SHARED),
+							new CreateSubConclusion(MODEL, "sc", SHARED)),
+					Arguments.of("evidence and abstract support",
+							new CreateEvidence(MODEL, "e", SHARED),
+							new CreateAbstractSupport(MODEL, "as", SHARED)),
+					Arguments.of("sub-conclusion and abstract support",
+							new CreateSubConclusion(MODEL, "sc", SHARED),
+							new CreateAbstractSupport(MODEL, "as", SHARED)));
+		}
+
+		@ParameterizedTest(name = "{0}")
+		@MethodSource("incomparablePairs")
+		void incomparableKindsAreRejected(String label, Command first,
+				Command second) {
+			List<Command> cmds = List.of(new CreateJustification(model()),
+					first, second);
+			assertThatThrownBy(() -> unifier.unify(model(), cmds, Map.of()))
+					.isInstanceOf(IncompatibleUnificationException.class)
+					.hasMessageContaining("cannot unify")
+					.hasMessageContaining(SHARED)
+					.hasMessageContaining("element kinds are incompatible")
+					.hasMessageContaining(Unifier.UNIFY_EXCLUDE_KEY);
+		}
+
+		@Test
+		void theRejectionMessageIsTheSameWhateverTheOrder() {
+			Command strategy = new CreateStrategy(model(), "s", SHARED);
+			Command evidence = new CreateEvidence(model(), "e", SHARED);
+			List<Command> oneWay = List.of(new CreateJustification(model()),
+					strategy, evidence);
+			List<Command> theOther = List.of(new CreateJustification(model()),
+					evidence, strategy);
+
+			String first = messageOf(oneWay);
+			String second = messageOf(theOther);
+
+			assertThat(first).isEqualTo(second);
+		}
+
+		private String messageOf(List<Command> cmds) {
+			try {
+				unifier.unify(model(), cmds, Map.of());
+				throw new AssertionError("expected the group to be rejected");
+			} catch (IncompatibleUnificationException e) {
+				return e.getMessage();
+			}
+		}
+
+		@Test
+		void homogeneousGroupStillTakesTheFirstMembersLabel() {
+			// sameShortId ignores labels, so a group can hold two evidence
+			// elements with different labels: the first one still wins.
+			UnificationEquivalenceRegistry registry = new UnificationEquivalenceRegistry();
+			registry.register("sameShortId", new SameShortId());
+			List<Command> cmds = List.of(new CreateJustification(model()),
+					new CreateEvidence(model(), "a:e", "first label"),
+					new CreateEvidence(model(), "b:e", "second label"));
+
+			List<Command> result = new Unifier(registry).unify(model(), cmds,
+					Map.of("unifyBy", "sameShortId"));
+
+			assertThat(result).filteredOn(Unifier::isElement).singleElement()
+					.extracting(Unifier::labelOf).isEqualTo("first label");
+		}
+	}
+
 	// ── unknown unifyBy
 	// ───────────────────────────────────────────────────────────────
 
@@ -271,6 +430,6 @@ class UnifierTest {
 	}
 
 	private static String model() {
-		return "m";
+		return MODEL;
 	}
 }

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/UnifierTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/UnifierTest.java
@@ -363,7 +363,8 @@ class UnifierTest {
 				Command second) {
 			List<Command> cmds = List.of(new CreateJustification(model()),
 					first, second);
-			assertThatThrownBy(() -> unifier.unify(model(), cmds, Map.of()))
+			Map<String, String> args = Map.of();
+			assertThatThrownBy(() -> unifier.unify(MODEL, cmds, args))
 					.isInstanceOf(IncompatibleUnificationException.class)
 					.hasMessageContaining("cannot unify")
 					.hasMessageContaining(SHARED)

--- a/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/builtin/AssembleOperatorTest.java
+++ b/jpipe-operators/src/test/java/ca/mcscert/jpipe/operators/builtin/AssembleOperatorTest.java
@@ -9,6 +9,7 @@ import ca.mcscert.jpipe.commands.creation.CreateConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateEvidence;
 import ca.mcscert.jpipe.commands.creation.CreateJustification;
 import ca.mcscert.jpipe.commands.creation.CreateStrategy;
+import ca.mcscert.jpipe.commands.creation.CreateSubConclusion;
 import ca.mcscert.jpipe.commands.creation.CreateTemplate;
 import ca.mcscert.jpipe.commands.linking.AddSupport;
 import ca.mcscert.jpipe.model.Justification;
@@ -16,13 +17,21 @@ import ca.mcscert.jpipe.model.JustificationModel;
 import ca.mcscert.jpipe.model.Template;
 import ca.mcscert.jpipe.model.Unit;
 import ca.mcscert.jpipe.model.elements.Conclusion;
+import ca.mcscert.jpipe.model.elements.JustificationElement;
 import ca.mcscert.jpipe.model.elements.Strategy;
 import ca.mcscert.jpipe.model.elements.SubConclusion;
+import ca.mcscert.jpipe.operators.IncompatibleUnificationException;
 import ca.mcscert.jpipe.operators.InvalidOperatorCallException;
 import ca.mcscert.jpipe.operators.ModelKind;
+import ca.mcscert.jpipe.operators.UnificationEquivalenceRegistry;
+import ca.mcscert.jpipe.operators.Unifier;
+import ca.mcscert.jpipe.operators.equivalences.SameLabel;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -31,11 +40,15 @@ class AssembleOperatorTest {
 
 	private ExecutionEngine engine;
 	private AssembleOperator assemble;
+	private Unifier unifier;
 
 	@BeforeEach
 	void setUp() {
 		engine = new ExecutionEngine();
 		assemble = new AssembleOperator();
+		UnificationEquivalenceRegistry registry = new UnificationEquivalenceRegistry();
+		registry.register("sameLabel", new SameLabel());
+		unifier = new Unifier(registry);
 	}
 
 	private static final Map<String, String> ARGS = Map.of("conclusionLabel",
@@ -247,6 +260,112 @@ class AssembleOperatorTest {
 					.filter(s -> s.id().equals(AssembleOperator.STRATEGY_ID))
 					.findFirst().orElseThrow();
 			assertThat(assembleS.getSupports()).hasSize(3);
+		}
+	}
+
+	// ── Commutativity ────────────────────────────────────────────────────────
+
+	/**
+	 * Assembling the same bricks in either order must give the same model, even
+	 * when unification merges a group that mixes element kinds: one source
+	 * argues the claim (sub-conclusion), the other still asserts it (evidence).
+	 * See issue #156.
+	 */
+	@Nested
+	class Commutativity {
+
+		private static final String SHARED = "A shared claim";
+
+		/** A brick whose shared claim is argued: a sub-conclusion. */
+		private Justification arguing(String name) {
+			List<Command> cmds = new ArrayList<>();
+			cmds.add(new CreateJustification(name));
+			cmds.add(new CreateConclusion(name, "c", "Argued holds"));
+			cmds.add(new CreateStrategy(name, "s", "because the claim"));
+			cmds.add(new CreateSubConclusion(name, "sc", SHARED));
+			cmds.add(new CreateStrategy(name, "deeper", "because of details"));
+			cmds.add(new CreateEvidence(name, "e", "Some detail"));
+			cmds.add(new AddSupport(name, "c", "s"));
+			cmds.add(new AddSupport(name, "s", "sc"));
+			cmds.add(new AddSupport(name, "sc", "deeper"));
+			cmds.add(new AddSupport(name, "deeper", "e"));
+			return (Justification) engine.spawn("src", cmds).get(name);
+		}
+
+		/** A brick whose shared claim is asserted: a plain evidence. */
+		private Justification asserting(String name) {
+			return buildJustification(name, "Asserted holds", "also because it",
+					SHARED);
+		}
+
+		private Justification assembled(String name,
+				List<JustificationModel<?>> sources) {
+			List<Command> cmds = unifier.unify(name,
+					assemble.apply(name, sources, ARGS), ARGS);
+			return (Justification) engine.spawn("out", cmds).get(name);
+		}
+
+		@Test
+		void assemblingThePlainSourceFirstStillBuilds() {
+			// The regression: with the evidence met first, the merged element
+			// used to be created as an evidence, which the arguing strategy
+			// could not support.
+			Justification result = assembled("right",
+					List.of(asserting("other"), arguing("deep")));
+
+			assertThat(result.subConclusions()).extracting(SubConclusion::id)
+					.contains("unified_0");
+		}
+
+		@Test
+		void bothArgumentOrdersProduceTheSameModel() {
+			// Labels are pairwise distinct in these fixtures, so (kind, label)
+			// identifies an element and comparing the two sets below is an
+			// exact isomorphism check. Ids cannot be compared directly: the
+			// unified_N counter follows group-discovery order.
+			Justification left = assembled("left",
+					List.of(arguing("deep"), asserting("other")));
+			Justification right = assembled("right",
+					List.of(asserting("other"), arguing("deep")));
+
+			assertThat(nodes(left)).isEqualTo(nodes(right));
+			assertThat(edges(left)).isEqualTo(edges(right));
+		}
+
+		@Test
+		void mergingTheGlobalConclusionWithASourceElementIsRejected() {
+			List<JustificationModel<?>> sources = List.of(arguing("deep"),
+					asserting("other"));
+			Map<String, String> clashing = Map.of("conclusionLabel", SHARED,
+					"strategyLabel", "An aggregating strategy");
+			List<Command> composed = assemble.apply("clash", sources, clashing);
+
+			assertThatThrownBy(() -> unifier.unify("clash", composed, clashing))
+					.isInstanceOf(IncompatibleUnificationException.class)
+					.hasMessageContaining("cannot unify")
+					.hasMessageContaining(SHARED);
+		}
+
+		private Set<String> nodes(JustificationModel<?> model) {
+			Set<String> nodes = model.getElements().stream()
+					.map(e -> e.kind() + "|" + e.label())
+					.collect(Collectors.toCollection(HashSet::new));
+			model.conclusion()
+					.ifPresent(c -> nodes.add(c.kind() + "|" + c.label()));
+			return nodes;
+		}
+
+		private Set<String> edges(JustificationModel<?> model) {
+			Set<String> edges = new HashSet<>();
+			model.strategies().forEach(s -> s.getSupports().forEach(
+					leaf -> edges.add(((JustificationElement) leaf).label()
+							+ " -> " + s.label())));
+			model.subConclusions().forEach(sc -> sc.getSupport().ifPresent(
+					s -> edges.add(s.label() + " -> " + sc.label())));
+			model.conclusion().flatMap(Conclusion::getSupport)
+					.ifPresent(s -> edges.add(s.label() + " -> "
+							+ model.conclusion().orElseThrow().label()));
+			return edges;
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jpipe</groupId>
     <artifactId>jpipe</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>jPipe</name>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <log4j-transform.version>0.1.0</log4j-transform.version>
         <spotless-plugin.version>3.9.0</spotless-plugin.version>
@@ -241,6 +242,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jpipe</groupId>
     <artifactId>jpipe</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>jPipe</name>


### PR DESCRIPTION
Closes out `[Unreleased]` as `## [2.5.0] — 2026-08-14` and sets every pom to
`2.5.0-SNAPSHOT`. MINOR per ADR-0001: the section carries new behaviour, not
fixes alone.

## What is in it

**Generated Python now reads in terms of what the author wrote.** A merged
element used to surface as the id unification minted for it (`unified_0`), a
name appearing in no source file, and every link repeated the exported model's
own name. Links are now the ids an element was merged from, resolved
transitively so a composition of a composition still names the original source
models, shortened to the least qualified form that designates one element and
floored at `justification:id`. Functions are grouped by namespace under a
banner, ordered bottom-up within a section; conclusions are omitted and
sub-conclusions emitted commented out, matching what the runner actually
executes.

**Two invariants the runner assumes are now guaranteed.** A new
`unique-identifiers` consistency rule fails compilation when an identifier
would designate two elements, which a consumer indexing ids and aliases into
one namespace cannot resolve. The exporter also refuses to write a module in
which one `@jpipe_link` would appear on two functions.

**JSON export** gains the transitive closure in its per-element `aliases`
array; composing a composition previously dropped the earlier ids in the chain,
leaving elements a consumer could not bind by their original names.

Plus the fixes already on `dev`: `jpipe diagnostic` reporting on unreadable and
fatally-failing inputs, order-independent unification, and `jpipe doctor`
reporting external tool versions.

## Release checklist

- [x] Version number matches what `[Unreleased]` contained (ADR-0001)
- [x] Dependency review (ADR-0007) — no changes. All six available updates are
      pre-release (Log4j `3.0.0-beta`, AssertJ `4.0.0-M1`) or major bumps that
      the policy routes to a dedicated branch (JUnit 5→6,
      json-schema-validator 1→3). Plugins are all on latest.
- [x] Ubuntu series matrix (ADR-0023) — `[noble, resolute, stonking]`
      unchanged; nothing has entered support or reached EOL since the ADR.
- [x] `scripts/release.sh preflight 2.5.0` green, `mvn verify` green
- [x] **Windows/Scoop smoke test (ADR-0025)** — outstanding. CI cannot run it.

After merging, tag on `main`:

```bash
git switch main && git pull --ff-only
scripts/release.sh preflight 2.5.0
git tag v2.5.0 && git push origin v2.5.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)